### PR TITLE
Roll back platform to avoid Job scheduling issue

### DIFF
--- a/releng/org.eclipse.cdt.target/cdt.target
+++ b/releng/org.eclipse.cdt.target/cdt.target
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="cdt" sequenceNumber="123">
+<target name="cdt" sequenceNumber="124">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
 			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.26-I-builds/I20220928-1800/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.25/R-4.25-202208311800/"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>


### PR DESCRIPTION
The 2022-12 M1 build from Platform may have a regression that is causing CDT build to fail more often due to deadlock in the indexer.
    
This commit uses 2022-09 R build of Platform to avoid the problem.
    
Note that this won't resolve the issue in Platform, but will allow CDT to be built.
