### PR TITLE
Don't error on no stack service

### DIFF
--- a/dsf/org.eclipse.cdt.dsf/src/org/eclipse/cdt/dsf/debug/sourcelookup/DsfSourceLookupParticipant.java
+++ b/dsf/org.eclipse.cdt.dsf/src/org/eclipse/cdt/dsf/debug/sourcelookup/DsfSourceLookupParticipant.java
@@ -190,9 +190,7 @@ public class DsfSourceLookupParticipant extends AbstractSourceLookupParticipant 
 
 		IStack stackService = fServicesTracker.getService(IStack.class);
 		if (stackService == null) {
-			rm.setStatus(new Status(IStatus.ERROR, DsfPlugin.PLUGIN_ID, IDsfStatusConstants.INVALID_HANDLE,
-					"Stack data not available", null)); //$NON-NLS-1$
-			rm.done();
+			rm.done((String) null);
 			return;
 		}
 


### PR DESCRIPTION
The only time the stack service is unavailable is:
1. Stack service hasn't been started yet
2. Stack service has been shutdown
3. Stack service never gets created

All of these cases are configuration error, except (2). In (2) the
stack service isn't available to do source lookup, so instead
of an error, simply return no file (aka null)

Fixes #53