### PR TITLE
Fix the dprintf tests when running on gdbserver

### DIFF
--- a/dsf-gdb/org.eclipse.cdt.tests.dsf.gdb/data/launch/src/BreakpointTestApp.cc
+++ b/dsf-gdb/org.eclipse.cdt.tests.dsf.gdb/data/launch/src/BreakpointTestApp.cc
@@ -48,6 +48,7 @@ int main()
 	loop();
 	setBlocks();
 	SLEEP(1);
+	cout << flush;
 	a++; // LINE_NUMBER_5
 	return 0; // LINE_NUMBER_6
 }


### PR DESCRIPTION
Because dprintf goes to stdout, need to make sure buffers are fully flushed before we check output.