### PR TITLE
Fix some flaky managedbuilder tests

### DIFF
--- a/build/org.eclipse.cdt.managedbuilder.core.tests/tests/org/eclipse/cdt/managedbuilder/language/settings/providers/tests/BuiltinSpecsDetectorTest.java
+++ b/build/org.eclipse.cdt.managedbuilder.core.tests/tests/org/eclipse/cdt/managedbuilder/language/settings/providers/tests/BuiltinSpecsDetectorTest.java
@@ -851,6 +851,10 @@ public class BuiltinSpecsDetectorTest extends BaseTestCase {
 		assertEquals(true, provider.isExecuted());
 		assertEquals(ENV_SAMPLE_VALUE_2, provider.getSampleEnvVar());
 
+		// clean up
+		vars.deleteAll();
+		fUserSupplier.setWorkspaceEnvironment(vars);
+
 		// unregister listeners
 		provider.unregisterListener();
 	}

--- a/build/org.eclipse.cdt.managedbuilder.core.tests/tests/org/eclipse/cdt/projectmodel/tests/CProjectDescriptionSerializationTests.java
+++ b/build/org.eclipse.cdt.managedbuilder.core.tests/tests/org/eclipse/cdt/projectmodel/tests/CProjectDescriptionSerializationTests.java
@@ -202,13 +202,19 @@ public class CProjectDescriptionSerializationTests extends TestCase {
 			coreModel.setProjectDescription(project, des);
 			Assert.assertEquals(project, des.getProject());
 
-			Thread.sleep(1000); // let scanner discovery participate
 			try {
 				QualifiedName pdomName = new QualifiedName(CCorePlugin.PLUGIN_ID, "pdomName");
 				QualifiedName activeCfg = new QualifiedName(CCorePlugin.PLUGIN_ID, "activeConfiguration");
 				QualifiedName settingCfg = new QualifiedName(CCorePlugin.PLUGIN_ID, "settingConfiguration");
 				QualifiedName discoveredScannerConfigFileName = new QualifiedName(MakeCorePlugin.PLUGIN_ID,
 						"discoveredScannerConfigFileName");
+
+				// pdomName is set by indexer setup, which may still be postponed or not even
+				// scheduled yet, so we can't join the job. Just wait for the property to appear.
+				// (The other properties were set synchronously in setProjectDescription().)
+				for (int i = 0; i < 100 && !project.getPersistentProperties().containsKey(pdomName); i++) {
+					Thread.sleep(100);
+				}
 
 				assertTrue("pdomName", project.getPersistentProperties().containsKey(pdomName));
 				assertTrue("activeCfg", project.getPersistentProperties().containsKey(activeCfg));


### PR DESCRIPTION
This fixes some tests that sometimes fail for me when I run them in the Eclipse GUI on Linux.

* CProjectDescriptionSerializationTests.testPersistentProperties contained a hardcoded sleep time to wait for an asynchronous operation that was often insufficient. Wait for the actual condition instead.

* BuiltinSpecsDetectorTest.testAbstractBuiltinSpecsDetector_EnvChangesGlobal did not properly clean up after itself, which caused it, and some of its siblings, to fail when run for the second time in the same session.

(Running tests twice in the same session is not done deliberately, but it happens in Eclipse with a JUnit Plug-in Test launch configuration set to run all tests in _org.eclipse.cdt.managedbuilder.core.tests/tests_ – once directly and once through _AllLanguageSettingsProvidersMBSTestSuite_. I have not found any way of running every test exactly once in the GUI – the [recommended](https://github.com/eclipse-cdt/cdt/blob/main/FAQ/README.md#how-do-i-run-cdt-junit-test-suite) way seems to be to select _org.eclipse.cdt.managedbuilder.tests.suite.AutomatedIntegrationSuite_, but that leaves out some tests.)