### PR TITLE
[releng] Fix up usages of tycho-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,12 +456,11 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.eclipse.tycho.extras</groupId>
-						<artifactId>tycho-source-feature-plugin</artifactId>
-						<version>${tycho-version}</version>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-source-plugin</artifactId>
 						<executions>
 							<execution>
-								<id>source-feature</id>
+								<id>attach-feature-source</id>
 								<phase>none</phase>
 							</execution>
 						</executions>
@@ -736,23 +735,14 @@
 							<goal>plugin-source</goal>
 						</goals>
 					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<configuration>
-					<includeBinaryFeature>false</includeBinaryFeature>
-				</configuration>
-				<executions>
 					<execution>
-						<id>source-feature</id>
+						<id>attach-feature-source</id>
 						<phase>package</phase>
 						<goals>
-							<goal>source-feature</goal>
+							<goal>feature-source</goal>
 						</goals>
 						<configuration>
+							<includeBinaryFeature>false</includeBinaryFeature>
 							<excludes>
 								<plugin id="org.eclipse.cdt.autotools.docs"/>
 								<plugin id="org.eclipse.cdt.meson.docs"/>
@@ -846,14 +836,6 @@
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-source-plugin</artifactId>
 					<version>${tycho-version}</version>
-					<executions>
-						<execution>
-							<id>plugin-source</id>
-							<goals>
-								<goal>plugin-source</goal>
-							</goals>
-						</execution>
-					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>


### PR DESCRIPTION
Currently you can see this warning about migrating to the new feature-source goal:

```
[INFO] --- tycho-source-feature-plugin:2.7.5:source-feature (source-feature) @ org.eclipse.cdt.testing ---
[WARNING] Mojo tycho-source-feature-plugin:source-feature is replaced by the tycho-source-plugin:feature-source which offers equivalent and even enhanced functionality
```

And you can see duplicate invokations of the plugin-source goal:

```
[INFO] --- tycho-source-plugin:2.7.5:plugin-source (plugin-source) @ org.eclipse.cdt.platform.branding ---
[INFO] Building jar: /home/mbooth/workspace-cdt/org.eclipse.cdt/releng/org.eclipse.cdt.platform.branding/target/org.eclipse.cdt.platform.branding-11.0.0-SNAPSHOT-sources.jar
[INFO] 
[INFO] --- tycho-source-plugin:2.7.5:plugin-source (attach-source) @ org.eclipse.cdt.platform.branding ---
[INFO] Building jar: /home/mbooth/workspace-cdt/org.eclipse.cdt/releng/org.eclipse.cdt.platform.branding/target/org.eclipse.cdt.platform.branding-11.0.0-SNAPSHOT-sources.jar
```

This change fixes both problems and will ease eventual migration to tycho 3.