### PR TITLE
Do not mark "removing unused section" lines as errors

### DIFF
--- a/core/org.eclipse.cdt.core/plugin.properties
+++ b/core/org.eclipse.cdt.core/plugin.properties
@@ -74,7 +74,7 @@ CDTGNULinkerErrorParser.regex.InFunction=(.*?):?(\\(\\.[^\\s+]+\\+.*\\))?:\\s*(I
 CDTGNULinkerErrorParser.regex.WarningDangerousFunction=(.*?):(\\d+):(\\d+:)? ([Ww]arning:)?\\s*(the use of [`'"](.*)['"] is dangerous, better use [`'"](.*)['"].*)
 CDTGNULinkerErrorParser.regex.TextWarning=(.*?):?\\(\\.[^\\s+]+\\+.*\\): [Ww]arning:? (.*)
 CDTGNULinkerErrorParser.regex.TextError=(.*?):?\\(\\.[^\\s+]+\\+.*\\): (.*)
-CDTGNULinkerErrorParser.regex.ldInfo=(.*[/\\\\])?ld(\\.exe)?: ((mode|Removing unused section) .*)
+CDTGNULinkerErrorParser.regex.ldInfo=(.*[/\\\\])?ld(\\.exe)?: ((mode|[Rr]emoving unused section) .*)
 CDTGNULinkerErrorParser.regex.ldWarning=(.*[/\\\\])?ld(\\.exe)?: [Ww]arning:? (.*)
 CDTGNULinkerErrorParser.regex.ldError=(.*[/\\\\])?ld(\\.exe)?: (.*)
 


### PR DESCRIPTION
gcc linker outputs "removing unused section" to stderr when the option "--print-gc-sections" is used. That is fine.

Eclipse CDT reports all these lines as errors however and the build seems to have failed, which is wrong.
The was a bug report Bug 539927: Do not mark "Removing unused section" lines as errors and a fix
To fix this bug a change was made 2020-12-02 05322656c66a375c541b1f4775960d408f5f6f52
-CDTGNULinkerErrorParser.regex.LdMode=(.*[/\\\\])?ld(\\.exe)?: (mode .*)
+CDTGNULinkerErrorParser.regex.ldInfo=(.*[/\\\\])?ld(\\.exe)?: ((mode|Removing unused section) .*)

That does however not solve problem entirely, as the output of gcc linker is "removing", not "Removing", i.e. the word "removing" starts with a lower-case "r"
To fix that problem both R and r should be accepted.