### PR TITLE
Resolve deadlock in Jobmanager related code

### DIFF
--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/pdom/PDOMManager.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/pdom/PDOMManager.java
@@ -709,8 +709,8 @@ public class PDOMManager implements IWritableIndexManager, IListener {
 				}
 			}
 			fTaskQueue.addLast(subjob);
-			fIndexerJob.schedule();
 		}
+		fIndexerJob.schedule();
 	}
 
 	IPDOMIndexerTask getNextTask() {
@@ -734,14 +734,16 @@ public class PDOMManager implements IWritableIndexManager, IListener {
 	}
 
 	void indexerJobCanceled(boolean byManager) {
+		boolean scheduleJob;
 		synchronized (fTaskQueue) {
 			fCurrentTask = null;
 			if (!byManager) {
 				fTaskQueue.clear();
 			}
-			if (!fTaskQueue.isEmpty()) {
-				fIndexerJob.schedule();
-			}
+			scheduleJob = !fTaskQueue.isEmpty();
+		}
+		if (scheduleJob) {
+			fIndexerJob.schedule();
 		}
 	}
 


### PR DESCRIPTION
Because of [changes](https://www.eclipse.org/eclipse/news/4.26/platform_isv.php#JobManager_Implementation) in Eclipse Platform where the jobmanager's behaviour changes (within the API), the consumers of the jobmanager can deadlock due to incorrect assumptions.

In particular, where we call job.schedule(), the callback can happen in different threads to the IJobChangeListener's. As CDT was holding a lock while calling schedule that is also required in those listeners, we need to no longer lock when calling schedule.

As the code already dealt with the case of when there was a delay between the job.schedule() and where & when it was run, we can move the schedule call out of the synchronized block.

Fixes #81