### PR TITLE
Bug 580505 - Fix and improve CDT.setup

### DIFF
--- a/releng/CDT.setup
+++ b/releng/CDT.setup
@@ -7,18 +7,15 @@
     xmlns:jdt="http://www.eclipse.org/oomph/setup/jdt/1.0"
     xmlns:pde="http://www.eclipse.org/oomph/setup/pde/1.0"
     xmlns:predicates="http://www.eclipse.org/oomph/predicates/1.0"
-    xmlns:projects="http://www.eclipse.org/oomph/setup/projects/1.0"
     xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
     xmlns:setup.p2="http://www.eclipse.org/oomph/setup/p2/1.0"
     xmlns:setup.targlets="http://www.eclipse.org/oomph/setup/targlets/1.0"
     xmlns:setup.workingsets="http://www.eclipse.org/oomph/setup/workingsets/1.0"
-    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/pde/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/PDE.ecore http://www.eclipse.org/oomph/predicates/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/projects/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Projects.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore"
+    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/pde/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/PDE.ecore http://www.eclipse.org/oomph/predicates/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/SetupWorkingSets.ecore"
     name="cdt"
     label="CDT">
   <setupTask
       xsi:type="setup.p2:P2Task">
-    <requirement
-        name="org.eclipse.pde.api.tools.ee.feature.feature.group"/>
     <requirement
         name="org.eclipse.swtbot.ide.feature.group"/>
     <requirement
@@ -200,189 +197,193 @@
       </repositoryList>
     </targlet>
   </setupTask>
-  <stream name="master">
-    <setupTask
-        xsi:type="pde:APIBaselineFromTargetTask"
-        predecessor="api.baseline.targlet"
-        name="Modular API Baseline"
-        targetName="Modular API Baseline Target"
-        version="0.0.0">
-      <description>An API baseline based on the target platform named 'Modular API Baseline Target'</description>
-    </setupTask>
-    <setupTask
-        xsi:type="setup.targlets:TargletTask"
-        programArguments="-consolelog"
-        vmArguments="-Xms40m -Xmx512M -ea">
-      <targlet
-          name="CDT">
-        <requirement
-            name="org.eclipse.license.feature.group"/>
-        <requirement
-            name="com.google.gson"/>
-        <requirement
-            name="com.sun.jna"
-            versionRange="5.8.0"/>
-        <requirement
-            name="com.sun.jna.platform"
-            versionRange="5.8.0"/>
-        <requirement
-            name="com.sun.xml.bind"
-            versionRange="2.3.3"/>
-        <requirement
-            name="jakarta.xml.bind"
-            versionRange="2.3.3"/>
-        <requirement
-            name="javax.activation"
-            versionRange="1.2.2"/>
-        <requirement
-            name="javax.xml.stream"/>
-        <requirement
-            name="net.sourceforge.lpg.lpgjavaruntime"/>
-        <requirement
-            name="org.antlr.runtime"/>
-        <requirement
-            name="org.apache.commons.compress"/>
-        <requirement
-            name="org.apache.log4j"/>
-        <requirement
-            name="org.assertj"/>
-        <requirement
-            name="org.eclipse.egit.feature.group"/>
-        <requirement
-            name="org.eclipse.equinox.executable.feature.group"/>
-        <requirement
-            name="org.eclipse.jdt.annotation"/>
-        <requirement
-            name="org.eclipse.launchbar.feature.group"/>
-        <requirement
-            name="org.eclipse.launchbar.remote.feature.group"/>
-        <requirement
-            name="org.eclipse.linuxtools.docker.feature.feature.group"/>
-        <requirement
-            name="org.eclipse.lsp4e"/>
-        <requirement
-            name="org.eclipse.lsp4e.debug"/>
-        <requirement
-            name="org.eclipse.remote.console.feature.group"/>
-        <requirement
-            name="org.eclipse.remote.feature.group"/>
-        <requirement
-            name="org.eclipse.remote.serial.feature.group"/>
-        <requirement
-            name="org.eclipse.sdk.feature.group"/>
-        <requirement
-            name="org.eclipse.swtbot.eclipse.feature.group"/>
-        <requirement
-            name="org.eclipse.swtbot.eclipse.test.junit.feature.group"/>
-        <requirement
-            name="org.eclipse.swtbot.feature.group"/>
-        <requirement
-            name="org.eclipse.test.feature.group"/>
-        <requirement
-            name="org.eclipse.tm.terminal.connector.cdtserial.feature.feature.group"/>
-        <requirement
-            name="org.eclipse.tm.terminal.control"/>
-        <requirement
-            name="org.eclipse.tm.terminal.feature.feature.group"/>
-        <requirement
-            name="org.eclipse.tm4e.feature.feature.group"/>
-        <requirement
-            name="org.freemarker"/>
-        <requirement
-            name="org.hamcrest"/>
-        <requirement
-            name="org.hamcrest.core"/>
-        <requirement
-            name="org.junit"/>
-        <requirement
-            name="org.junit.jupiter.api"/>
-        <requirement
-            name="org.mockito"/>
-        <requirement
-            name="org.slf4j.impl.log4j12"/>
-        <requirement
-            name="org.yaml.snakeyaml"/>
-        <requirement
-            name="org.eclipse.unittest.ui"/>
-        <sourceLocator
-            rootFolder="${git.clone.cdt.location}"
-            locateNestedProjects="true"/>
-        <repositoryList>
-          <repository
-              url="https://download.eclipse.org/cbi/updates/license/"/>
-          <repository
-              url="https://download.eclipse.org/eclipse/updates/4.22/R-4.22-202111241800/"/>
-          <repository
-              url="https://download.eclipse.org/egit/updates/"/>
-          <repository
-              url="https://download.eclipse.org/linuxtools/updates-docker-nightly/"/>
-          <repository
-              url="https://download.eclipse.org/lsp4e/releases/0.20.2/"/>
-          <repository
-              url="https://download.eclipse.org/modeling/emf/emf/builds/release/latest/"/>
-          <repository
-              url="https://download.eclipse.org/mylyn/docs/releases/3.0.42/"/>
-          <repository
-              url="https://download.eclipse.org/mylyn/drops/3.25.2/v20200831-1956"/>
-          <repository
-              url="https://download.eclipse.org/technology/swtbot/releases/3.1.0/"/>
-          <repository
-              url="https://download.eclipse.org/tm4e/releases/0.4.3/"/>
-          <repository
-              url="https://download.eclipse.org/tools/cdt/releases/10.6/cdt-10.6.0/">
-            <annotation>
-              <detail
-                  key="description">
-                <value>We explicitly have CDT in target platform so that developers can develop org.eclipse.cdt.core/ui without requiring all the projects from CDT in their workspace.</value>
-              </detail>
-            </annotation>
-          </repository>
-          <repository
-              url="https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository/"/>
-          <repository
-              url="https://download.eclipse.org/tools/ptp/builds/remote/3.0/2021-09"/>
-          <repository
-              url="https://download.eclipse.org/wildwebdeveloper/snapshots/"/>
-        </repositoryList>
-      </targlet>
-    </setupTask>
-    <setupTask
-        xsi:type="git:GitCloneTask"
-        id="git.clone.cdt"
-        remoteURI="cdt/org.eclipse.cdt"
-        checkoutBranch="master">
-      <annotation
-          source="http://www.eclipse.org/oomph/setup/InducedChoices">
-        <detail
-            key="inherit">
-          <value>eclipse.git.gerrit.remoteURIs</value>
-        </detail>
-        <detail
-            key="label">
-          <value>${scope.project.label} Git or Gerrit Repository</value>
-        </detail>
-        <detail
-            key="target">
-          <value>remoteURI</value>
-        </detail>
-      </annotation>
-      <description>CDT</description>
-    </setupTask>
-    <setupTask
-        xsi:type="projects:ProjectsImportTask">
+  <setupTask
+      xsi:type="pde:APIBaselineFromTargetTask"
+      predecessor="api.baseline.targlet"
+      name="Modular API Baseline"
+      targetName="Modular API Baseline Target"
+      version="0.0.0">
+    <description>An API baseline based on the target platform named 'Modular API Baseline Target'</description>
+  </setupTask>
+  <setupTask
+      xsi:type="git:GitCloneTask"
+      id="github.clone.cdt"
+      remoteURI="eclipse-cdt/cdt"
+      checkoutBranch="main">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/InducedChoices">
+      <detail
+          key="inherit">
+        <value>github.remoteURIs</value>
+      </detail>
+      <detail
+          key="label">
+        <value>CDT Github Repository</value>
+      </detail>
+      <detail
+          key="target">
+        <value>remoteURI</value>
+      </detail>
+    </annotation>
+    <description>CDT</description>
+  </setupTask>
+  <setupTask
+      xsi:type="setup.targlets:TargletTask"
+      programArguments="-consolelog"
+      vmArguments="-Xms40m -Xmx512M -ea">
+    <targlet
+        name="CDT"
+        includeAllPlatforms="true">
+      <requirement
+          name="org.eclipse.license.feature.group"/>
+      <requirement
+          name="com.google.gson"/>
+      <requirement
+          name="com.sun.jna"
+          versionRange="5.8.0"/>
+      <requirement
+          name="com.sun.jna.platform"
+          versionRange="5.8.0"/>
+      <requirement
+          name="com.sun.xml.bind"
+          versionRange="2.3.3"/>
+      <requirement
+          name="jakarta.xml.bind"
+          versionRange="2.3.3"/>
+      <requirement
+          name="javax.activation"
+          versionRange="1.2.2"/>
+      <requirement
+          name="javax.xml.stream"/>
+      <requirement
+          name="net.sourceforge.lpg.lpgjavaruntime"/>
+      <requirement
+          name="org.antlr.runtime"/>
+      <requirement
+          name="org.apache.commons.compress"/>
+      <requirement
+          name="org.apache.log4j"/>
+      <requirement
+          name="org.assertj"/>
+      <requirement
+          name="org.eclipse.egit.feature.group"/>
+      <requirement
+          name="org.eclipse.equinox.executable.feature.group"/>
+      <requirement
+          name="org.eclipse.jdt.annotation"/>
+      <requirement
+          name="org.eclipse.launchbar.feature.group"/>
+      <requirement
+          name="org.eclipse.launchbar.remote.feature.group"/>
+      <requirement
+          name="org.eclipse.linuxtools.docker.feature.feature.group"/>
+      <requirement
+          name="org.eclipse.lsp4e"/>
+      <requirement
+          name="org.eclipse.lsp4e.debug"/>
+      <requirement
+          name="org.eclipse.remote.console.feature.group"/>
+      <requirement
+          name="org.eclipse.remote.feature.group"/>
+      <requirement
+          name="org.eclipse.remote.serial.feature.group"/>
+      <requirement
+          name="org.eclipse.sdk.feature.group"/>
+      <requirement
+          name="org.eclipse.swtbot.eclipse.feature.group"/>
+      <requirement
+          name="org.eclipse.swtbot.eclipse.test.junit.feature.group"/>
+      <requirement
+          name="org.eclipse.swtbot.feature.group"/>
+      <requirement
+          name="org.eclipse.test.feature.group"/>
+      <requirement
+          name="org.eclipse.tm.terminal.connector.cdtserial.feature.feature.group"/>
+      <requirement
+          name="org.eclipse.tm.terminal.control"/>
+      <requirement
+          name="org.eclipse.tm.terminal.feature.feature.group"/>
+      <requirement
+          name="org.eclipse.tm4e.feature.feature.group"/>
+      <requirement
+          name="org.freemarker"/>
+      <requirement
+          name="org.hamcrest"/>
+      <requirement
+          name="org.hamcrest.core"/>
+      <requirement
+          name="org.junit"/>
+      <requirement
+          name="org.junit.jupiter.api"/>
+      <requirement
+          name="org.mockito"/>
+      <requirement
+          name="org.slf4j.impl.log4j12"/>
+      <requirement
+          name="org.yaml.snakeyaml"/>
+      <requirement
+          name="org.eclipse.unittest.ui"/>
+      <requirement
+          name="*"/>
       <sourceLocator
-          rootFolder="${git.clone.cdt.location}"
+          rootFolder="${github.clone.cdt.location}"
           locateNestedProjects="true"/>
-    </setupTask>
+      <repositoryList>
+        <repository
+            url="https://download.eclipse.org/cbi/updates/license/"/>
+        <repository
+            url="https://download.eclipse.org/eclipse/updates/4.22/R-4.22-202111241800/"/>
+        <repository
+            url="https://download.eclipse.org/egit/updates/"/>
+        <repository
+            url="https://download.eclipse.org/linuxtools/updates-docker-nightly/"/>
+        <repository
+            url="https://download.eclipse.org/lsp4e/releases/0.20.2/"/>
+        <repository
+            url="https://download.eclipse.org/modeling/emf/emf/builds/release/latest/"/>
+        <repository
+            url="https://download.eclipse.org/mylyn/docs/releases/3.0.42/"/>
+        <repository
+            url="https://download.eclipse.org/mylyn/drops/3.25.2/v20200831-1956"/>
+        <repository
+            url="https://download.eclipse.org/technology/swtbot/releases/3.1.0/"/>
+        <repository
+            url="https://download.eclipse.org/tm4e/releases/0.4.3/"/>
+        <repository
+            url="https://download.eclipse.org/tools/cdt/releases/10.6/cdt-10.6.0/">
+          <annotation>
+            <detail
+                key="description">
+              <value>We explicitly have CDT in target platform so that developers can develop org.eclipse.cdt.core/ui without requiring all the projects from CDT in their workspace.</value>
+            </detail>
+          </annotation>
+        </repository>
+        <repository
+            url="https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository/"/>
+        <repository
+            url="https://download.eclipse.org/tools/ptp/builds/remote/3.0/2021-09"/>
+        <repository
+            url="https://download.eclipse.org/wildwebdeveloper/snapshots/"/>
+      </repositoryList>
+    </targlet>
+  </setupTask>
+  <setupTask
+      xsi:type="setup.workingsets:WorkingSetTask">
+    <workingSet
+        name="CDT">
+      <predicate
+          xsi:type="predicates:RepositoryPredicate"
+          project="org.eclipse.cdt-feature"/>
+    </workingSet>
+    <description>The dynamic working sets for ${scope.project.label}</description>
+  </setupTask>
+  <stream name="main">
     <setupTask
-        xsi:type="setup.workingsets:WorkingSetTask">
-      <workingSet
-          name="CDT">
-        <predicate
-            xsi:type="predicates:RepositoryPredicate"
-            project="org.eclipse.cdt-feature"/>
-      </workingSet>
-      <description>The dynamic working sets for ${scope.project.label}</description>
+        xsi:type="setup:EclipseIniTask"
+        option="-Doomph.redirection.cdt"
+        value="=https://raw.githubusercontent.com/eclipse-cdt/cdt/main/releng/CDT.setup->${github.clone.cdt.location|uri}/releng/CDT.setup"
+        vm="true">
+      <description>Set an Oomph redirection system property to redirect the logical location of this setup to its physical location in the Git clone.</description>
     </setupTask>
   </stream>
   <logicalProjectContainer


### PR DESCRIPTION
Don't install org.eclipse.pde.api.tools.ee.feature.feature.group because
it's no longer in the latest update site, and that causes problems like
this one as noticed by a user:

https://www.eclipse.org/forums/index.php?t=msg&th=1111320&goto=1854139&#msg_1854139

Move all the tasks up to the project level.

Include a * requirement on the CDT targlet so that all projects are
imported by the targlet task with no need for a separate import task.
Probably many of the explicitly listed requirements are no longer needed
because all requirements of all projects in the clone are resolved now
automatically.  Also ensure that all platforms are resolved so that all
of CDT fragments are imported.

Move the Git clone task before the modular targlet task so that the
clone is available during the first resolution.

Add an EclipseIni task so that the CDT.setup is redirected into the
local clone's version such that you can modify that setup and test it
locally via Help -> Perform Setup tasks (and so that Navigate -> Open
Setup -> CDT opens the editable workspace version).

https://bugs.eclipse.org/bugs/show_bug.cgi?id=580505