### PR TITLE
Fix widget is disposed error during shutdown

### DIFF
--- a/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/buildconsole/BuildConsolePage.java
+++ b/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/buildconsole/BuildConsolePage.java
@@ -249,9 +249,16 @@ public class BuildConsolePage extends Page
 
 		if (BuildConsole.P_STREAM_COLOR.equals(property) && source instanceof IBuildConsoleStreamDecorator) {
 			IBuildConsoleStreamDecorator stream = (IBuildConsoleStreamDecorator) source;
-			if (stream.getConsole().equals(getConsole()) && getControl() != null) {
-				Display display = getControl().getDisplay();
-				display.asyncExec(() -> getViewer().getTextWidget().redraw());
+			if (stream.getConsole().equals(getConsole())) {
+				Control control = getControl();
+				if (control != null && !control.isDisposed()) {
+					control.getDisplay().asyncExec(() -> {
+						StyledText textWidget = getViewer().getTextWidget();
+						if (textWidget != null && !textWidget.isDisposed()) {
+							textWidget.redraw();
+						}
+					});
+				}
 			}
 		} else if (property.equals(BuildConsolePreferencePage.PREF_BUILDCONSOLE_FONT)) {
 			setFont(JFaceResources.getFont(BuildConsolePreferencePage.PREF_BUILDCONSOLE_FONT));
@@ -259,8 +266,11 @@ public class BuildConsolePage extends Page
 			setTabs(CUIPlugin.getDefault().getPreferenceStore()
 					.getInt(BuildConsolePreferencePage.PREF_BUILDCONSOLE_TAB_WIDTH));
 		} else if (IConsoleConstants.P_BACKGROUND_COLOR.equals(property)) {
-			if (fViewer != null && fViewer.getTextWidget() != null && fConsole != null) {
-				fViewer.getTextWidget().setBackground(fConsole.getBackground());
+			if (fViewer != null && fConsole != null) {
+				StyledText textWidget = fViewer.getTextWidget();
+				if (textWidget != null && !textWidget.isDisposed()) {
+					textWidget.setBackground(fConsole.getBackground());
+				}
 			}
 		} else if (property.equals(BuildConsolePreferencePage.PREF_BUILDCONSOLE_WRAP_LINES)
 				|| property.equals(BuildConsolePreferencePage.PREF_BUILDCONSOLE_LINES)
@@ -471,7 +481,10 @@ public class BuildConsolePage extends Page
 	 *            font
 	 */
 	protected void setFont(Font font) {
-		getViewer().getTextWidget().setFont(font);
+		StyledText textWidget = getViewer().getTextWidget();
+		if (textWidget != null && !textWidget.isDisposed()) {
+			textWidget.setFont(font);
+		}
 	}
 
 	/**
@@ -482,7 +495,7 @@ public class BuildConsolePage extends Page
 	 */
 	protected void setTabs(int tabs) {
 		StyledText textWidget = getViewer().getTextWidget();
-		if (textWidget != null) {
+		if (textWidget != null && !textWidget.isDisposed()) {
 			textWidget.setTabs(tabs);
 		}
 	}


### PR DESCRIPTION
After building a project and shuting down eclipse, the build console
will have a propertyChange event fired that will attempt to modify the
stream and background color that will trigger a use-after-dispose error
from SWT. This changeset ensures that the action is only taken on
non-disposed widgets.

Contributed by STMicroelectronics

Change-Id: I872c28da1b2fca7ec39f5b12d9d1ec398e559814
Signed-off-by: Torbjörn Svensson <torbjorn.svensson@st.com>