### PR TITLE
Bug 552070 - Build not configured correctly error while building a pr…

### DIFF
--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/CBuildConfiguration.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/CBuildConfiguration.java
@@ -59,6 +59,7 @@ import org.eclipse.cdt.core.parser.IScannerInfoChangeListener;
 import org.eclipse.cdt.core.resources.IConsole;
 import org.eclipse.cdt.internal.core.BuildRunnerHelper;
 import org.eclipse.cdt.internal.core.ConsoleOutputSniffer;
+import org.eclipse.cdt.internal.core.build.CBuildConfigurationManager;
 import org.eclipse.cdt.internal.core.build.Messages;
 import org.eclipse.cdt.internal.core.model.BinaryRunner;
 import org.eclipse.cdt.internal.core.model.CModelManager;
@@ -94,6 +95,19 @@ import com.google.gson.GsonBuilder;
 /**
  * Root class for CDT build configurations. Provides access to the build
  * settings for subclasses.
+ *
+ * Each Eclipse project has one or more build configurations ({@link IBuildConfiguration}).
+ * A CDT Core Build project pairs each build configuration with a Core Build configuration
+ * ({@link ICBuildConfiguration}). A Core Build configuration has variable config pointing to
+ * the IBuildConfiguration. The link from IBuildConfiguration to ICBuildConfiguration
+ * goes via getAdapter(ICBuildConfiguration.class) which gets the ICBuildConfiguration
+ * from Map configs in the {@link CBuildConfigurationManager}.
+ *
+ * In a new project the initial Core Build configurations creation is triggered by the
+ * {@link CoreBuildLaunchBarTracker}. The initial configuration for Debug will only be
+ * created if the user selects the Debug launch mode. Restoration of Core Build configurations,
+ * after an Eclipse restart or close and open of the project, uses the settings which are
+ * persistently stored in the backing store. @see org.osgi.service.prefs.Preferences
  *
  * @since 6.0
  */

--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/internal/core/build/CBuildConfigurationManager.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/internal/core/build/CBuildConfigurationManager.java
@@ -367,7 +367,12 @@ public class CBuildConfigurationManager
 					Preferences projectNode = parentNode.node(project.getName());
 					if (projectNode != null) {
 						try {
-							projectNode.removeNode();
+							if (event.getType() == IResourceChangeEvent.PRE_DELETE) {
+								// We need to keep the settings when the project is closed. They are used by
+								// CBuildConfiguration.CBuildConfiguration(IBuildConfiguration config, String name)
+								// to restore Debug core build configurations when the project is reopened.
+								projectNode.removeNode();
+							}
 							parentNode.flush();
 						} catch (BackingStoreException e) {
 							CCorePlugin.log(e);


### PR DESCRIPTION
…oject

https://bugs.eclipse.org/bugs/show_bug.cgi?id=552070

After closing and opening a CMake or Makefile Core Buil project, the project could not be built for Debug anymore. Error: "Build not configured correctly".

The CBuildConfigurationManager calls
provider.getCBuildConfiguration(buildConfig, configName), which starts a recreation of the ICBuild and IBuild configurations. For the Debug configurations this led to a call to
CBuildConfiguration(IBuildConfiguration config, String name), which always fails with a CoreException. The CBuildConfigurationManager silently catched the exception and put the IBuildConfiguration for debug in the noConfigs list.

With this change the CBuildConfigurationProviders will for both Run and Debug find a toolchain and create build configurations for the correct launch mode (run or debug).