### PR TITLE
Improve the CMake project wizard template

### DIFF
--- a/cmake/org.eclipse.cdt.cmake.core/templates/simple/CMakeLists.txt
+++ b/cmake/org.eclipse.cdt.cmake.core/templates/simple/CMakeLists.txt
@@ -1,5 +1,15 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
-project (${projectName})
+# Set some basic project attributes
+project (${projectName?replace(" ", "_")}
+	VERSION 0.1
+	DESCRIPTION "A Hello World Project")
 
-add_executable(${projectName} ${projectName}.cpp)
+# This project will output an executable file
+add_executable(${r"${PROJECT_NAME}"} ${projectName?replace(" ", "_")}.cpp)
+
+# Create a simple configuration header
+configure_file(config.h.in config.h)
+
+# Include the configuration header in the build
+target_include_directories(${r"${PROJECT_NAME}"} PUBLIC "${r"${PROJECT_BINARY_DIR}"}")

--- a/cmake/org.eclipse.cdt.cmake.core/templates/simple/config.h.in
+++ b/cmake/org.eclipse.cdt.cmake.core/templates/simple/config.h.in
@@ -1,0 +1,2 @@
+#define ${projectName?replace(" ", "_")}_VERSION_MAJOR @${projectName?replace(" ", "_")}_VERSION_MAJOR@
+#define ${projectName?replace(" ", "_")}_VERSION_MINOR @${projectName?replace(" ", "_")}_VERSION_MINOR@

--- a/cmake/org.eclipse.cdt.cmake.core/templates/simple/main.cpp
+++ b/cmake/org.eclipse.cdt.cmake.core/templates/simple/main.cpp
@@ -1,7 +1,8 @@
 #include <iostream>
-using namespace std;
+#include "config.h"
 
 int main(int argc, char **argv) {
-	cout << "Hello world";
+	std::cout << "Hello World" << std::endl;
+	std::cout << "Version " << ${projectName?replace(" ", "_")}_VERSION_MAJOR << "." << ${projectName?replace(" ", "_")}_VERSION_MINOR << std::endl;
 	return 0;
 }

--- a/cmake/org.eclipse.cdt.cmake.core/templates/simple/manifest.xml
+++ b/cmake/org.eclipse.cdt.cmake.core/templates/simple/manifest.xml
@@ -1,7 +1,9 @@
 <templateManifest>
 	<file src="/templates/simple/CMakeLists.txt"
 		dest="/${projectName}/CMakeLists.txt"/>
+	<file src="/templates/simple/config.h.in"
+		dest="/${projectName}/config.h.in"/>
 	<file src="/templates/simple/main.cpp"
-		dest="/${projectName}/${projectName}.cpp"
+		dest="/${projectName}/${projectName?replace(" ", "_")}.cpp"
 		open="true"/>
 </templateManifest>


### PR DESCRIPTION
The hello world CMake project template is extremely basic and generates deprecation warnings out-of-the-box:

```
Configuring in: /home/mbooth/runtime-cdt-0/MrProj/build/default
cmake -G Unix Makefiles -DCMAKE_EXPORT_COMPILE_COMMANDS=ON /home/mbooth/runtime-cdt-0/MrProj
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

And will not build at all if you name the project something containing a space:

```
CMake Error: Could not find cmake module file: CMakeDetermineProjCompiler.cmake
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
-- Configuring incomplete, errors occurred!
See also "/home/mbooth/runtime-cdt-0/A Proj/build/default/CMakeFiles/CMakeOutput.log".
Missing variable is:
CMAKE_Proj_COMPILER_ENV_VAR
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
```


Every currently supported distro of Linux that I checked comes with CMake > 3 so I propose we make the template a bit better. This change fixes the deprecation warnings by bumping the min version of CMake to 3.10 (still a very old version) and takes advantage of some features from CMake > 3, like showing how to set some project configuration details, and showing how to implement the common idiom of generating configuration headers.

Project names containing spaces is also allowed by this patch by using freemarker syntax to remove them where necessary in the template.