### PR TITLE
DSF-GDB tests in GitHub Actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,12 +15,27 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          dsf:
+            - 'dsf-gdb/**'
+            - 'dsf/**'
+            - 'debug/**'
+            - 'jtag/**'
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+    - name: Install GCC & GDB & other build essentials
+      run: |
+        sudo apt-get -y install build-essential gcc g++ gdb gdbserver
+        gdb --version
+        gcc --version
+        gdbserver --version
     - name: Build and Test
       run: |
         export DISPLAY=:99
@@ -31,6 +46,7 @@ jobs:
           -DexcludedGroups=flakyTest,slowTest \
           -P baseline-compare-and-replace \
           -Ddsf.gdb.tests.timeout.multiplier=50 \
+          -Ddsf-gdb.skip.tests=$(test ${{ steps.filter.outputs.dsf }} == 'false' && echo 'true' || echo 'false') \
           -Dindexer.timeout=300
     - name: Upload Logs
       uses: actions/upload-artifact@v3

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -26,11 +26,3 @@ jobs:
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           junit_files: "test-results/**/*.xml"
-      - name: Publish Test Report in GitHub Actions UI
-        uses: mikepenz/action-junit-report@v3
-        with:
-          commit: ${{github.event.workflow_run.head_sha}}
-          report_paths: 'test-results/**/*.xml'
-          fail_on_failure: true
-          require_tests: true
-          check_name: Test Results

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -116,6 +116,9 @@ uncommited changes use `-Djgit.dirtyWorkingTree-cdtDefault=warning`
 
 For running CDT's DSF-GDB tests, this specifies the path to the location of gdb.
 
+The default, defined in the root pom.xml, it is blank, which uses gdb from the `PATH`.
+See BaseTestCase for more info.
+
 #### cdt.tests.dsf.gdb.versions
 
 For running CDT's DSF-GDB tests, this specifies the executable names of the gdbs to run, comma-separated.
@@ -126,7 +129,8 @@ There are a few special values that can be specified (see BaseParametrizedTestCa
 - supported: run all versions listed in ITestConstants.ALL_SUPPORTED_VERSIONS
 - unsupported: run all versions listed in ITestConstants.ALL_UNSUPPORTED_VERSIONS
 
-The default, defined in the root pom.xml, should be the most recent released version of gdb.
+The default, defined in the root pom.xml, it is blank, which uses `gdb` and `gdbserver`.
+See BaseParametrizedTestCase for more info.
 
 To build all gdb versions for testing CDT see [download-build-gdb.sh](https://github.com/eclipse-cdt/cdt-infra/blob/master/docker/scripts/download-build-gdb.sh)
 

--- a/dsf-gdb/org.eclipse.cdt.tests.dsf.gdb/src/org/eclipse/cdt/tests/dsf/gdb/framework/BaseParametrizedTestCase.java
+++ b/dsf-gdb/org.eclipse.cdt.tests.dsf.gdb/src/org/eclipse/cdt/tests/dsf/gdb/framework/BaseParametrizedTestCase.java
@@ -54,7 +54,7 @@ public abstract class BaseParametrizedTestCase extends BaseTestCase {
 			return Collections.singletonList(globalVersion);
 		}
 		String gdbVersions = System.getProperty("cdt.tests.dsf.gdb.versions");
-		if (gdbVersions == null) {
+		if (gdbVersions == null || gdbVersions.isBlank()) {
 			// this has to be put in maven using -Dcdt.tests.dsf.gdb.versions or
 			// in junit config if you run locally
 			// like this -Dcdt.tests.dsf.gdb.versions=gdb.7.7,gdbserver.7.7

--- a/dsf-gdb/org.eclipse.cdt.tests.dsf.gdb/src/org/eclipse/cdt/tests/dsf/gdb/framework/BaseTestCase.java
+++ b/dsf-gdb/org.eclipse.cdt.tests.dsf.gdb/src/org/eclipse/cdt/tests/dsf/gdb/framework/BaseTestCase.java
@@ -743,7 +743,7 @@ public class BaseTestCase {
 		String fileExtension = isWindows ? ".exe" : "";
 		String versionPostfix = (!version.equals(DEFAULT_VERSION_STRING)) ? "." + version : "";
 		String debugName = main + versionPostfix + fileExtension;
-		if (gdbPath != null) {
+		if (gdbPath != null && !gdbPath.isBlank()) {
 			debugName = gdbPath + "/" + debugName;
 		}
 		return debugName;

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
 		     -DskipTests will override anything else as normal maven
 		     users expect. -->
 		<skipTests>${cdt-other.skip.tests}</skipTests>
-		<dsf.gdb.tests.gdbPath>/shared/common/gdb/gdb-all/bin</dsf.gdb.tests.gdbPath>
-		<cdt.tests.dsf.gdb.versions>gdb.10,gdbserver.10</cdt.tests.dsf.gdb.versions>
+		<dsf.gdb.tests.gdbPath></dsf.gdb.tests.gdbPath>
+		<cdt.tests.dsf.gdb.versions></cdt.tests.dsf.gdb.versions>
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
 		<buildTimestamp>${maven.build.timestamp}</buildTimestamp>
 	    <buildId>${buildTimestamp}</buildId>


### PR DESCRIPTION
- Fix the running so that the correct gdb is used.
- Only run DSF tests if dsf directories have been modified
- Default to using gdb,gdbserver on the PATH when running tests
- Remove double reporting of test results

Part of #32 