### PR TITLE
Use mi-async instead of target-async on GDB >= 7.12

### DIFF
--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/launching/FinalLaunchSequence_7_12.java
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/launching/FinalLaunchSequence_7_12.java
@@ -115,7 +115,7 @@ public class FinalLaunchSequence_7_12 extends FinalLaunchSequence_7_7 {
 			asyncOn = true;
 		}
 
-		fCommandControl.queueCommand(fCommandFactory.createMIGDBSetTargetAsync(fCommandControl.getContext(), asyncOn),
+		fCommandControl.queueCommand(fCommandFactory.createMIGDBSetMIAsync(fCommandControl.getContext(), asyncOn),
 				new DataRequestMonitor<MIInfo>(getExecutor(), requestMonitor) {
 					@Override
 					protected void handleError() {

--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/mi/service/command/CommandFactory.java
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/mi/service/command/CommandFactory.java
@@ -135,6 +135,7 @@ import org.eclipse.cdt.dsf.mi.service.command.commands.MIGDBSetDisconnectedTraci
 import org.eclipse.cdt.dsf.mi.service.command.commands.MIGDBSetEnv;
 import org.eclipse.cdt.dsf.mi.service.command.commands.MIGDBSetHostCharset;
 import org.eclipse.cdt.dsf.mi.service.command.commands.MIGDBSetLanguage;
+import org.eclipse.cdt.dsf.mi.service.command.commands.MIGDBSetMIAsync;
 import org.eclipse.cdt.dsf.mi.service.command.commands.MIGDBSetNewConsole;
 import org.eclipse.cdt.dsf.mi.service.command.commands.MIGDBSetNonStop;
 import org.eclipse.cdt.dsf.mi.service.command.commands.MIGDBSetPagination;
@@ -893,6 +894,11 @@ public class CommandFactory {
 
 	public ICommand<MIInfo> createMIGDBSetTargetAsync(ICommandControlDMContext ctx, boolean isSet) {
 		return new MIGDBSetTargetAsync(ctx, isSet);
+	}
+
+	/** @since 7.0 */
+	public ICommand<MIInfo> createMIGDBSetMIAsync(ICommandControlDMContext ctx, boolean isSet) {
+		return new MIGDBSetMIAsync(ctx, isSet);
 	}
 
 	/** @since 4.4 */

--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/mi/service/command/commands/MIGDBSetMIAsync.java
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/mi/service/command/commands/MIGDBSetMIAsync.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2022 Ericsson and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Ericsson - Initial API and implementation
+ *******************************************************************************/
+package org.eclipse.cdt.dsf.mi.service.command.commands;
+
+import org.eclipse.cdt.dsf.debug.service.command.ICommandControlService.ICommandControlDMContext;
+
+/**
+ *
+ * -gdb-set mi-async [on | off]
+ *
+ * @since 7.0
+ */
+public class MIGDBSetMIAsync extends MIGDBSet {
+	public MIGDBSetMIAsync(ICommandControlDMContext ctx, boolean isSet) {
+		super(ctx, new String[] { "mi-async", isSet ? "on" : "off" });//$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+	}
+}

--- a/jtag/org.eclipse.cdt.debug.gdbjtag.core/src/org/eclipse/cdt/debug/gdbjtag/core/GDBJtagDSFFinalLaunchSequence_7_12.java
+++ b/jtag/org.eclipse.cdt.debug.gdbjtag.core/src/org/eclipse/cdt/debug/gdbjtag/core/GDBJtagDSFFinalLaunchSequence_7_12.java
@@ -65,7 +65,7 @@ public class GDBJtagDSFFinalLaunchSequence_7_12 extends GDBJtagDSFFinalLaunchSeq
 			// Use target async when interfacing with the full GDB console (i.e. minimum GDB version 7.12)
 			// otherwise explicitly set it to off.
 			commandControl.queueCommand(commandControl.getCommandFactory()
-					.createMIGDBSetTargetAsync(commandControl.getContext(), gdbBackEnd.useTargetAsync()),
+					.createMIGDBSetMIAsync(commandControl.getContext(), gdbBackEnd.useTargetAsync()),
 					new DataRequestMonitor<MIInfo>(getExecutor(), rm) {
 						@Override
 						protected void handleError() {


### PR DESCRIPTION
target-async is the old name for mi-async. mi-async came into existence in GDB 7.8, but in later releases it becomes a warning to use the old name.

Because we already have the version infra for 7.12 we change to using mi-async from 7.12

A similar change was made for [cdt-gdb-adapter a while ago](https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/blob/main/src/GDBBackend.ts#L114-L116)

Fixes #176

