### PR TITLE
Fix race condition in multithread test

### DIFF
--- a/dsf-gdb/org.eclipse.cdt.tests.dsf.gdb/data/launch/src/MultiThreadRunControl.cc
+++ b/dsf-gdb/org.eclipse.cdt.tests.dsf.gdb/data/launch/src/MultiThreadRunControl.cc
@@ -22,7 +22,7 @@ static ThreadRet THREAD_CALL_CONV PrintHello(void *void_arg) {
 
 	firstBreakpoint(thread_id);  // Stop a second time
 
-	SLEEP(3); // Resuming past this will give us a running thread
+	SLEEP(30); // Resuming past this will give us a running thread
 
 	return THREAD_DEFAULT_RET;
 }
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
 
 	SLEEP(1);  // Resuming past this will make this thread run, while we stop the second thread
 
-	SLEEP(3);  // Resuming past this will make this thread run, while we also run the second thread
+	SLEEP(30);  // Resuming past this will make this thread run, while we also run the second thread
 
 	return 0;
 }


### PR DESCRIPTION
The long sleep at the end of each thread is to make sure that while the test code is waiting for an event the "other" thread doesn't finish. 3 seconds is not long enough for this.

This is similar to why we need dsf.gdb.tests.timeout.multiplier for other tests. Especially on the build machines the tests can run much slower causing the sleep to be insufficient.

Increasing this to 30 seconds doesn't make the test suites take any longer, when they are all passing.

Fixes #119