### PR TITLE
Remove old m2e connectors

### DIFF
--- a/releng/CDT.setup
+++ b/releng/CDT.setup
@@ -34,12 +34,8 @@
         name="org.eclipse.jdt.feature.group"/>
     <requirement
         name="org.eclipse.pde.feature.group"/>
-    <requirement
-        name="org.sonatype.tycho.m2e.feature.feature.group"/>
     <repository
         url="http://download.eclipse.org/technology/swtbot/releases/latest"/>
-    <repository
-        url="https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/LATEST/"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>
   </setupTask>
   <setupTask


### PR DESCRIPTION
With m2e upgrading to 2.0 in 2022-09, the old m2e connectors don't work anymore and generally aren't needed either.