### PR TITLE
Migrate run-dash-licenses from cdt-infra to main CDT repo

### DIFF
--- a/releng/run-dash-licenses.Jenkinsfile
+++ b/releng/run-dash-licenses.Jenkinsfile
@@ -1,0 +1,32 @@
+pipeline {
+  agent {
+    kubernetes {
+      yamlFile 'jenkins/pod-templates/cdt-full-pod-plus-eclipse-install.yaml'
+    }
+  }
+  options {
+    timestamps()
+    disableConcurrentBuilds()
+  }
+  stages {
+    stage('Run Dash Licenses Check') {
+      steps {
+        container('cdt') {
+          timeout(activity: true, time: 20) {
+            withEnv(['MAVEN_OPTS=-XX:MaxRAMPercentage=60.0']) {
+              sh 'MVN="/usr/share/maven/bin/mvn -Dmaven.repo.local=/home/jenkins/.m2/repository \
+                        --settings /home/jenkins/.m2/settings.xml" ./releng/scripts/run_dash_licenses.sh'
+            }
+          }
+        }
+      }
+    }
+  }
+  post {
+    always {
+      container('cdt') {
+        archiveArtifacts allowEmptyArchive: true, artifacts: '*.log'
+      }
+    }
+  }
+}


### PR DESCRIPTION
This needs the update to https://ci.eclipse.org/cdt/view/all/job/cdt-master-run-dash-licenses/ (which will be renamed to https://ci.eclipse.org/cdt/view/all/job/cdt-main-run-dash-licenses/)