### PR TITLE
Add reflection access when running some old tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,8 @@
 		<help-docs-eclipserun-repo>https://download.eclipse.org/eclipse/updates/4.24/</help-docs-eclipserun-repo>
 
 		<tycho.scmUrl>scm:git:https://git.eclipse.org/r/cdt/org.eclipse.cdt</tycho.scmUrl>
-		<base.test.vmargs>-Xms256m -Xmx512m -ea</base.test.vmargs>
+		<!-- Some old tests, like CDescriptorOldTests, fail due to reflection access. Therefore we add-opens to make that pass -->
+		<base.test.vmargs>-Xms256m -Xmx512m -ea --add-opens=java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED</base.test.vmargs>
 		<comparator.repo>https://download.eclipse.org/tools/cdt/releases/10.6/cdt-10.6.0/</comparator.repo>
 		<!-- these parameters are to control baseline replace and compare. On a local build you want
 		     to avoid baseline replace and compare, especially if you have different versions of Java than


### PR DESCRIPTION
This is the exception that would have been raised.

```
java.lang.reflect.UndeclaredThrowableException
	at org.eclipse.cdt.core.cdescriptor.tests.CDescriptorOldTests.testProjectDataCreate(CDescriptorOldTests.java:370)
Caused by: java.lang.IllegalAccessException: class org.eclipse.cdt.internal.core.CConfigBasedDescriptor$1 cannot access class com.sun.org.apache.xerces.internal.dom.ParentNode (in module java.xml) because module java.xml does not export com.sun.org.apache.xerces.internal.dom to unnamed module @772861aa
	at org.eclipse.cdt.core.cdescriptor.tests.CDescriptorOldTests.testProjectDataCreate(CDescriptorOldTests.java:370)
```

It may be that `--add-opens=java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED`
can/should be added to the product, similar to linuxtools in
https://github.com/eclipse-linuxtools/org.eclipse.linuxtools/pull/20/files
but as this affects only some special use cases that are probably
not really in existence anymore we are just fixing the tests.

Alternative would be to simply delete these old tests (`CDescriptorOldTests`)
and surrounding code.