### PR TITLE
GitHub Action for Code Cleanliness Check

### DIFF
--- a/.github/workflows/code-cleanliness.yml
+++ b/.github/workflows/code-cleanliness.yml
@@ -1,0 +1,38 @@
+name: Code Cleanliness Checks
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Install dependencies
+      run: |
+        sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+          libxml2-utils
+    - name: Install Eclipse SDK
+      run: |
+        curl -sL https://download.eclipse.org/eclipse/downloads/drops4/R-4.23-202203080310/eclipse-SDK-4.23-linux-gtk-x86_64.tar.gz | tar xz
+    - name: Run Check Code Cleanliness
+      run: ECLIPSE=$PWD/eclipse/eclipse ./releng/scripts/check_code_cleanliness.sh
+    - name: Upload Logs
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: Code Cleanliness Detailed Logs
+        path: '*.log'

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ check_code_cleanliness_workspace/
 *.takari_issue_192
 *.log
 .tycho-consumer-pom.xml
+/eclipse/

--- a/releng/scripts/check_code_cleanliness.sh
+++ b/releng/scripts/check_code_cleanliness.sh
@@ -56,7 +56,6 @@ ${DIR}/check_glibc_dependencies.sh
 ##
 # Make sure all versions have been bumped appropriately compared to the baseline
 ##
-java -XX:+PrintFlagsFinal -version 
 logfile=baseline-compare-and-replace.log
 echo "Running 'mvn verify -P baseline-compare-and-replace' to make sure all versions"
 echo "have been appropriately incremented. The check output is very verbose, so it is"

--- a/releng/scripts/check_dll_dependencies.sh
+++ b/releng/scripts/check_dll_dependencies.sh
@@ -12,6 +12,14 @@
 
 set -eu
 
+SCRIPT=$( basename "${BASH_SOURCE[0]}" )
+
+if ! command -v x86_64-w64-mingw32-objdump &> /dev/null
+then
+    echo "WARNING: Skipping ${SCRIPT} because mingw cross compiler tools are not available"
+    exit 0
+fi
+
 # This is the current set of allowed DLL dependencies for CDT code. Additional entries here are permitted,
 # provided they are found on all Windows machines by default.
 ALLOWED_DLLS="KERNEL32.DLL MSVCRT.DLL USER32.DLL PSAPI.DLL SHELL32.DLL ADVAPI32.DLL"

--- a/releng/scripts/check_glibc_dependencies.sh
+++ b/releng/scripts/check_glibc_dependencies.sh
@@ -12,6 +12,14 @@
 
 set -eu
 
+SCRIPT=$( basename "${BASH_SOURCE[0]}" )
+
+if ! command -v aarch64-linux-gnu-readelf &> /dev/null
+then
+    echo "WARNING: Skipping ${SCRIPT} because aarch/powerpc cross compiler tools are not available"
+    exit 0
+fi
+
 
 ###
 # Check that all .so files in CDT for a given ${ARCH} (using ${PREFIX} toolchain) 

--- a/releng/scripts/do_rebuild_natives.sh
+++ b/releng/scripts/do_rebuild_natives.sh
@@ -12,6 +12,14 @@
 
 set -e
 
+SCRIPT=$( basename "${BASH_SOURCE[0]}" )
+
+if ! command -v x86_64-apple-darwin21.1-clang &> /dev/null
+then
+    echo "WARNING: Skipping ${SCRIPT} because Darwin clang is not available"
+    exit 0
+fi
+
 ##
 # Make sure that natives are up to date
 ##


### PR DESCRIPTION
This commit runs GitHub actions for code cleanliness. Because this includes compare and replace build, this verifies that the commit is buildable and clean.

The natives are not rebuilt here (yet) because the GitHub actions runner does not have the cross compiler tools installed.

Part of migration to GitHub - Issue #32