### PR TITLE
C and C++ should not be labelled as GNU dialects

### DIFF
--- a/NewAndNoteworthy/CDT-11.0.md
+++ b/NewAndNoteworthy/CDT-11.0.md
@@ -34,6 +34,10 @@ Please see the corresponding issue for more details.
   - `org.eclipse.cdt.lsp.cquery`
   - `org.eclipse.cdt.lsp.ui`
 
+## GNU removed from display name language for C/C++
+
+C and C++ have been renamed from "GNU C" and "GNU C++" to just "C" and "C++". If you have exported settings with CDT prior to CDT 10.5 they may not import successfully with CDT 11. See #178
+
 # Build
 
 ## Scanner Discovery able to consider all flags

--- a/NewAndNoteworthy/CDT-11.0.md
+++ b/NewAndNoteworthy/CDT-11.0.md
@@ -36,7 +36,8 @@ Please see the corresponding issue for more details.
 
 ## GNU removed from display name language for C/C++
 
-C and C++ have been renamed from "GNU C" and "GNU C++" to just "C" and "C++". If you have exported settings with CDT prior to CDT 10.5 they may not import successfully with CDT 11. See #178
+C and C++ have been renamed from "GNU C" and "GNU C++" to just "C" and "C++". If you have exported settings with CDT prior to CDT 10.5 they may not import
+successfully with CDT 11. See #178
 
 # Build
 

--- a/core/org.eclipse.cdt.core/plugin.properties
+++ b/core/org.eclipse.cdt.core/plugin.properties
@@ -110,8 +110,8 @@ PDOMProviderName=PDOM Provider
 fastIndexer.name=Fast Indexer
 
 # Built-in languages
-language.name.gcc= GNU C
-language.name.gpp= GNU C++
+language.name.gcc= C
+language.name.gpp= C++
 language.name.asm= Assembly
 
 CConfigurationDataProvider.name = CConfigurationData provider

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/wizards/settingswizards/SettingsImportExportTest.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/wizards/settingswizards/SettingsImportExportTest.java
@@ -246,7 +246,7 @@ public class SettingsImportExportTest extends BaseUITestCase {
 	// {badXML6}
 	// <cdtprojectproperties>
 	// <section name="org.eclipse.cdt.internal.ui.wizards.settingswizards.Macros">
-	// <language name="GNU C++">
+	// <language name="C++">
 	// <macro>
 	// <name>aaaa</name>
 	// </macro>
@@ -257,7 +257,7 @@ public class SettingsImportExportTest extends BaseUITestCase {
 	// {badXML7}
 	// <cdtprojectproperties>
 	// <section name="org.eclipse.cdt.internal.ui.wizards.settingswizards.Macros">
-	// <language name="GNU C++">
+	// <language name="C++">
 	// <macro>
 	// <name>aaaa</name><value></value><value></value>
 	// </macro>
@@ -268,7 +268,7 @@ public class SettingsImportExportTest extends BaseUITestCase {
 	// {badXML8}
 	// <cdtprojectproperties>
 	// <section name="org.eclipse.cdt.internal.ui.wizards.settingswizards.IncludePaths">
-	// <language name="GNU C++">
+	// <language name="C++">
 	// <includepath>C:\WINDOWS</includepath><invalid></invalid>
 	// </language>
 	// </section>


### PR DESCRIPTION
C and C++ are currently labelled as "GNU C" and "GNU C++" in the explorer when choosing what options to set for any specified language (For example, in the Preprocessor Include Paths, Macros etc screen). Not only is this confusing since it implies that Eclipse by default uses the GNU dialects of the languages (which is not true), this is also flat out wrong in other cases, such as when Workspaces configured with the Microsoft Visual C++ compiler (one that couldn't possibly be more incompatible with the actual GNU dialect) are _also_ labelled as "GNU C". This was likely due to Eclipse only really supporting gcc when it started out, but this is no longer the case with the IDE becoming more and more flexible over the years, and it's probably time to ditch the GNU labels in the hardcoded language names.