### PR TITLE
Correct typographical error in remote console translation

### DIFF
--- a/remote/org.eclipse.remote.console/src/org/eclipse/remote/internal/console/ConsoleMessages.java
+++ b/remote/org.eclipse.remote.console/src/org/eclipse/remote/internal/console/ConsoleMessages.java
@@ -31,7 +31,7 @@ public class ConsoleMessages extends NLS {
 	public static String STATUS_CLOSED;
 
 	public static String CONNECTING_TO_TERMINAL;
-	public static String OPENNING_TERMINAL;
+	public static String OPENING_TERMINAL;
 	public static String MAKING_CONNECTION;
 	public static String DISCONNECTING;
 	public static String TerminalConsoleConnector_0;

--- a/remote/org.eclipse.remote.console/src/org/eclipse/remote/internal/console/ConsoleMessages.properties
+++ b/remote/org.eclipse.remote.console/src/org/eclipse/remote/internal/console/ConsoleMessages.properties
@@ -22,7 +22,7 @@ STATUS_CONNECTING      = CONNECTING...
 STATUS_CLOSED          = CLOSED
 
 CONNECTING_TO_TERMINAL = Connecting to Command Shell
-OPENNING_TERMINAL      = Openning Command Shell
+OPENING_TERMINAL       = Opening Command Shell
 MAKING_CONNECTION      = Making Connection
 DISCONNECTING          = Disconnecting
 TerminalConsoleConnector_0=Command shell not supported on this connection

--- a/remote/org.eclipse.remote.console/src/org/eclipse/remote/internal/console/TerminalConsoleFactory.java
+++ b/remote/org.eclipse.remote.console/src/org/eclipse/remote/internal/console/TerminalConsoleFactory.java
@@ -42,7 +42,7 @@ public class TerminalConsoleFactory implements IConsoleFactory {
 	}
 
 	public static void openConsole(final IRemoteConnection connection, final String encoding) {
-		Job j = new Job(ConsoleMessages.OPENNING_TERMINAL) {
+		Job j = new Job(ConsoleMessages.OPENING_TERMINAL) {
 			@Override
 			public IStatus run(IProgressMonitor monitor) {
 				return openConsoleImplementation(connection, encoding, monitor);


### PR DESCRIPTION
Openning -> Opening