### PR TITLE
Add ManagedBuildManager#createConfigurationForProject()

### DIFF
--- a/NewAndNoteworthy/CDT-11.0.md
+++ b/NewAndNoteworthy/CDT-11.0.md
@@ -50,6 +50,11 @@ Job.getJobManager().join(ManagedBuilderCorePlugin.BUILD_SETTING_UPDATE_JOB_FAMIL
 This new job family was added to improve stability of tests to ensure background operations are complete.
 It may have other uses to other API consumers as well and is therefore included here.
 
+## New method ManagedBuildManager#createConfigurationForProject()
+
+This should allow ISV's to create MBS based project with a vendor-specific build-system ID without using internal API.
+
+
 # Bugs Fixed in this Release
 
 See [GitHub milestones](https://github.com/eclipse-cdt/cdt/milestone/2?closed=1) and for bugs that haven't been transitioned to GitHub please see Bugzilla report [Bugs Fixed in CDT 11.0](https://bugs.eclipse.org/bugs/buglist.cgi?bug_status=RESOLVED&bug_status=VERIFIED&bug_status=CLOSED&classification=Tools&product=CDT&query_format=advanced&resolution=FIXED&target_milestone=11.0.0).

--- a/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/core/ManagedBuildManager.java
+++ b/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/core/ManagedBuildManager.java
@@ -848,7 +848,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 				return;
 			}
 		} catch (BuildException e) {return;}
-	
+
 		// Figure out if there is a listener for this change
 		IResource resource = config.getOwner();
 		List listeners = (List) getBuildModelListeners().get(resource);
@@ -1353,10 +1353,10 @@ public class ManagedBuildManager extends AbstractCExtension {
 		try {
 			DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
 			Document doc = builder.newDocument();
-		
+
 			// Get the build information for the project
 			ManagedBuildInfo buildInfo = (ManagedBuildInfo) getBuildInfo(project);
-		
+
 			// Save the build info
 			if (buildInfo != null &&
 					!buildInfo.isReadOnly() &&
@@ -1371,7 +1371,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 				Element rootElement = doc.createElement(ROOT_NODE_NAME);
 				doc.appendChild(rootElement);
 				buildInfo.serialize(doc, rootElement);
-		
+
 				// Transform the document to something we can save in a file
 				ByteArrayOutputStream stream = new ByteArrayOutputStream();
 				Transformer transformer = TransformerFactory.newInstance().newTransformer();
@@ -1381,11 +1381,11 @@ public class ManagedBuildManager extends AbstractCExtension {
 				DOMSource source = new DOMSource(doc);
 				StreamResult result = new StreamResult(stream);
 				transformer.transform(source, result);
-		
+
 				// Save the document
 				IFile projectFile = project.getFile(SETTINGS_FILE_NAME);
 				String utfString = stream.toString("UTF-8");	//$NON-NLS-1$
-		
+
 				if (projectFile.exists()) {
 					if (projectFile.isReadOnly()) {
 						// If we are not running headless, and there is a UI Window around, grab it
@@ -1419,7 +1419,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 				} else {
 					projectFile.create(new ByteArrayInputStream(utfString.getBytes("UTF-8")), IResource.FORCE, new NullProgressMonitor());	//$NON-NLS-1$
 				}
-		
+
 				// Close the streams
 				stream.close();
 			}
@@ -1440,7 +1440,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 			// Save to IFile failed
 		    err = e;
 		}
-		
+
 		if (err != null) {
 			// Put out an error message indicating that the attempted write to the .cdtbuild project file failed
 			IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
@@ -1448,7 +1448,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 				IWorkbenchWindow windows[] = PlatformUI.getWorkbench().getWorkbenchWindows();
 				window = windows[0];
 			}
-		
+
 			final Shell shell = window.getShell();
 			if (shell != null) {
 				final String exceptionMsg = err.getMessage();
@@ -1526,9 +1526,9 @@ public class ManagedBuildManager extends AbstractCExtension {
 			for (int i=0; i < configs.length; i++) {
 				ManagedBuildManager.performValueHandlerEvent(configs[i], IManagedOptionValueHandler.EVENT_CLOSE);
 			}
-		
+
 			info.setValid(false);
-		
+
 			try {
 				resource.setSessionProperty(buildInfoProperty, null);
 			} catch (CoreException e) {
@@ -1809,7 +1809,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 		return Status.OK_STATUS;
 		/*
 		ManagedBuildInfo buildInfo = null;
-		
+
 		// Get the build info associated with this project for this session
 		try {
 			buildInfo = findBuildInfo(resource.getProject(), true);
@@ -2716,7 +2716,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 					} catch (Exception e) {
 						// TODO:  Issue error reagarding not being able to load the project file (.cdtbuild)
 					}
-		
+
 					try {
 						// Check if the project needs its container initialized
 						initBuildInfoContainer(buildInfo);
@@ -2798,7 +2798,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 	 */
 	/*	synchronized private static ManagedBuildInfo findBuildInfoSynchronized(IProject project, boolean forceLoad) {
 			ManagedBuildInfo buildInfo = null;
-	
+
 			// Check if there is any build info associated with this project for this session
 			try {
 				buildInfo = (ManagedBuildInfo)project.getSessionProperty(buildInfoProperty);
@@ -2809,7 +2809,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 			} catch (CoreException e) {
 		//		return null;
 			}
-	
+
 			if(buildInfo == null && forceLoad){
 				// Make sure the extension information is loaded first
 				try {
@@ -2818,11 +2818,11 @@ public class ManagedBuildManager extends AbstractCExtension {
 					e.printStackTrace();
 					return null;
 				}
-	
-	
+
+
 				// Check weather getBuildInfo is called from converter
 				buildInfo = UpdateManagedProjectManager.getConvertedManagedBuildInfo(project);
-	
+
 				// Nothing in session store, so see if we can load it from cdtbuild
 				if (buildInfo == null) {
 					try {
@@ -2839,7 +2839,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 							IWorkbenchWindow windows[] = PlatformUI.getWorkbench().getWorkbenchWindows();
 							window = windows[0];
 						}
-	
+
 						final Shell shell = window.getShell();
 						final String exceptionMsg = e.getMessage();
 						//using syncExec could cause a dead-lock
@@ -2853,7 +2853,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 							}
 						} );
 					}
-	
+
 					if (buildInfo != null && !buildInfo.isContainerInited()) {
 						//  NOTE:  If this is called inside the above rule, then an IllegalArgumentException can
 						//         occur when the CDT project file is saved - it uses the Workspace Root as the scheduling rule.
@@ -2867,7 +2867,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 					}
 				}
 			}
-	
+
 			return buildInfo;
 		}
 	*/

--- a/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/core/ManagedBuildManager.java
+++ b/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/core/ManagedBuildManager.java
@@ -848,7 +848,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 				return;
 			}
 		} catch (BuildException e) {return;}
-
+	
 		// Figure out if there is a listener for this change
 		IResource resource = config.getOwner();
 		List listeners = (List) getBuildModelListeners().get(resource);
@@ -1353,10 +1353,10 @@ public class ManagedBuildManager extends AbstractCExtension {
 		try {
 			DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
 			Document doc = builder.newDocument();
-
+		
 			// Get the build information for the project
 			ManagedBuildInfo buildInfo = (ManagedBuildInfo) getBuildInfo(project);
-
+		
 			// Save the build info
 			if (buildInfo != null &&
 					!buildInfo.isReadOnly() &&
@@ -1371,7 +1371,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 				Element rootElement = doc.createElement(ROOT_NODE_NAME);
 				doc.appendChild(rootElement);
 				buildInfo.serialize(doc, rootElement);
-
+		
 				// Transform the document to something we can save in a file
 				ByteArrayOutputStream stream = new ByteArrayOutputStream();
 				Transformer transformer = TransformerFactory.newInstance().newTransformer();
@@ -1381,11 +1381,11 @@ public class ManagedBuildManager extends AbstractCExtension {
 				DOMSource source = new DOMSource(doc);
 				StreamResult result = new StreamResult(stream);
 				transformer.transform(source, result);
-
+		
 				// Save the document
 				IFile projectFile = project.getFile(SETTINGS_FILE_NAME);
 				String utfString = stream.toString("UTF-8");	//$NON-NLS-1$
-
+		
 				if (projectFile.exists()) {
 					if (projectFile.isReadOnly()) {
 						// If we are not running headless, and there is a UI Window around, grab it
@@ -1419,7 +1419,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 				} else {
 					projectFile.create(new ByteArrayInputStream(utfString.getBytes("UTF-8")), IResource.FORCE, new NullProgressMonitor());	//$NON-NLS-1$
 				}
-
+		
 				// Close the streams
 				stream.close();
 			}
@@ -1440,7 +1440,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 			// Save to IFile failed
 		    err = e;
 		}
-
+		
 		if (err != null) {
 			// Put out an error message indicating that the attempted write to the .cdtbuild project file failed
 			IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
@@ -1448,7 +1448,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 				IWorkbenchWindow windows[] = PlatformUI.getWorkbench().getWorkbenchWindows();
 				window = windows[0];
 			}
-
+		
 			final Shell shell = window.getShell();
 			if (shell != null) {
 				final String exceptionMsg = err.getMessage();
@@ -1526,9 +1526,9 @@ public class ManagedBuildManager extends AbstractCExtension {
 			for (int i=0; i < configs.length; i++) {
 				ManagedBuildManager.performValueHandlerEvent(configs[i], IManagedOptionValueHandler.EVENT_CLOSE);
 			}
-
+		
 			info.setValid(false);
-
+		
 			try {
 				resource.setSessionProperty(buildInfoProperty, null);
 			} catch (CoreException e) {
@@ -1809,7 +1809,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 		return Status.OK_STATUS;
 		/*
 		ManagedBuildInfo buildInfo = null;
-
+		
 		// Get the build info associated with this project for this session
 		try {
 			buildInfo = findBuildInfo(resource.getProject(), true);
@@ -2716,7 +2716,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 					} catch (Exception e) {
 						// TODO:  Issue error reagarding not being able to load the project file (.cdtbuild)
 					}
-
+		
 					try {
 						// Check if the project needs its container initialized
 						initBuildInfoContainer(buildInfo);
@@ -2798,7 +2798,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 	 */
 	/*	synchronized private static ManagedBuildInfo findBuildInfoSynchronized(IProject project, boolean forceLoad) {
 			ManagedBuildInfo buildInfo = null;
-
+	
 			// Check if there is any build info associated with this project for this session
 			try {
 				buildInfo = (ManagedBuildInfo)project.getSessionProperty(buildInfoProperty);
@@ -2809,7 +2809,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 			} catch (CoreException e) {
 		//		return null;
 			}
-
+	
 			if(buildInfo == null && forceLoad){
 				// Make sure the extension information is loaded first
 				try {
@@ -2818,11 +2818,11 @@ public class ManagedBuildManager extends AbstractCExtension {
 					e.printStackTrace();
 					return null;
 				}
-
-
+	
+	
 				// Check weather getBuildInfo is called from converter
 				buildInfo = UpdateManagedProjectManager.getConvertedManagedBuildInfo(project);
-
+	
 				// Nothing in session store, so see if we can load it from cdtbuild
 				if (buildInfo == null) {
 					try {
@@ -2839,7 +2839,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 							IWorkbenchWindow windows[] = PlatformUI.getWorkbench().getWorkbenchWindows();
 							window = windows[0];
 						}
-
+	
 						final Shell shell = window.getShell();
 						final String exceptionMsg = e.getMessage();
 						//using syncExec could cause a dead-lock
@@ -2853,7 +2853,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 							}
 						} );
 					}
-
+	
 					if (buildInfo != null && !buildInfo.isContainerInited()) {
 						//  NOTE:  If this is called inside the above rule, then an IllegalArgumentException can
 						//         occur when the CDT project file is saved - it uses the Workspace Root as the scheduling rule.
@@ -2867,7 +2867,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 					}
 				}
 			}
-
+	
 			return buildInfo;
 		}
 	*/
@@ -3648,6 +3648,54 @@ public class ManagedBuildManager extends AbstractCExtension {
 			return cfg;
 		}
 		return null;
+	}
+
+	/**
+	 * Creates a new <code>IConfiguration</code> object associated to the specified
+	 * managed project and adds it to the corresponding project description.<br>
+	 * This purpose of this method is to set up build configurations for MBS
+	 * projects that are in the phase of being created programmatically.
+	 *
+	 * @param projectDescription the <code>ICProjectDescription</code> to use for
+	 *                           creating the new configuration
+	 * @param managedProject     the managed project to associate the new
+	 *                           <code>IConfiguration</code> with
+	 * @param cloneConfiguration the <code>IConfiguration</code> to copy the
+	 *                           settings from
+	 * @param buildSystemId      buildSystemId build system id, i.e. the extension
+	 *                           id contributing to the
+	 *                           org.eclipse.cdt.core.CConfigurationDataProvider
+	 *                           extension point
+	 *
+	 * @return the newly created <code>IConfiguration</code> object
+	 *
+	 * @throws CoreException            if the creation of a new
+	 *                                  ICConfigurationDescription failed
+	 * @throws IllegalArgumentException if the <code>IProject</code> associated with
+	 *                                  the specified
+	 *                                  <code>ICProjectDescription</code> does not
+	 *                                  match the project associated with the given
+	 *                                  <code>IManagedProject</code>
+	 * @since 9.5
+	 */
+	public static IConfiguration createConfigurationForProject(ICProjectDescription projectDescription,
+			IManagedProject managedProject, IConfiguration cloneConfiguration, String buildSystemId)
+			throws CoreException {
+		// sanity checks..
+		if (projectDescription.getProject() != managedProject.getOwner()) {
+			String msg = String.format(
+					"IProject associated with 'projectDescription' (%s) does not match the one associated with 'managedProject' (%s)", //$NON-NLS-1$
+					projectDescription.getProject(), managedProject.getOwner());
+			throw new IllegalArgumentException(msg);
+		}
+		String id = calculateChildId(cloneConfiguration.getId(), null);
+		Configuration config = new Configuration((ManagedProject) managedProject, (Configuration) cloneConfiguration,
+				id, false, true);
+		config.exportArtifactInfo();
+		CConfigurationData data = config.getConfigurationData();
+		ICConfigurationDescription cfgDes = projectDescription.createConfiguration(buildSystemId, data);
+		config.setConfigurationDescription(cfgDes);
+		return config;
 	}
 
 	/**

--- a/build/org.eclipse.cdt.managedbuilder.ui/src/org/eclipse/cdt/managedbuilder/ui/wizards/MBSWizardHandler.java
+++ b/build/org.eclipse.cdt.managedbuilder.ui/src/org/eclipse/cdt/managedbuilder/ui/wizards/MBSWizardHandler.java
@@ -618,7 +618,6 @@ public class MBSWizardHandler extends CWizardHandler {
 			cf = (Configuration) cfg.getConfiguration();
 			IConfiguration config = ManagedBuildManager.createConfigurationForProject(des, mProj, cf,
 					ManagedBuildManager.CFG_DATA_PROVIDER_ID);
-			// TODO check 			config.exportArtifactInfo();
 			IBuilder bld = config.getEditableBuilder();
 			if (bld != null) {
 				bld.setManagedBuildOn(true);


### PR DESCRIPTION
This should allow ISV's to create MBS based project with a vendor-specific build-system ID without using internal API.

Signed-off-by: 15knots <11367029+15knots@users.noreply.github.com>