### PR TITLE
Bug 580314 - Remove deprecated methods from core build

### DIFF
--- a/NewAndNoteworthy/CHANGELOG-API.md
+++ b/NewAndNoteworthy/CHANGELOG-API.md
@@ -10,6 +10,8 @@ This section describes API removals that occurred in past releases, and upcoming
 
 - [org.eclipse.cdt.ui.newui.AbstractPage reduced visibility of many fields](#newUIAbstractPage)
 - [org.eclipse.cdt.dsf.gdb.breakpoints.Messages is no longer API](#org.eclipse.cdt.dsf.gdb.breakpoints.Messages)
+- [Removal of deprecated CommandLauncher.execute() method](#executeCommandLauncher)
+- [Removal of deprecated CBuildConfiguration.watchProcess() methods](#watchProcessCBuildConfig)
 
 ## API Changes in CDT 10.5.0
 
@@ -108,6 +110,28 @@ See [Bug 579666](https://bugs.eclipse.org/bugs/show_bug.cgi?id=579666).
 org.eclipse.cdt.dsf.gdb.breakpoints.Messages should never have been API, Messages classes generally should not be.
 
 See https://github.com/eclipse-cdt/cdt/pull/90
+
+### <span id="executeCommandLauncher">Removal of deprecated CommandLauncher.execute() method</span>
+
+The following method is removed because it does not implement the ICommandLauncher
+interface. It has been deprecated since 2009:
+
+- org.eclipse.cdt.core.CommandLauncher.execute(IPath, String[], String[], IPath)
+
+Clients should instead use the equivilent method from the ICommandLauncher interface.
+See [Bug 268615](https://bugs.eclipse.org/bugs/show_bug.cgi?id=268615).
+
+### <span id="watchProcessCBuildConfig">Removal of deprecated CBuildConfiguration.watchProcess() methods</span>
+
+The following methods are removed because their use prevents cancellation of
+in-progress builds of core-build projects:
+
+- org.eclipse.cdt.core.build.CBuildConfiguration.watchProcess(Process, IConsoleParser[], IConsole)
+- org.eclipse.cdt.core.build.CBuildConfiguration.watchProcess(Process, IConsole)
+- org.eclipse.cdt.core.build.CBuildConfiguration.watchProcess(Process, IConsoleParser[])
+
+Clients should instead use the methods of the same name that take a progress monitor object.
+See [Bug 580314](https://bugs.eclipse.org/bugs/show_bug.cgi?id=580314).
 
 ---
 

--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/CommandLauncher.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/CommandLauncher.java
@@ -143,20 +143,6 @@ public class CommandLauncher implements ICommandLauncher {
 	}
 
 	/**
-	 * @deprecated
-	 * @since 5.1
-	 */
-	@Deprecated
-	public Process execute(IPath commandPath, String[] args, String[] env, IPath changeToDirectory) {
-		try {
-			return execute(commandPath, args, env, changeToDirectory, null);
-		} catch (CoreException e) {
-			CCorePlugin.log(e);
-		}
-		return null;
-	}
-
-	/**
 	 * @since 5.1
 	 * @see org.eclipse.cdt.core.ICommandLauncher#execute(IPath, String[], String[], IPath, IProgressMonitor)
 	 */

--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/CBuildConfiguration.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/CBuildConfiguration.java
@@ -518,47 +518,10 @@ public abstract class CBuildConfiguration extends PlatformObject implements ICBu
 
 	/**
 	 * @return The exit code of the build process.
-	 *
-	 * @deprecated use {@link #watchProcess(IConsole, IProgressMonitor)} or {@link #watchProcess(IConsoleParser[], IProgressMonitor)} instead
-	 */
-	@Deprecated
-	protected int watchProcess(Process process, IConsoleParser[] consoleParsers, IConsole console)
-			throws CoreException {
-		if (consoleParsers == null || consoleParsers.length == 0) {
-			return watchProcess(process, console);
-		} else {
-			return watchProcess(process, consoleParsers);
-		}
-	}
-
-	/**
-	 * @return The exit code of the build process.
-	 * @since 6.4
-	 *
-	 * @deprecated use {@link #watchProcess(IConsole, IProgressMonitor)} instead and pass in a monitor
-	 */
-	@Deprecated
-	protected int watchProcess(Process process, IConsole console) throws CoreException {
-		return watchProcess(console, new NullProgressMonitor());
-	}
-
-	/**
-	 * @return The exit code of the build process.
 	 * @since 7.5
 	 */
 	protected int watchProcess(IConsole console, IProgressMonitor monitor) throws CoreException {
 		return launcher.waitAndRead(console.getInfoStream(), console.getErrorStream(), monitor);
-	}
-
-	/**
-	 * @return The exit code of the build process.
-	 * @since 6.4
-	 *
-	 * @deprecated use {@link #watchProcess(IConsoleParser[], IProgressMonitor)} instead and pass in a monitor
-	 */
-	@Deprecated
-	protected int watchProcess(Process process, IConsoleParser[] consoleParsers) throws CoreException {
-		return watchProcess(consoleParsers, new NullProgressMonitor());
 	}
 
 	/**


### PR DESCRIPTION
Mark deprecated methods in CommandLauncher and CBuildConfig as "for removal"

Moved this PR over from gerrit: https://git.eclipse.org/r/c/cdt/org.eclipse.cdt/+/194515
