### PR TITLE
Handle all errors and runtime exceptions that may be thrown

### DIFF
--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/pdom/FailedToReAcquireLockException.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/pdom/FailedToReAcquireLockException.java
@@ -16,27 +16,26 @@ import org.eclipse.core.runtime.OperationCanceledException;
 /**
  * This exception is raised when {@link YieldableIndexLock#yield()} fails to
  * reacquire the lock after yielding, this may be due to an {@link InterruptedException}
- * or an {@link OperationCanceledException} which will be the nested exception.
+ * or an {@link OperationCanceledException} or some other type of runtime exception or
+ * error (especially assertion errors) which will be the nested exception.
  */
 public class FailedToReAcquireLockException extends Exception {
 
-	public FailedToReAcquireLockException(InterruptedException e) {
-		super(e);
-		Assert.isNotNull(e);
+	public FailedToReAcquireLockException(Throwable t) {
+		super(t);
+		Assert.isNotNull(t);
 	}
 
-	public FailedToReAcquireLockException(OperationCanceledException e) {
-		super(e);
-		Assert.isNotNull(e);
-	}
-
-	public void reThrow() throws InterruptedException, OperationCanceledException {
+	public void reThrow() throws InterruptedException {
 		if (getCause() instanceof InterruptedException ie) {
 			throw ie;
 		}
-		if (getCause() instanceof OperationCanceledException oce) {
-			throw oce;
+		if (getCause() instanceof RuntimeException re) {
+			throw re;
 		}
-		throw new RuntimeException("Unexpectedly the exception cause was none of the allowed types", this); //$NON-NLS-1$
+		if (getCause() instanceof Error er) {
+			throw er;
+		}
+		throw new RuntimeException("Checked exception changed wrapped in runtime exception", getCause()); //$NON-NLS-1$
 	}
 }

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/pdom/YieldableIndexLock.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/pdom/YieldableIndexLock.java
@@ -15,7 +15,6 @@ package org.eclipse.cdt.internal.core.pdom;
 
 import org.eclipse.cdt.internal.core.index.IWritableIndex;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.OperationCanceledException;
 
 /**
  * Write lock on the index that can be yielded temporarily to unblock threads that need
@@ -67,10 +66,8 @@ public class YieldableIndexLock {
 			lastLockTime = 0;
 			try {
 				acquire();
-			} catch (OperationCanceledException e) {
-				throw new FailedToReAcquireLockException(e);
-			} catch (InterruptedException e) {
-				throw new FailedToReAcquireLockException(e);
+			} catch (Throwable t) {
+				throw new FailedToReAcquireLockException(t);
 			}
 		}
 	}


### PR DESCRIPTION
We can fail to regain our lock in other cases than just operation cancelled exception, so capture all of those cases to throw an FailedToReAcquireLockException.

Also, fix another finally block that assumes it has the lock.

Fixes #128

---

I am going to run this change a bunch of times on GHA to see what happens. I may need to deal with the new *Exception hit in finally block* log message as the tests fail on unexpected log messages.