### PR TITLE
Increase timeout waiting for stopped event in test

### DIFF
--- a/dsf-gdb/org.eclipse.cdt.tests.dsf.gdb/src/org/eclipse/cdt/tests/dsf/gdb/tests/nonstop/GDBMultiNonStopRunControlTest.java
+++ b/dsf-gdb/org.eclipse.cdt.tests.dsf.gdb/src/org/eclipse/cdt/tests/dsf/gdb/tests/nonstop/GDBMultiNonStopRunControlTest.java
@@ -3234,8 +3234,8 @@ public class GDBMultiNonStopRunControlTest extends BaseParametrizedTestCase {
 			}
 		});
 
-		eventWaitor.waitForEvent(TestsPlugin.massageTimeout(100)); // confirm one thread was suspended
-		eventWaitor.waitForEvent(TestsPlugin.massageTimeout(100)); // confirm the other thread was suspended
+		eventWaitor.waitForEvent(TestsPlugin.massageTimeout(1000)); // confirm one thread was suspended
+		eventWaitor.waitForEvent(TestsPlugin.massageTimeout(1000)); // confirm the other thread was suspended
 
 		// Also confirm that all processes are suspended
 		Boolean result = runAsyncCall(new AsyncRunnable<Boolean>() {


### PR DESCRIPTION
Fixes #119

I have not seen #119 fail on GitHub. The issues on GitHub seems related to the machines being too fast, and the issues on Jenkins seem related to the machines being too slow. So once GHA confirms I haven't messed anything up I will merge and monitor builds on Jenkins.