### PR TITLE
org.eclipse.cdt.target should have shortcut for CDTConfiguration.setup

### DIFF
--- a/releng/org.eclipse.cdt.target/.project
+++ b/releng/org.eclipse.cdt.target/.project
@@ -15,6 +15,11 @@
 			<locationURI>$%7BPARENT-1-PROJECT_LOC%7D/CDT.setup</locationURI>
 		</link>
 		<link>
+			<name>CDTConfiguration.setup</name>
+			<type>1</type>
+			<locationURI>$%7BPARENT-1-PROJECT_LOC%7D/CDTConfiguration.setup</locationURI>
+		</link>
+		<link>
 			<name>parent-pom.xml</name>
 			<type>1</type>
 			<locationURI>PARENT-2-PROJECT_LOC/pom.xml</locationURI>


### PR DESCRIPTION
Added shortcut to CDTConfiguration.setup in order to resolve validation problems in CDT.setup