### PR TITLE
CDT.setup working set definitions: fix swapped LSP and LLVM

### DIFF
--- a/releng/CDT.setup
+++ b/releng/CDT.setup
@@ -371,14 +371,14 @@
       <predicate
           xsi:type="predicates:RepositoryPredicate"
           project="org.eclipse.cdt"
-          relativePathPattern="lsp/.*"/>
+          relativePathPattern="llvm/.*"/>
     </workingSet>
     <workingSet
         name="CDT LSP">
       <predicate
           xsi:type="predicates:RepositoryPredicate"
           project="org.eclipse.cdt"
-          relativePathPattern="llvm/.*"/>
+          relativePathPattern="lsp/.*"/>
     </workingSet>
     <workingSet
         name="CDT Memory">


### PR DESCRIPTION
Fix working set predicate patterns for "CDT LLVM" and "CDT LSP"