### PR TITLE
Docker: Allow setting a mapping for docker paths

### DIFF
--- a/launch/org.eclipse.cdt.docker.launcher/META-INF/MANIFEST.MF
+++ b/launch/org.eclipse.cdt.docker.launcher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.cdt.docker.launcher;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-Activator: org.eclipse.cdt.docker.launcher.DockerLaunchUIPlugin
 Bundle-Vendor: %Plugin.vendor
 Bundle-Localization: plugin

--- a/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/ContainerLaunchUtils.java
+++ b/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/ContainerLaunchUtils.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.docker.launcher;
 
+import java.util.Map;
+
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 
@@ -59,11 +61,23 @@ public class ContainerLaunchUtils {
 	 * @param path The path on the hose
 	 * @return The string to be passed to the docker daemon
 	 */
-	public static final String toDockerVolume(IPath path) {
-		IPath p = path.makeAbsolute();
-		String rv = toDockerPath(p);
+	public static final String toDockerVolume(Map<String, String> pMap, IPath path) {
+		// The path on the Docker host
+		var dhPath = path.makeAbsolute().toString();
+
+		for (var me : pMap.entrySet()) {
+			var elp = me.getKey();
+			var edhp = me.getValue();
+			if (dhPath.startsWith(elp)) {
+				dhPath = edhp + dhPath.substring(elp.length());
+				break;
+			}
+		}
+
+		// docker-path first, docker-host-path third
+		String rv = toDockerPath(path.makeAbsolute());
 		rv += ":HOST_FILE_SYSTEM:"; //$NON-NLS-1$
-		rv += p.toOSString();
+		rv += dhPath;
 		rv += ":false:true"; //$NON-NLS-1$ RO=false, selected = true
 		return rv;
 	}

--- a/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/ContainerPropertyTab.java
+++ b/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/ContainerPropertyTab.java
@@ -170,83 +170,97 @@ public class ContainerPropertyTab extends AbstractCBuildPropertyTab
 
 		usercomp.setLayoutData(gd);
 
-		enableButton = new Button(usercomp, SWT.CHECK);
-		enableButton.setText(Messages.ContainerPropertyTab_Enable_Msg);
+		//Enable button
+		{
+			enableButton = new Button(usercomp, SWT.CHECK);
+			enableButton.setText(Messages.ContainerPropertyTab_Enable_Msg);
 
-		iCfg = getCfg();
-		iCfgd = getResDesc().getConfiguration();
+			iCfg = getCfg();
+			iCfgd = getResDesc().getConfiguration();
 
-		gd = new GridData(GridData.FILL_HORIZONTAL);
-		gd.horizontalSpan = 5;
-		enableButton.setLayoutData(gd);
+			gd = new GridData(GridData.FILL_HORIZONTAL);
+			gd.horizontalSpan = 5;
+			enableButton.setLayoutData(gd);
+		}
+		// Connection
+		{
+			Label connectionSelectorLabel = new Label(usercomp, SWT.NULL);
+			connectionSelectorLabel.setText(Messages.ContainerTab_Connection_Selector_Label);
+			gd = new GridData(GridData.FILL_HORIZONTAL);
+			gd.horizontalSpan = 1;
+			gd.grabExcessHorizontalSpace = false;
+			connectionSelectorLabel.setLayoutData(gd);
 
-		Label connectionSelectorLabel = new Label(usercomp, SWT.NULL);
-		connectionSelectorLabel.setText(Messages.ContainerTab_Connection_Selector_Label);
-		gd = new GridData(GridData.FILL_HORIZONTAL);
-		gd.horizontalSpan = 1;
-		gd.grabExcessHorizontalSpace = false;
-		connectionSelectorLabel.setLayoutData(gd);
+			connectionSelector = new Combo(usercomp, SWT.BORDER | SWT.READ_ONLY);
+			connectionSelector.setToolTipText(Messages.ContainerTab_Connection_Selector_Tooltip);
+			initializeConnectionSelector();
+			connectionSelector.addModifyListener(connectionModifyListener);
+			// Following is a kludge so that on Linux the Combo is read-only but
+			// has a white background.
+			connectionSelector.addVerifyListener(new VerifyListener() {
+				@Override
+				public void verifyText(VerifyEvent e) {
+					e.doit = false;
+				}
+			});
+			gd = new GridData(GridData.FILL_HORIZONTAL);
+			gd.horizontalSpan = 3;
+			gd.grabExcessHorizontalSpace = true;
+			connectionSelector.setLayoutData(gd);
 
-		connectionSelector = new Combo(usercomp, SWT.BORDER | SWT.READ_ONLY);
-		connectionSelector.setToolTipText(Messages.ContainerTab_Connection_Selector_Tooltip);
-		initializeConnectionSelector();
-		connectionSelector.addModifyListener(connectionModifyListener);
-		// Following is a kludge so that on Linux the Combo is read-only but
-		// has a white background.
-		connectionSelector.addVerifyListener(new VerifyListener() {
-			@Override
-			public void verifyText(VerifyEvent e) {
-				e.doit = false;
-			}
-		});
-		gd = new GridData(GridData.FILL_HORIZONTAL);
-		gd.horizontalSpan = 3;
-		gd.grabExcessHorizontalSpace = true;
-		connectionSelector.setLayoutData(gd);
+			Label label1 = new Label(usercomp, SWT.NULL);
+			gd = new GridData();
+			gd.horizontalSpan = 1;
+			gd.grabExcessHorizontalSpace = false;
+			label1.setLayoutData(gd);
+		}
+		// Image selector
+		{
+			Label imageSelectorLabel = new Label(usercomp, SWT.NULL);
+			imageSelectorLabel.setText(Messages.ContainerTab_Image_Selector_Label);
+			gd = new GridData(GridData.FILL_HORIZONTAL);
+			gd.horizontalSpan = 1;
+			imageSelectorLabel.setLayoutData(gd);
 
-		Label label1 = new Label(usercomp, SWT.NULL);
-		gd = new GridData();
-		gd.horizontalSpan = 1;
-		gd.grabExcessHorizontalSpace = false;
-		label1.setLayoutData(gd);
+			imageCombo = new Combo(usercomp, SWT.DROP_DOWN);
+			gd = new GridData(GridData.FILL_HORIZONTAL);
+			gd.horizontalSpan = 3;
+			gd.grabExcessHorizontalSpace = true;
+			imageCombo.setLayoutData(gd);
 
-		Label imageSelectorLabel = new Label(usercomp, SWT.NULL);
-		imageSelectorLabel.setText(Messages.ContainerTab_Image_Selector_Label);
-		gd = new GridData(GridData.FILL_HORIZONTAL);
-		gd.horizontalSpan = 1;
-		connectionSelectorLabel.setLayoutData(gd);
+			Label label2 = new Label(usercomp, SWT.NULL);
+			gd = new GridData();
+			gd.horizontalSpan = 1;
+			gd.grabExcessHorizontalSpace = false;
+			label2.setLayoutData(gd);
+			initializeImageCombo();
 
-		imageCombo = new Combo(usercomp, SWT.DROP_DOWN);
-		gd = new GridData(GridData.FILL_HORIZONTAL);
-		gd.horizontalSpan = 3;
-		gd.grabExcessHorizontalSpace = true;
-		imageCombo.setLayoutData(gd);
+			imageCombo.addSelectionListener(new SelectionListener() {
 
-		Label label2 = new Label(usercomp, SWT.NULL);
-		gd = new GridData();
-		gd.horizontalSpan = 1;
-		gd.grabExcessHorizontalSpace = false;
-		label2.setLayoutData(gd);
+				@Override
+				public void widgetSelected(SelectionEvent e) {
+					setImageId(imageCombo.getText());
+					model.setSelectedImage(displayedImages.get(imageCombo.getSelectionIndex()));
+				}
 
-		initializeImageCombo();
+				@Override
+				public void widgetDefaultSelected(SelectionEvent e) {
+				}
 
-		imageCombo.addSelectionListener(new SelectionListener() {
-
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				setImageId(imageCombo.getText());
-				model.setSelectedImage(displayedImages.get(imageCombo.getSelectionIndex()));
-			}
-
-			@Override
-			public void widgetDefaultSelected(SelectionEvent e) {
-			}
-
-		});
-
-		createVolumeSettingsContainer(usercomp);
-
+			});
+		}
+		// Volume
+		{
+			Label label = new Label(usercomp, SWT.NULL);
+			gd = new GridData();
+			gd.horizontalSpan = 1;
+			gd.grabExcessHorizontalSpace = false;
+			label.setLayoutData(gd);
+			createVolumeSettingsContainer(usercomp);
+		}
+		// Autotools
 		try {
+
 			IProject project = iCfgd.getProjectDescription().getProject();
 			IProjectNature nature = project.getNature("org.eclipse.cdt.autotools.core.autotoolsNatureV2"); //$NON-NLS-1$
 			isAutotoolsProject = (nature != null);
@@ -275,6 +289,7 @@ public class ContainerPropertyTab extends AbstractCBuildPropertyTab
 			DockerLaunchUIPlugin.log(e);
 		}
 
+		// Handle enablement stuff
 		initializeEnablementButton();
 		enableButton.addSelectionListener(new SelectionListener() {
 

--- a/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/ContainerPropertyTab.java
+++ b/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/ContainerPropertyTab.java
@@ -222,6 +222,7 @@ public class ContainerPropertyTab extends AbstractCBuildPropertyTab
 			Label label = new Label(usercomp, SWT.NULL);
 			label.setText(Messages.ContainerPropertyTab_dockerDPath);
 			gd = new GridData(GridData.FILL_HORIZONTAL);
+			gd.horizontalSpan = 1;
 			label.setLayoutData(gd);
 
 			dockerDPath = new Text(usercomp, SWT.BORDER);
@@ -239,11 +240,13 @@ public class ContainerPropertyTab extends AbstractCBuildPropertyTab
 
 			label = new Label(usercomp, SWT.NULL);
 			gd = new GridData();
+			gd.horizontalSpan = 1;
 			gd.grabExcessHorizontalSpace = false;
 			label.setLayoutData(gd);
 
 			label = new Label(usercomp, SWT.NULL);
 			gd = new GridData();
+			gd.horizontalSpan = 1;
 			gd.grabExcessHorizontalSpace = false;
 			label.setLayoutData(gd);
 
@@ -256,6 +259,7 @@ public class ContainerPropertyTab extends AbstractCBuildPropertyTab
 
 			label = new Label(usercomp, SWT.NULL);
 			gd = new GridData();
+			gd.horizontalSpan = 1;
 			gd.grabExcessHorizontalSpace = false;
 			label.setLayoutData(gd);
 
@@ -296,14 +300,8 @@ public class ContainerPropertyTab extends AbstractCBuildPropertyTab
 			});
 		}
 		// Volume
-		{
-			Label label = new Label(usercomp, SWT.NULL);
-			gd = new GridData();
-			gd.horizontalSpan = 1;
-			gd.grabExcessHorizontalSpace = false;
-			label.setLayoutData(gd);
-			createVolumeSettingsContainer(usercomp);
-		}
+		createVolumeSettingsContainer(usercomp);
+
 		// Autotools
 		try {
 

--- a/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/ContainerPropertyVolumesModel.java
+++ b/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/ContainerPropertyVolumesModel.java
@@ -53,6 +53,16 @@ public class ContainerPropertyVolumesModel extends BaseDatabindingModel {
 
 	private IDockerImage selectedImage;
 
+	private String dockerDPath;
+
+	public String getDockerDPath() {
+		return dockerDPath;
+	}
+
+	public void setDockerDPath(String dockerDPath) {
+		this.dockerDPath = dockerDPath;
+	}
+
 	public ContainerPropertyVolumesModel(final IDockerConnection connection) {
 		this.connection = connection;
 	}

--- a/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/Messages.java
+++ b/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/Messages.java
@@ -112,6 +112,9 @@ public class Messages extends NLS {
 
 	public static String StandardGDBDebuggerPage14;
 
+	public static String ContainerPropertyTab_dockerDPath;
+	public static String ContainerPropertyTab_dockerDPath_Instruction;
+	public static String ContainerPropertyTab_dockerDPath_Tooltip;
 	public static String ContainerPropertyTab_Title;
 	public static String ContainerPropertyTab_Enable_Msg;
 	public static String ContainerPropertyTab_Run_Autotools_In_Container_Msg;

--- a/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/messages.properties
+++ b/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/messages.properties
@@ -61,6 +61,9 @@ ContainerPortDialog_containerLabel=Container port:
 ContainerPortDialog_hostAddressLabel=Host address:
 ContainerPortDialog_hostPortLabel=Host port:
 
+ContainerPropertyTab_dockerDPath=Path mapping:
+ContainerPropertyTab_dockerDPath_Instruction="<host path>|<container path>;[..]" - e.g "C:|/mnt/c;D:|/mnt/d"
+ContainerPropertyTab_dockerDPath_Tooltip=Leave empty when in doubt. Mapping is done using string replacement.
 ContainerPropertyTab_Title=Container Settings
 ContainerPropertyTab_Enable_Msg=Build inside Docker Image
 ContainerPropertyTab_Run_Autotools_In_Container_Msg=Run all Autotools in Container


### PR DESCRIPTION
[Bug 579944](https://bugs.eclipse.org/bugs/show_bug.cgi?id=579944) introduced using Windows paths, to allow putting your project into the WSL's file system. 
While Docker for Windows (the commercial version) supports Windows paths, this does not work with a OSS-docker installed in the WSL. 
[See discussion in Bug 579944]] (https://bugs.eclipse.org/bugs/show_bug.cgi?id=579944#c5)
It is now possible to provide a path mapping to work around this.