### PR TITLE
Fix fragment name

### DIFF
--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb.multicorevisualizer.ui.tests/fragment.properties
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb.multicorevisualizer.ui.tests/fragment.properties
@@ -10,5 +10,5 @@
 # Torbjörn Svensson - initial API and implementation
 ##################################################################################
 
-pluginName = DSF-GDB test fragment
+pluginName = DSF-GDB multicorevisualizer test fragment
 providerName = Eclipse CDT


### PR DESCRIPTION
Two bundles were called DSF-GDB test fragment,
rename this one to be more explicit

PS. Also using this trivial change to test the new GitHub actions in #97 