### PR TITLE
Enable the profile in the GH Actions to verify standalone builds

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -45,6 +45,7 @@ jobs:
           -Dmaven.test.failure.ignore=true \
           -DexcludedGroups=flakyTest,slowTest \
           -P baseline-compare-and-replace \
+          -P build-standalone-debugger-rcp \
           -Ddsf.gdb.tests.timeout.multiplier=50 \
           -Ddsf-gdb.skip.tests=$(test ${{ steps.filter.outputs.dsf }} == 'false' && echo 'true' || echo 'false') \
           -Dindexer.timeout=300


### PR DESCRIPTION
Follow up from c1269a99905e6a1fd6260d56ec2f36216de19f8b