### PR TITLE
Bug: Docker: Save correct docker image name

### DIFF
--- a/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/ContainerPropertyTab.java
+++ b/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/ContainerPropertyTab.java
@@ -310,7 +310,7 @@ public class ContainerPropertyTab extends AbstractCBuildPropertyTab
 					final String nimg = currentText.substring(0, e.start) + e.text + currentText.substring(e.end);
 					var t = displayedImages.stream().filter(x -> x.repoTags().contains(nimg)).findAny().orElse(null);
 					// Set to 0 if it does not exist
-					setImageId(imageCombo.getText());
+					setImageId(nimg);
 					model.setSelectedImage(t);
 				}
 			});


### PR DESCRIPTION
When the docker image was not locally available the name of the image was not correctly saved.

@jonahgraham @jjohnstn : I fixed this one before, but somehow it got lost during rebasing. Sorry for not testing it earlier.
