### PR TITLE
Fixing @since and cosmetics

### DIFF
--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/CBuildConfiguration.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/CBuildConfiguration.java
@@ -106,7 +106,7 @@ public abstract class CBuildConfiguration extends PlatformObject implements ICBu
 
 	private static final List<String> DEFAULT_COMMAND = new ArrayList<>(0);
 
-	private final Map<IResource, IToolChain> tcMap = new HashMap<IResource, IToolChain>();
+	private final Map<IResource, IToolChain> tcMap = new HashMap<>();
 
 	private final String name;
 	private final IBuildConfiguration config;

--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/CBuildConfiguration.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/CBuildConfiguration.java
@@ -316,6 +316,7 @@ public abstract class CBuildConfiguration extends PlatformObject implements ICBu
 	 * Get the toolchain based on the compiler found in the command line.
 	 * Sub-classes can override this method to set their own method for
 	 * getting the toolchain.
+	 * @since 8.0
 	 *
 	 */
 	protected IToolChain getToolChain(List<String> command) throws CoreException {


### PR DESCRIPTION
This change adds the missing `@since` in new code added in #157

Part of #77