### PR TITLE
ignore top directory editor temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ check_code_cleanliness_workspace/
 *.log
 .tycho-consumer-pom.xml
 /eclipse/
+/*~


### PR DESCRIPTION
This was an unrelated, but useful change that I pulled out of #188