### PR TITLE
Add basic support for c++20 three-way comparison operator

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPAttributeTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPAttributeTests.java
@@ -515,13 +515,13 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 
 	//	struct S __attribute__((__packed__)) {};
 	public void testGCCAttributedStruct() throws Exception {
-		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, true);
+		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTCompositeTypeSpecifier.class);
 	}
 
 	//	int a __attribute__ ((aligned ((64))));
 	public void testGCCAttributedVariableDeclarator_bug391572() throws Exception {
-		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, true);
+		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTDeclarator.class);
 	}
 
@@ -529,7 +529,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	  void foo() override __attribute__((attr));
 	//	};
 	public void testGCCAttributeAfterOverride_bug413615() throws Exception {
-		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, true);
+		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTFunctionDeclarator.class);
 	}
 
@@ -537,33 +537,33 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//		value1 [[attr1]], value2 [[attr2]] = 1
 	//	};
 	public void testAttributedEnumerator_Bug535269() throws Exception {
-		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, true);
+		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTEnumerator.class, IASTEnumerator.class);
 	}
 
 	//void f([[attr1]] int [[attr2]] p) {
 	//}
 	public void testAttributedFunctionParameter_Bug535275() throws Exception {
-		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, true);
+		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTParameterDeclaration.class,
 				ICPPASTSimpleDeclSpecifier.class);
 	}
 
 	//namespace [[attr]] NS {}
 	public void testAttributedNamedNamespace_Bug535274() throws Exception {
-		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, true);
+		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTNamespaceDefinition.class);
 	}
 
 	//namespace [[attr]] {}
 	public void testAttributedUnnamedNamespace_Bug535274() throws Exception {
-		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, true);
+		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTNamespaceDefinition.class);
 	}
 
 	//namespace NS __attribute__((__visibility__("default"))) {}
 	public void testGnuAndCppMixedAttributedNamedNamespace_Bug535274() throws Exception {
-		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, true);
+		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTNamespaceDefinition.class);
 	}
 }

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
@@ -416,9 +416,9 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	public void testBug95424() throws Exception {
-		IASTTranslationUnit tu = parse("void f(){ traits_type::copy(__r->_M_refdata(), __buf, __i); }", CPP, true,
-				true);
-		tu = parse("void f(){ traits_type::copy(__r->_M_refdata(), __buf, __i); }", CPP, false, true);
+		IASTTranslationUnit tu = parse("void f(){ traits_type::copy(__r->_M_refdata(), __buf, __i); }", CPP,
+				ScannerKind.GNU, true);
+		tu = parse("void f(){ traits_type::copy(__r->_M_refdata(), __buf, __i); }", CPP, ScannerKind.STD, true);
 		IASTFunctionDefinition f = (IASTFunctionDefinition) tu.getDeclarations()[0];
 		IASTCompoundStatement cs = (IASTCompoundStatement) f.getBody();
 		IASTExpressionStatement es = (IASTExpressionStatement) cs.getStatements()[0];
@@ -1932,7 +1932,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    AB::f(`c`);
 	// }
 	public void testBug84679() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, false, false);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.STD, false);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -3666,7 +3666,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	public void testBug87424() throws Exception {
-		IASTTranslationUnit tu = parse("int * __restrict x;", CPP, true);
+		IASTTranslationUnit tu = parse("int * __restrict x;", CPP, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -3675,7 +3675,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertTrue(t instanceof IPointerType);
 		assertTrue(((IPointerType) t).isRestrict());
 
-		tu = parse("class A {}; int A::* __restrict x;", CPP, true);
+		tu = parse("class A {}; int A::* __restrict x;", CPP, ScannerKind.GNU);
 		col = new NameCollector();
 		tu.accept(col);
 
@@ -3686,7 +3686,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	public void testBug87705() throws Exception {
-		IASTTranslationUnit tu = parse("class A { friend class B::C; };", CPP, true);
+		IASTTranslationUnit tu = parse("class A { friend class B::C; };", CPP, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -4439,7 +4439,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	public void testBug92980() throws Exception {
 		String code = "struct A { A(); A(const A&) throw(1); ~A() throw(X); };";
-		parse(code, CPP, true, false);
+		parse(code, CPP, ScannerKind.GNU, false);
 	}
 
 	// class Dummy { int v(); int d; };
@@ -4940,7 +4940,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// float _Complex x;
 	// double _Complex y;
 	public void testBug95757() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		IASTDeclaration[] decls = tu.getDeclarations();
 
 		assertTrue(((IASTSimpleDeclSpecifier) ((IASTSimpleDeclaration) decls[0]).getDeclSpecifier()).isComplex());
@@ -4997,7 +4997,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	public void testBug96678() throws Exception {
-		parse("int x; // comment \r\n", CPP, false, true);
+		parse("int x; // comment \r\n", CPP, ScannerKind.STD, true);
 	}
 
 	// struct A {};
@@ -5233,7 +5233,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	public void testBug99262() throws Exception {
-		parse("void foo() {void *f; f=__null;}", CPP, true, true);
+		parse("void foo() {void *f; f=__null;}", CPP, ScannerKind.GNU, true);
 	}
 
 	// void f1(int*) {
@@ -5278,7 +5278,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    }
 	// }
 	public void testBug84478b() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -5302,7 +5302,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    free(p);
 	// }
 	public void testBug100415() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -5322,7 +5322,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    };
 	// }
 	public void testBug86688() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -5337,7 +5337,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// };
 	// int m::f(){}
 	public void testBug100403() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -5356,7 +5356,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    friend void A::f2(BT);
 	// };
 	public void testBug90609() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -5379,7 +5379,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    }
 	// }
 	public void testBug103281() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -5403,7 +5403,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    i;
 	// }
 	public void test10_2s3b() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -5476,7 +5476,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// return 0;
 	// }
 	public void testBug108202() throws Exception {
-		parse(getAboveComment(), CPP, true, true);
+		parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 	}
 
 	// // Test redundant class specifiers
@@ -5486,7 +5486,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// };
 	// int MyClass::static_field;
 	public void testBug174791() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
 		// check class
 		IASTSimpleDeclaration sd = (IASTSimpleDeclaration) tu.getDeclarations()[0];
@@ -5524,7 +5524,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void nsSplit::a() {
 	// }
 	public void testBug180979() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
 		// check class
 		IASTFunctionDefinition fd = (IASTFunctionDefinition) tu.getDeclarations()[2];
@@ -5540,7 +5540,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// _GLIBCXX_BEGIN_NAMESPACE(std)
 	// } // end the namespace
 	public void testBug195701() throws Exception {
-		parse(getAboveComment(), CPP, true, true);
+		parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 	}
 
 	// class A {
@@ -5551,14 +5551,14 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    using A::operator*;
 	// };
 	public void testBug178059() throws Exception {
-		parse(getAboveComment(), CPP, true, true);
+		parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 	}
 
 	// void foo (void *p) throw () ;
 	// void bar (void *p) __attribute__ ((__nonnull__(1)));
 	// void zot (void *p) throw () __attribute__ ((__nonnull__(1)));
 	public void testBug179712() throws Exception {
-		parse(getAboveComment(), CPP, true, true);
+		parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 	}
 
 	//	class C {
@@ -5621,7 +5621,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	outer::foo x;
 	//	outer::inner::foo y;
 	public void testAttributeInUsingDirective_351228() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	namespace source {
@@ -5646,7 +5646,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		fs(1);
 	//	}
 	public void testReferencesOfUsingDecls() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
 		IASTDeclaration[] decls = tu.getDeclarations();
 		ICPPASTNamespaceDefinition nsdef = (ICPPASTNamespaceDefinition) decls[0];
@@ -5936,7 +5936,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// long       l(0L);
 	// long long  ll(0LL);
 	public void testInitializeUnsigned_245070() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	void foo/*_a*/(int x) {}
@@ -6111,7 +6111,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// }
 	public void testTrailingSyntaxErrorInNamespace() throws Exception {
 		final String comment = getAboveComment();
-		IASTTranslationUnit tu = parse(comment, CPP, false, false);
+		IASTTranslationUnit tu = parse(comment, CPP, ScannerKind.STD, false);
 		ICPPASTNamespaceDefinition ns = getDeclaration(tu, 0);
 		IASTDeclaration decl = getDeclaration(ns, 0);
 		IASTProblemDeclaration pdecl = getDeclaration(ns, 1);
@@ -6124,7 +6124,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// }
 	public void testTrailingSyntaxErrorInLinkageSpec() throws Exception {
 		final String comment = getAboveComment();
-		IASTTranslationUnit tu = parse(comment, CPP, false, false);
+		IASTTranslationUnit tu = parse(comment, CPP, ScannerKind.STD, false);
 		ICPPASTLinkageSpecification ls = getDeclaration(tu, 0);
 		IASTDeclaration decl = getDeclaration(ls, 0);
 		IASTProblemDeclaration pdecl = getDeclaration(ls, 1);
@@ -6359,8 +6359,8 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void restrict();
 	public void testRestrictIsNoCPPKeyword_228826() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, CPP, false);
-		parseAndCheckBindings(getAboveComment(), CPP, true); // even with gnu extensions
+		parseAndCheckBindings(code, CPP, ScannerKind.STD);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU); // even with gnu extensions
 	}
 
 	// void test1();
@@ -6598,7 +6598,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    }
 	public void testFunctionCallOnLHS_252695() throws Exception {
 		final String code = getAboveComment();
-		IASTTranslationUnit tu = parseAndCheckBindings(code, CPP, true);
+		IASTTranslationUnit tu = parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 		IASTFunctionDefinition fdef = getDeclaration(tu, 1);
 		IASTExpressionStatement exstmt = getStatement(fdef, 0);
 		assertInstance(exstmt.getExpression(), IASTBinaryExpression.class);
@@ -6614,7 +6614,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    template <int E> class B {};
 	public void testInvalidClassRedeclaration_254961() throws Exception {
 		final String code = getAboveComment();
-		IASTTranslationUnit tu = parse(code, CPP, true, false);
+		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.GNU, false);
 		NameCollector nc = new NameCollector();
 		tu.accept(nc);
 		assertProblemBindings(nc, 4);
@@ -6632,7 +6632,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    template <typename T> class B {};
 	public void testInvalidClassRedeclaration_364226() throws Exception {
 		final String code = getAboveComment();
-		IASTTranslationUnit tu = parse(code, CPP, true, false);
+		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.GNU, false);
 		NameCollector nc = new NameCollector();
 		tu.accept(nc);
 		assertProblemBindings(nc, 4);
@@ -9169,7 +9169,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	enum E; // illegal
 	public void testScopedEnums_305975c() throws Exception {
 		String code = getAboveComment();
-		IASTTranslationUnit tu = parse(code, CPP, true, false);
+		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.GNU, false);
 		IASTDeclaration[] decls = tu.getDeclarations();
 		assertEquals(3, decls.length);
 		assertInstance(decls[0], IASTProblemDeclaration.class);
@@ -10499,7 +10499,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		~T();
 	//	};
 	public void testErrorForDestructorWithWrongName_367590() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, false, false);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.STD, false);
 		IASTCompositeTypeSpecifier S;
 		IASTProblemDeclaration p;
 		IASTSimpleDeclaration s;
@@ -10874,7 +10874,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		static const bool value = __is_trivially_constructible(S, Args...);
 	//	};
 	public void testParsingOfGcc5TypeTraitIntrinsics_485713() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true /* use GNU extensions */);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
 	}
 
 	//	struct S1 {};
@@ -10940,7 +10940,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	const bool b = __is_base_of(S, int);
 	//	typedef A<b>::type T;
 	public void testIsBaseOf_395019() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	template<typename T, T v>
@@ -10978,7 +10978,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//
 	//	Waldo<A> c;
 	public void testIsBaseOf_446094() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//  struct Bool { Bool(bool); };
@@ -11117,7 +11117,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		return i ? "a" : "b";
 	//	}
 	public void testThrowExpressionInConditional_396663() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	struct A {};
@@ -11155,7 +11155,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	struct derived : base {};
 	//	typedef enable_if<__is_base_of(base, derived)>::type T;
 	public void testIsBaseOf_399353() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	struct base {};
@@ -11291,7 +11291,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		__sync_synchronize();
 	//	}
 	public void testGNUSyncBuiltins_389578() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	int main() {
@@ -11300,7 +11300,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		__sync_fetch_and_add(&p, p, 2);
 	//	}
 	public void testGNUSyncBuiltinsOnVoidPtr_533822() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	// __int128_t and __uint128_t are available but are not keywords.
@@ -11313,7 +11313,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  int __uint128_t;
 	//	}
 	public void testGCCIntBuiltins_444577() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	template <typename T>
@@ -11379,7 +11379,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  bar(2);
 	//	}
 	public void testUnderlyingType_540909() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true /* use GNU extensions */);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
 	}
 
 	//	enum class TestEnum : char {
@@ -11392,7 +11392,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  bar('a'); // Invalid arguments 'Candidates are: void bar(@120932903)'
 	//	}
 	public void testUnderlyingType_568625() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true /* use GNU extensions */);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
 	}
 
 	//	void ptrFunc(void*);
@@ -11404,7 +11404,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		ptrFunc(__builtin_return_address(4));
 	//	}
 	public void testGCCBuiltins_512932a() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	void ptrFunc(void*);
@@ -11532,7 +11532,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	//	void bar(void *a1, void *a2) __attribute__((nonnull(1, 2)));
 	public void testGCCAttributeSequence_416430() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		IASTDeclaration[] declarations = tu.getDeclarations();
 		assertEquals(1, declarations.length);
 		IASTDeclaration declaration = declarations[0];
@@ -11722,7 +11722,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	//	__attribute__((section(".example"))) alignas(4) static int waldo;
 	public void testAlignasAfterAttribute_538615() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true /* use GNU extensions */);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
 	}
 
 	// int operator "" _A(unsigned long long i) { return 1; }
@@ -12102,7 +12102,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// Ret operator "" _Y(const char* s, unsigned sz) { return Ret(); }
 	// auto test = "123"_X "123"_Y;
 	public void testUserDefinedLiteralBadConcatenation1() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, false);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, false);
 
 		IASTProblem[] problems = tu.getPreprocessorProblems();
 		assertEquals(1, problems.length);
@@ -12183,7 +12183,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// auto e5 = U"1" _X "2";
 	// auto d5 = U"1" _X;
 	public void testUserDefinedLiteralNoWhiteSpace2() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, false);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, false);
 		IASTDeclaration[] decls = tu.getDeclarations();
 
 		for (int i = 1; i < decls.length; i++) {
@@ -12648,7 +12648,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    el1,
 	//	};
 	public void testEnumeratorAttribute_514821() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true /* use GNU extensions */);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
 	}
 
 	//	void foo([[maybe_unused]] int a);
@@ -13655,7 +13655,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		Test<TemplateArgs<int, int>::Value>::true_val;
 	//	}
 	public void testIsSame() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	void function(int * a) { }

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
@@ -4181,6 +4181,18 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertEquals(col.getName(158).toString(), "operator >");
 	}
 
+	// struct C {
+	//    auto operator<=>(const C&);
+	// };
+	public void testThreeWayComparisonOperatorName() throws Exception {
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.STDCPP20);
+		NameCollector col = new NameCollector();
+		tu.accept(col);
+
+		assertEquals(col.size(), 4);
+		assertEquals(col.getName(1).toString(), "operator <=>");
+	}
+
 	// typedef int I;
 	// typedef int I;
 	// typedef I I;

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
@@ -4193,6 +4193,32 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertEquals(col.getName(1).toString(), "operator <=>");
 	}
 
+	// constexpr bool less(int x, int y) { return x <=> y < 0; }
+	// constexpr bool equals(int x, int y) { return x <=> y == 0; }
+	// constexpr bool greater(int x, int y) { return x <=> y > 0; }
+	//
+	// static constexpr auto less01 = less(0, 1);
+	// static constexpr auto less00 = less(0, 0);
+	// static constexpr auto less10 = less(1, 0);
+	// static constexpr auto equals01 = equals(0, 1);
+	// static constexpr auto equals11 = equals(1, 1);
+	// static constexpr auto equals10 = equals(1, 0);
+	// static constexpr auto greater01 = greater(0, 1);
+	// static constexpr auto greater00 = greater(0, 0);
+	// static constexpr auto greater10 = greater(1, 0);
+	public void testThreeWayComparisonSimpleCase() throws Exception {
+		BindingAssertionHelper helper = getAssertionHelper(CPP, ScannerKind.STDCPP20);
+		helper.assertVariableValue("less01", 1);
+		helper.assertVariableValue("less00", 0);
+		helper.assertVariableValue("less10", 0);
+		helper.assertVariableValue("equals01", 0);
+		helper.assertVariableValue("equals11", 1);
+		helper.assertVariableValue("equals10", 0);
+		helper.assertVariableValue("greater01", 0);
+		helper.assertVariableValue("greater00", 0);
+		helper.assertVariableValue("greater10", 1);
+	}
+
 	// typedef int I;
 	// typedef int I;
 	// typedef I I;

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2KnRTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2KnRTests.java
@@ -76,7 +76,7 @@ public class AST2KnRTests extends AST2TestBase {
 		buffer.append("int f(char x);\n"); //$NON-NLS-1$
 		buffer.append("int f(x) char x;\n"); //$NON-NLS-1$
 		buffer.append("{ return x == 0; }\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU);
 
 		IASTSimpleDeclaration f1 = (IASTSimpleDeclaration) tu.getDeclarations()[0];
 		IASTFunctionDefinition f2 = (IASTFunctionDefinition) tu.getDeclarations()[1];
@@ -118,7 +118,7 @@ public class AST2KnRTests extends AST2TestBase {
 		buffer.append("int f();\n"); //$NON-NLS-1$
 		buffer.append("int f(x) char x;\n"); //$NON-NLS-1$
 		buffer.append("{ return x == 0; }\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU);
 
 		IASTSimpleDeclaration f1 = (IASTSimpleDeclaration) tu.getDeclarations()[0];
 		IASTFunctionDefinition f2 = (IASTFunctionDefinition) tu.getDeclarations()[1];
@@ -154,7 +154,7 @@ public class AST2KnRTests extends AST2TestBase {
 		buffer.append("int const *f();\n"); //$NON-NLS-1$
 		buffer.append("int const *f(x) char x;\n"); //$NON-NLS-1$
 		buffer.append("{ return x == 0; }\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU);
 
 		IASTSimpleDeclaration f1 = (IASTSimpleDeclaration) tu.getDeclarations()[0];
 		IASTFunctionDefinition f2 = (IASTFunctionDefinition) tu.getDeclarations()[1];
@@ -181,7 +181,7 @@ public class AST2KnRTests extends AST2TestBase {
 		buffer.append("int x;\n"); //$NON-NLS-1$
 		buffer.append("int y;\n"); //$NON-NLS-1$
 		buffer.append("{ return x == 0; }\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU);
 
 		IASTFunctionDefinition isroot_def = (IASTFunctionDefinition) tu.getDeclarations()[0];
 
@@ -235,7 +235,7 @@ public class AST2KnRTests extends AST2TestBase {
 		buffer.append("int isroot (x) \n"); //$NON-NLS-1$
 		buffer.append("c x;\n"); //$NON-NLS-1$
 		buffer.append("{ return x == 0; }\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU);
 
 		IASTSimpleDeclaration c_decl = (IASTSimpleDeclaration) tu.getDeclarations()[0];
 		IASTSimpleDeclaration isroot_decl = (IASTSimpleDeclaration) tu.getDeclarations()[1];
@@ -291,7 +291,7 @@ public class AST2KnRTests extends AST2TestBase {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(x) char\n"); //$NON-NLS-1$
 		buffer.append("{ return x == 0; }\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true, false);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU, false);
 		IASTDeclaration[] decls = tu.getDeclarations();
 
 		assertTrue(CVisitor.getProblems(tu).length > 0);
@@ -302,7 +302,7 @@ public class AST2KnRTests extends AST2TestBase {
 		buffer.append("int i=0;\n"); //$NON-NLS-1$
 		buffer.append("int f(x) i++;\n"); //$NON-NLS-1$
 		buffer.append("{ return x == 0; }\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true, false);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU, false);
 
 		IASTSimpleDeclaration sd = getDeclaration(tu, 0);
 		assertTrue(CVisitor.getProblems(tu).length > 0);
@@ -312,7 +312,7 @@ public class AST2KnRTests extends AST2TestBase {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(x) char y;\n"); //$NON-NLS-1$
 		buffer.append("{ return x == 0; }\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true, false);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU, false);
 
 		IASTFunctionDefinition f = (IASTFunctionDefinition) tu.getDeclarations()[0];
 		assertTrue(f.getDeclarator() instanceof ICASTKnRFunctionDeclarator);
@@ -348,7 +348,7 @@ public class AST2KnRTests extends AST2TestBase {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(x,y,z) char x,y,z; int a;\n"); //$NON-NLS-1$
 		buffer.append("{ return x == 0; }\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true, false);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU, false);
 
 		IASTFunctionDefinition f = (IASTFunctionDefinition) tu.getDeclarations()[0];
 		assertTrue(f.getDeclarator() instanceof ICASTKnRFunctionDeclarator);
@@ -409,7 +409,7 @@ public class AST2KnRTests extends AST2TestBase {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(x) char x,a;\n"); //$NON-NLS-1$
 		buffer.append("{ return x == 0; }\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true, false);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU, false);
 
 		IASTFunctionDefinition f = (IASTFunctionDefinition) tu.getDeclarations()[0];
 		assertTrue(f.getDeclarator() instanceof ICASTKnRFunctionDeclarator);
@@ -460,7 +460,7 @@ public class AST2KnRTests extends AST2TestBase {
 		buffer.append("x->a = 0;\n"); //$NON-NLS-1$
 		buffer.append("x->c[1]=x->c[2];\n"); //$NON-NLS-1$
 		buffer.append("}\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU);
 
 		IASTSimpleDeclaration A_struct = (IASTSimpleDeclaration) tu.getDeclarations()[0];
 		IASTSimpleDeclaration A = (IASTSimpleDeclaration) tu.getDeclarations()[1];
@@ -583,7 +583,7 @@ public class AST2KnRTests extends AST2TestBase {
 		buffer.append("getinp(prompt, list)\n"); //$NON-NLS-1$
 		buffer.append("        const char *prompt, *const list[];\n"); //$NON-NLS-1$
 		buffer.append("{\n	*list[1] = 'a';\n}\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU);
 
 		IASTFunctionDefinition getinp = (IASTFunctionDefinition) tu.getDeclarations()[0];
 
@@ -628,7 +628,7 @@ public class AST2KnRTests extends AST2TestBase {
 	public void testKRC_getParametersOrder() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(a, b) int b,a;{}\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU);
 
 		IASTFunctionDefinition f = (IASTFunctionDefinition) tu.getDeclarations()[0];
 		ICASTKnRFunctionDeclarator f_decltor = (ICASTKnRFunctionDeclarator) f.getDeclarator();
@@ -650,7 +650,7 @@ public class AST2KnRTests extends AST2TestBase {
 		buffer.append("struct lemon *lemp;\n{\n"); //$NON-NLS-1$
 		buffer.append("lemp->symbols[1]->lambda = 1;\n"); //$NON-NLS-1$
 		buffer.append("lemp->errorcnt++;}\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU);
 
 		IASTSimpleDeclaration symbol_decl = (IASTSimpleDeclaration) tu.getDeclarations()[0];
 		IASTSimpleDeclaration lemon_decl = (IASTSimpleDeclaration) tu.getDeclarations()[1];
@@ -700,7 +700,7 @@ public class AST2KnRTests extends AST2TestBase {
 		buffer.append("void f(a) int a; {} \n"); //$NON-NLS-1$
 		buffer.append("void f(int);        \n"); //$NON-NLS-1$
 
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -720,7 +720,7 @@ public class AST2KnRTests extends AST2TestBase {
 		buffer.append("};\n"); //$NON-NLS-1$
 		buffer.append("}\n"); //$NON-NLS-1$
 
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, true, true);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.C, ScannerKind.GNU, true);
 		assertTrue(tu.getDeclarations()[0] instanceof IASTSimpleDeclaration);
 		assertTrue(tu.getDeclarations()[1] instanceof IASTFunctionDefinition);
 		IASTStatement[] stmts = ((IASTCompoundStatement) ((IASTFunctionDefinition) tu.getDeclarations()[1]).getBody())
@@ -748,7 +748,7 @@ public class AST2KnRTests extends AST2TestBase {
 	//  	return 0;
 	//  }
 	public void testBug203050() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), ParserLanguage.C, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), ParserLanguage.C, ScannerKind.GNU, true);
 		assertTrue(tu.getDeclarations()[0] instanceof IASTSimpleDeclaration);
 		assertTrue(tu.getDeclarations()[1] instanceof IASTFunctionDefinition);
 		assertTrue(tu.getDeclarations()[2] instanceof IASTFunctionDefinition);
@@ -775,6 +775,6 @@ public class AST2KnRTests extends AST2TestBase {
 	//    {}
 	public void testFunctionPtrParameter_378614() throws Exception {
 		String code = getAboveComment();
-		parseAndCheckBindings(code, ParserLanguage.C, true);
+		parseAndCheckBindings(code, ParserLanguage.C, ScannerKind.GNU);
 	}
 }

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateLValueRValueTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateLValueRValueTests.java
@@ -862,7 +862,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 
 	private void parseAndCheckBindingsForOneProblem() throws IOException, ParserException {
 		final String code = getAboveComment();
-		IASTTranslationUnit tu = parse(code, CPP, true, false);
+		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.GNU, false);
 		NameCollector nc = new NameCollector();
 		tu.accept(nc);
 		assertProblemBindings(nc, 1);
@@ -870,7 +870,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 
 	private void parseAndCheckBindingsForProblem() throws IOException, ParserException {
 		final String code = getAboveComment();
-		IASTTranslationUnit tu = parse(code, CPP, true, false);
+		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.GNU, false);
 		NameCollector nc = new NameCollector();
 		tu.accept(nc);
 		assertProblemBindings(nc);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateTests.java
@@ -1936,7 +1936,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    A<int, local> broken;
 	// };
 	public void testBug103578() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -1956,7 +1956,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    a.base;
 	// }
 	public void testBug103715() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -1981,7 +1981,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void complex<float>::f(float){
 	// }
 	public void testBug74276() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -2007,7 +2007,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    myType t;
 	// }
 	public void testBug105852() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -2030,7 +2030,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    k.c;
 	//	}
 	public void testBug105769() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -2046,7 +2046,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    template <> C(wchar_t * c) : blah(c) {}
 	//	};
 	public void testBug162230() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -2081,7 +2081,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template< class T > class C {};
 	//	typedef struct C<int> CInt;
 	public void testBug169628() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -2450,7 +2450,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//            // foo<int,int> -> CPPMethodInstance
 	//    }
 	public void testCPPConstructorTemplateSpecialization() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
 		NameCollector col = new NameCollector(true);
 		tu.accept(col);
@@ -2472,7 +2472,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    return (lhs < rhs ? rhs : lhs);
 	// }
 	public void testNestedFuncTemplatedDeclarator_bug190241() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
 		NameCollector col = new NameCollector();
 		tu.accept(col);
@@ -2522,7 +2522,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void f(B<int>::tb r) {}
 	public void testTemplateTypedef_214447() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
 		NameCollector col = new NameCollector();
 		tu.accept(col);
@@ -2556,7 +2556,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void f(Vec<int>::reference r) {}
 	public void testRebindPattern_214447a() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
 		NameCollector col = new NameCollector();
 		tu.accept(col);
@@ -2596,7 +2596,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void f(Vec<int>::reference r) {}
 	public void testRebindPattern_214447b() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
 		NameCollector col = new NameCollector();
 		tu.accept(col);
@@ -2635,7 +2635,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void f(map<int>::value_type r) {}
 	public void testRebindPattern_236197() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 		for (IASTName name : col.nameList) {
@@ -2667,7 +2667,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void main(Iter<int*>::iter_reference r);
 	public void testSpecializationSelection_229218() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 		for (IASTName name : col.nameList) {
@@ -2797,7 +2797,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// B<int>::b::a x;
 	public void testDefaultTemplateParameter() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
 		NameCollector col = new NameCollector();
 		tu.accept(col);
@@ -2942,7 +2942,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	const int i= 1;
 	//	A<i> a1;
 	public void testNonTypeArgumentIsIDExpression_229942a() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -2961,7 +2961,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     const int i= 1;
 	//  };
 	public void testNonTypeArgumentIsIDExpression_229942b() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -2975,7 +2975,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	const int i= 1;
 	//	A<i+1> a1;
 	public void testExpressionArgumentIsExpression_229942() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -2990,7 +2990,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	const int i= 1;
 	//	A<typeid(1)> a1;
 	public void testTypeIdOperatorArgumentIsUnaryExpression_229942() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -3003,7 +3003,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template< class T1, class T2, int q1, int q2>
 	// class A< C<T1, q1>, C<T2, q2> > {};
 	public void testTemplateIdAsTemplateArgumentIsTypeId_229942() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -3036,7 +3036,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ba.assertNonProblem("T> at) {", 1);
 
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -3056,7 +3056,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	inline const void foo(void (*f)(A<i>), T* t) { // disallowed, but we're testing the AST
 	//	}
 	public void testTypeIdAsTemplateArgumentIsTypeId_229942b() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -3747,7 +3747,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//	template<class T> void A<T, int>::foo(T t) {}
 	public void testBug177418() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
 		NameCollector col = new NameCollector();
 		tu.accept(col);
@@ -4201,7 +4201,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  p.waldo();
 	//	}
 	public void testTypeTraitWithQualifier_511143() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//  template <typename CL, typename T>
@@ -4973,7 +4973,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	}
 	public void testClosingAngleBrackets2_261268() throws Exception {
 		final String code = getAboveComment();
-		IASTTranslationUnit tu = parse(code, CPP, true, false);
+		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.GNU, false);
 		IASTFunctionDefinition fdef = getDeclaration(tu, 2);
 		IASTProblemStatement p1 = getStatement(fdef, 1);
 	}
@@ -5618,7 +5618,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 			code.append('\n').append("int_<0> >::type,");
 		}
 		code.append("int_<0> >::type tdef;");
-		IASTTranslationUnit tu = parse(code.toString(), CPP, true, true);
+		IASTTranslationUnit tu = parse(code.toString(), CPP, ScannerKind.GNU, true);
 		tu = validateCopy(tu);
 		assertEquals(1, tu.getDeclarations().length);
 	}
@@ -6884,7 +6884,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  f<int>();
 	//	}
 	public void testIsPOD_367993() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	template<typename T, void (T::*M)()> class A {
@@ -6907,7 +6907,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		c.callDelegate(a); /* Invalid arguments 'Candidates are: void callDelegate(A<#0,#1> &)' */
 	//	}
 	public void testDeductionOfNonTypeTemplateArg_372587() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	template<typename _Functor> void b(_Functor __f) {}
@@ -6917,7 +6917,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		b(f<int*, int>);
 	//	}
 	public void testFunctionSetWithNonMatchingTemplateArgs_379604() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	template <typename T> struct C {
@@ -6933,7 +6933,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		f(v);
 	//	}
 	public void testPointerToMemberAsDependentExpression_391001() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	template<typename>
@@ -6991,7 +6991,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    it.test;  // Field 'test' could not be resolved
 	//	}
 	public void testAddressAsTemplateArgument_391190() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	template <typename T> struct CT {
@@ -7001,7 +7001,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    off < CT<int>::const_min || off > CT<int>::const_min;
 	//	}
 	public void testTemplateIDAmbiguity_393959() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	// template<typename T> class CT {
@@ -10104,7 +10104,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  C<T>::c; // problems on C, T and ::c
 	//	}
 	public void testRegression_485388a() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	template <typename T>

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TestBase.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TestBase.java
@@ -539,7 +539,12 @@ public abstract class AST2TestBase extends SemanticTestBase {
 		}
 
 		public AST2AssertionHelper(String contents, ParserLanguage lang) throws ParserException {
-			super(contents, parse(contents, lang, ScannerKind.GNU, false));
+			this(contents, lang, ScannerKind.GNU);
+		}
+
+		public AST2AssertionHelper(String contents, ParserLanguage lang, ScannerKind scannerKind)
+				throws ParserException {
+			super(contents, parse(contents, lang, scannerKind, false));
 			this.isCPP = lang.isCPP();
 		}
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TestBase.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TestBase.java
@@ -576,8 +576,13 @@ public abstract class AST2TestBase extends SemanticTestBase {
 	}
 
 	protected BindingAssertionHelper getAssertionHelper(ParserLanguage lang) throws ParserException, IOException {
+		return getAssertionHelper(lang, ScannerKind.GNU);
+	}
+
+	protected BindingAssertionHelper getAssertionHelper(ParserLanguage lang, ScannerKind scannerKind)
+			throws ParserException, IOException {
 		String code = getAboveComment();
-		return new AST2AssertionHelper(code, lang);
+		return new AST2AssertionHelper(code, lang, scannerKind);
 	}
 
 	final protected void assertNoProblemBindings(NameCollector col) {

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2Tests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2Tests.java
@@ -505,6 +505,10 @@ public class AST2Tests extends AST2TestBase {
 		validateConditionalExpressionC("x ? y : x"); //$NON-NLS-1$
 	}
 
+	public void testCPP20Expressions() throws ParserException {
+		validateSimpleBinaryExpressionCPP20("x<=>y", IASTBinaryExpression.op_threewaycomparison); //$NON-NLS-1$
+	}
+
 	public void testMultipleDeclarators() throws Exception {
 		IASTTranslationUnit tu = parse("int r, s;", C); //$NON-NLS-1$
 		assertTrue(tu.isFrozen());

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2Tests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2Tests.java
@@ -157,13 +157,13 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	private void parseAndCheckBindings() throws Exception {
-		parseAndCheckBindings(false);
+		parseAndCheckBindings(ScannerKind.STD);
 	}
 
-	private void parseAndCheckBindings(boolean useGnuExtensions) throws Exception {
+	private void parseAndCheckBindings(ScannerKind scannerKind) throws Exception {
 		String code = getAboveComment();
-		parseAndCheckBindings(code, C, useGnuExtensions);
-		parseAndCheckBindings(code, CPP, useGnuExtensions);
+		parseAndCheckBindings(code, C, scannerKind);
+		parseAndCheckBindings(code, CPP, scannerKind);
 	}
 
 	protected IASTTranslationUnit parseAndCheckBindings(String code) throws Exception {
@@ -2724,7 +2724,7 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	public void testProblems() throws Exception {
-		IASTTranslationUnit tu = parse("    a += ;", C, true, false); //$NON-NLS-1$
+		IASTTranslationUnit tu = parse("    a += ;", C, ScannerKind.GNU, false); //$NON-NLS-1$
 		IASTProblem[] ps = CVisitor.getProblems(tu);
 		assertEquals(1, ps.length);
 		ps[0].getMessage();
@@ -2797,7 +2797,7 @@ public class AST2Tests extends AST2TestBase {
 	// p = &((struct s) { j++ });
 	// }
 	public void testBug84176() throws Exception {
-		parse(getAboveComment(), C, false, true);
+		parse(getAboveComment(), C, ScannerKind.STD, true);
 	}
 
 	// struct s { double i; } f(void);
@@ -3136,7 +3136,7 @@ public class AST2Tests extends AST2TestBase {
 	// float _Complex x;
 	// double _Complex y;
 	public void testBug95757() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), C, true, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.GNU, true);
 		IASTDeclaration[] decls = tu.getDeclarations();
 
 		assertTrue(((ICASTSimpleDeclSpecifier) ((IASTSimpleDeclaration) decls[0]).getDeclSpecifier()).isComplex());
@@ -3151,7 +3151,7 @@ public class AST2Tests extends AST2TestBase {
 	// typeof({ int x = foo();
 	//          x; }) zoot;
 	public void testBug93980() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), C, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -3165,14 +3165,14 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	public void testBug95866() throws Exception {
-		IASTTranslationUnit tu = parse("int test[10] = { [0 ... 9] = 2 };", C, true, true); //$NON-NLS-1$
+		IASTTranslationUnit tu = parse("int test[10] = { [0 ... 9] = 2 };", C, ScannerKind.GNU, true); //$NON-NLS-1$
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 		assertNoProblemBindings(col);
 	}
 
 	public void testBug98502() throws Exception {
-		IASTTranslationUnit tu = parse("typedef enum { ONE } e;", C, true, true); //$NON-NLS-1$
+		IASTTranslationUnit tu = parse("typedef enum { ONE } e;", C, ScannerKind.GNU, true); //$NON-NLS-1$
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -3188,7 +3188,7 @@ public class AST2Tests extends AST2TestBase {
 	//    PIPERR;
 	// }
 	public void testBug98365() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), C, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -3197,7 +3197,7 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	public void testBug99262() throws Exception {
-		parse("void foo() {void *f; f=__null;}", C, true, true); //$NON-NLS-1$
+		parse("void foo() {void *f; f=__null;}", C, ScannerKind.GNU, true); //$NON-NLS-1$
 	}
 
 	// void f1(int*) {
@@ -3215,7 +3215,7 @@ public class AST2Tests extends AST2TestBase {
 	//    { a; int a; }
 	// }
 	public void testBug98960() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), C, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -3244,7 +3244,7 @@ public class AST2Tests extends AST2TestBase {
 	// {
 	// }
 	public void testBug98760() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), C, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -3321,7 +3321,7 @@ public class AST2Tests extends AST2TestBase {
 	//       blah: x;
 	// }
 	public void testBug104390_2() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), C, true);
+		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 
@@ -3447,7 +3447,7 @@ public class AST2Tests extends AST2TestBase {
 	//     return newWindow;
 	// }
 	public void testBug143502() throws Exception {
-		parse(getAboveComment(), C, true, false);
+		parse(getAboveComment(), C, ScannerKind.GNU, false);
 	}
 
 	// void func(int a) {
@@ -3462,13 +3462,13 @@ public class AST2Tests extends AST2TestBase {
 	// }
 	public void testBracketAroundIdentifier_168924() throws IOException, ParserException {
 		String content = getAboveComment();
-		IASTTranslationUnit tu = parse(content, C, true, true);
+		IASTTranslationUnit tu = parse(content, C, ScannerKind.GNU, true);
 		IASTFunctionDefinition func = (IASTFunctionDefinition) tu.getDeclarations()[0];
 		IASTParameterDeclaration[] params = ((IASTStandardFunctionDeclarator) func.getDeclarator()).getParameters();
 		IBinding binding = params[0].getDeclarator().getName().resolveBinding();
 		assertEquals(7, tu.getReferences(binding).length);
 
-		tu = parse(content, CPP, true, true);
+		tu = parse(content, CPP, ScannerKind.GNU, true);
 		func = (IASTFunctionDefinition) tu.getDeclarations()[0];
 		params = ((IASTStandardFunctionDeclarator) func.getDeclarator()).getParameters();
 		binding = params[0].getDeclarator().getName().resolveBinding();
@@ -3480,7 +3480,7 @@ public class AST2Tests extends AST2TestBase {
 	//     MAC(");
 	//  }
 	public void testBug179383() throws ParserException, IOException {
-		parse(getAboveComment(), C, false, false);
+		parse(getAboveComment(), C, ScannerKind.STD, false);
 	}
 
 	/**
@@ -3492,7 +3492,7 @@ public class AST2Tests extends AST2TestBase {
 		String simple = "#define LIT 1  // my value\r\n" + "int func(int x) {\r\n" + "}\r\n" + "int main() {\r\n"
 				+ "  return func(LIT);   // fails to parse\r\n" + "}\r\n";
 
-		IASTTranslationUnit tu = parse(simple, CPP, true, true);
+		IASTTranslationUnit tu = parse(simple, CPP, ScannerKind.GNU, true);
 
 		// actual reduced test case, plus extra cases
 		String text = "#define KBOOT		1 //0x00000002\r\n"
@@ -3504,7 +3504,7 @@ public class AST2Tests extends AST2TestBase {
 				+ "__KTRACE_OPT(KBOOT2,fail());\r\n" + "}\r\n";
 
 		// essential test: this code should be parseable
-		tu = parse(text, CPP, true, true);
+		tu = parse(text, CPP, ScannerKind.GNU, true);
 
 		// verify macros
 		IASTPreprocessorMacroDefinition[] macroDefinitions = tu.getMacroDefinitions();
@@ -3526,7 +3526,7 @@ public class AST2Tests extends AST2TestBase {
 	// }
 	public void testBug181305_1() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(getAboveComment(), lang, true, true);
+			IASTTranslationUnit tu = parse(getAboveComment(), lang, ScannerKind.GNU, true);
 
 			// check class
 			IASTFunctionDefinition fd = (IASTFunctionDefinition) tu.getDeclarations()[1];
@@ -3547,7 +3547,7 @@ public class AST2Tests extends AST2TestBase {
 	// }
 	public void testBug181305_2() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(getAboveComment(), lang, true, true);
+			IASTTranslationUnit tu = parse(getAboveComment(), lang, ScannerKind.GNU, true);
 
 			// check class
 			IASTFunctionDefinition fd = (IASTFunctionDefinition) tu.getDeclarations()[1];
@@ -3574,7 +3574,7 @@ public class AST2Tests extends AST2TestBase {
 	// }
 	public void testBug181942() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values())
-			parse(getAboveComment(), lang, true, true);
+			parse(getAboveComment(), lang, ScannerKind.GNU, true);
 	}
 
 	public void testMacroCommentsBug_177154_2() throws Exception {
@@ -3594,18 +3594,18 @@ public class AST2Tests extends AST2TestBase {
 
 		// this should work
 		String textNoComment = noCommentMacro + textTail;
-		IASTTranslationUnit tu = parse(textNoComment, CPP, true, true);
+		IASTTranslationUnit tu = parse(textNoComment, CPP, ScannerKind.GNU, true);
 
 		// this fails
 		String textComment = commentMacro + textTail;
-		tu = parse(textComment, CPP, true, true);
+		tu = parse(textComment, CPP, ScannerKind.GNU, true);
 
 	}
 
 	// int __builtin_sin;
 	public void testBug182464() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values())
-			parseAndCheckBindings(getAboveComment(), lang, true);
+			parseAndCheckBindings(getAboveComment(), lang, ScannerKind.GNU);
 	}
 
 	public void testBug186018() throws Exception {
@@ -3761,7 +3761,7 @@ public class AST2Tests extends AST2TestBase {
 	// typedef int (*J)(J);
 	public void testBug192165() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(getAboveComment(), lang, true, false);
+			IASTTranslationUnit tu = parse(getAboveComment(), lang, ScannerKind.GNU, false);
 			NameCollector col = new NameCollector();
 			tu.accept(col);
 			assertInstance(col.getName(0).resolveBinding(), IProblemBinding.class);
@@ -3797,8 +3797,8 @@ public class AST2Tests extends AST2TestBase {
 	// INVALID(1, 2)
 	//
 	public void test192639() throws Exception {
-		parse(getAboveComment(), CPP, false, false);
-		parse(getAboveComment(), C, false, false);
+		parse(getAboveComment(), CPP, ScannerKind.STD, false);
+		parse(getAboveComment(), C, ScannerKind.STD, false);
 	}
 
 	public void test195943() throws Exception {
@@ -3818,11 +3818,11 @@ public class AST2Tests extends AST2TestBase {
 	// int array[12]= {};
 	public void testBug196468_emptyArrayInitializer() throws Exception {
 		final String content = getAboveComment();
-		parse(content, CPP, false);
-		parse(content, CPP, true);
-		parse(content, C, true);
+		parse(content, CPP, ScannerKind.STD);
+		parse(content, CPP, ScannerKind.GNU);
+		parse(content, C, ScannerKind.GNU);
 		try {
-			parse(content, C, false);
+			parse(content, C, ScannerKind.STD);
 			fail("C89 does not allow empty braces in array initializer");
 		} catch (ParserException e) {
 		}
@@ -3848,8 +3848,8 @@ public class AST2Tests extends AST2TestBase {
 	// void  (* __attribute__((__stdcall__)) foo2) (int);
 	// void  (* __attribute__((__stdcall__))* foo3) (int);
 	public void testBug191450_attributesInBetweenPointers() throws Exception {
-		parse(getAboveComment(), CPP, true, true);
-		parse(getAboveComment(), C, true, true);
+		parse(getAboveComment(), CPP, ScannerKind.GNU, true);
+		parse(getAboveComment(), C, ScannerKind.GNU, true);
 	}
 
 	// class NameClash {};
@@ -3857,7 +3857,7 @@ public class AST2Tests extends AST2TestBase {
 	// namespace NameClash2 {};
 	// class NameClash2 {};
 	public void testBug202271_nameClash() throws Exception {
-		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), CPP, true);
+		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 		assertTrue(tu.isFrozen());
 		for (int i = 0; i < NUM_TESTS; i++) {
 			NameCollector col = new NameCollector();
@@ -3877,7 +3877,7 @@ public class AST2Tests extends AST2TestBase {
 	// int b= WRAP(MACRO);
 	public void testBug94673_refsForMacrosAsArguments() throws Exception {
 		String content = getAboveComment();
-		IASTTranslationUnit tu = parseAndCheckBindings(content, CPP, true);
+		IASTTranslationUnit tu = parseAndCheckBindings(content, CPP, ScannerKind.GNU);
 		IASTPreprocessorMacroDefinition[] defs = tu.getMacroDefinitions();
 		assertEquals(2, defs.length);
 		IASTPreprocessorMacroDefinition md = defs[1];
@@ -4096,7 +4096,7 @@ public class AST2Tests extends AST2TestBase {
 	//  f3(&i); // ok
 	// }
 	public void testBug213029_cvConversion() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), CPP, false);
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.STD);
 		NameCollector col = new NameCollector();
 		tu.accept(col);
 		for (Object o : col.nameList) {
@@ -4597,16 +4597,16 @@ public class AST2Tests extends AST2TestBase {
 	// }
 	public void testRedefinedGCCKeywords_226112() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	//	int foo asm ("myfoo") __attribute__((__used__)), ff asm("ss") = 2;
 	//	extern void func () asm ("FUNC") __attribute__((__used__));
 	public void testASMLabels_226121() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	// void test() {
@@ -4614,8 +4614,8 @@ public class AST2Tests extends AST2TestBase {
 	// }
 	public void testCompoundStatementExpression_226274() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	//  int main() {
@@ -4623,8 +4623,8 @@ public class AST2Tests extends AST2TestBase {
 	//  }
 	public void testTypeofStatementExpressionInCastExpression_427950() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	// void test(int count) {
@@ -4633,8 +4633,8 @@ public class AST2Tests extends AST2TestBase {
 	// }
 	public void testTypeofUnaryExpression_226492() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	// void test(int count) {
@@ -4642,8 +4642,8 @@ public class AST2Tests extends AST2TestBase {
 	// }
 	public void testTypeofExpression_226492() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	//	void func() {
@@ -4651,8 +4651,8 @@ public class AST2Tests extends AST2TestBase {
 	//	}
 	public void testTypeofExpressionWithAttribute_226492() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	//    struct test {
@@ -4676,7 +4676,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testCaseRange_211882() throws Exception {
 		final String code = getAboveComment();
 		{
-			IASTTranslationUnit tu = parseAndCheckBindings(code, C, true);
+			IASTTranslationUnit tu = parseAndCheckBindings(code, C, ScannerKind.GNU);
 			IASTCompoundStatement body = (IASTCompoundStatement) ((IASTFunctionDefinition) tu.getDeclarations()[0])
 					.getBody();
 			IASTSwitchStatement switchStmt = (IASTSwitchStatement) body.getStatements()[0];
@@ -4688,7 +4688,7 @@ public class AST2Tests extends AST2TestBase {
 			assertTrue(binExpr.getOperand2() instanceof IASTLiteralExpression);
 		}
 		{
-			IASTTranslationUnit tu = parseAndCheckBindings(code, CPP, true);
+			IASTTranslationUnit tu = parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 			IASTCompoundStatement body = (IASTCompoundStatement) ((IASTFunctionDefinition) tu.getDeclarations()[0])
 					.getBody();
 			IASTSwitchStatement switchStmt = (IASTSwitchStatement) body.getStatements()[0];
@@ -4706,8 +4706,8 @@ public class AST2Tests extends AST2TestBase {
 	//	int x(int(TIntPtr));
 	public void testInfiniteRecursion_269052() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	//	template<typename T> class X {
@@ -4723,15 +4723,15 @@ public class AST2Tests extends AST2TestBase {
 	//	struct __attribute__((declspec)) bla;
 	public void testAttributeInElaboratedTypeSpecifier_227085() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	// struct X;
 	// void test(struct X* __restrict result);
 	public void testRestrictReference_227110() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	// char buf[256];
@@ -4761,7 +4761,7 @@ public class AST2Tests extends AST2TestBase {
 	// }
 	public void testBug228422_noKnrParam() throws Exception {
 		CharSequence buffer = getContents(1)[0];
-		parse(buffer.toString(), C, false);
+		parse(buffer.toString(), C, ScannerKind.STD);
 	}
 
 	//    struct {
@@ -4878,8 +4878,8 @@ public class AST2Tests extends AST2TestBase {
 	//    }
 	public void testReturnTypeOfBuiltin_234309() throws Exception {
 		String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	//    typedef void VOID;
@@ -5064,7 +5064,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testTrailingSyntaxErrorInTU() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTDeclaration decl = getDeclaration(tu, 0);
 			IASTProblemDeclaration pdecl = getDeclaration(tu, 1);
 			assertEquals("+", pdecl.getRawSignature());
@@ -5078,7 +5078,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testTrailingSyntaxErrorInCompositeType() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTCompositeTypeSpecifier ct = getCompositeType(tu, 0);
 			IASTDeclaration decl = getDeclaration(ct, 0);
 			IASTProblemDeclaration pdecl = getDeclaration(ct, 1);
@@ -5095,7 +5095,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testTrailingSyntaxErrorInCompoundStatements() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTFunctionDefinition def = getDeclaration(tu, 0);
 			IASTCompoundStatement compStmt = getStatement(def, 0);
 			IASTDeclarationStatement dstmt = getStatement(compStmt, 0);
@@ -5111,7 +5111,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testEmptyDeclarations() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTCompositeTypeSpecifier ct = getCompositeType(tu, 0);
 			IASTDeclaration empty = getDeclaration(ct, 0);
 			assertEquals(";", empty.getRawSignature());
@@ -5411,13 +5411,13 @@ public class AST2Tests extends AST2TestBase {
 	//	spinlock_t _lock = (spinlock_t) {  };
 	public void testCompoundInitializer_145387() throws Exception {
 		// valid in C99, not in C++.
-		parseAndCheckBindings(getAboveComment(), C, true);
+		parseAndCheckBindings(getAboveComment(), C, ScannerKind.GNU);
 	}
 
 	// enum __declspec(uuid("uuid")) bla { a, b};
 	public void testDeclspecInEnumSpecifier_241203() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			parseAndCheckBindings(getAboveComment(), lang, true);
+			parseAndCheckBindings(getAboveComment(), lang, ScannerKind.GNU);
 		}
 	}
 
@@ -5430,7 +5430,7 @@ public class AST2Tests extends AST2TestBase {
 	//		Vector <__declspec(dllexport) int> a;
 	//	}
 	public void testDeclspecTypeId_574578() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//typedef struct _MyStruct {
@@ -5440,7 +5440,7 @@ public class AST2Tests extends AST2TestBase {
 	//MyStruct  __declspec(dllexport) __declspec(deprecated) bar;
 	public void testDeclspecAfterDeclSpecifierIdentifier_464624() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			parseAndCheckBindings(getAboveComment(), lang, true);
+			parseAndCheckBindings(getAboveComment(), lang, ScannerKind.GNU);
 		}
 	}
 
@@ -5469,7 +5469,7 @@ public class AST2Tests extends AST2TestBase {
 	// }
 	public void testBuiltinTypesCompatible_241570() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			parseAndCheckBindings(getAboveComment(), lang, true);
+			parseAndCheckBindings(getAboveComment(), lang, ScannerKind.GNU);
 		}
 	}
 
@@ -5478,8 +5478,8 @@ public class AST2Tests extends AST2TestBase {
 	//	    alloc(__func__);
 	//	}
 	public void testPredefinedFunctionName_247747() throws Exception {
-		parseAndCheckBindings(getAboveComment(), C, false);
-		parseAndCheckBindings(getAboveComment(), CPP, false);
+		parseAndCheckBindings(getAboveComment(), C, ScannerKind.STD);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.STD);
 	}
 
 	//	void alloc(const char * id) {}
@@ -5489,16 +5489,16 @@ public class AST2Tests extends AST2TestBase {
 	//	    alloc(__PRETTY_FUNCTION__);
 	//	}
 	public void testPredefinedFunctionNameGcc_247747() throws Exception {
-		parseAndCheckBindings(getAboveComment(), C, true);
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), C, ScannerKind.GNU);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	int foo = 42;
 	//  typedef char StupidType;
 	//  StupidType const *bar = (StupidType const*)&foo;
 	public void testUnusualDeclSpecOrdering_251514() throws Exception {
-		parseAndCheckBindings(getAboveComment(), C, true);
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), C, ScannerKind.GNU);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	//	#define IF      if
@@ -5837,7 +5837,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testReferencesInInitializer_251514() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parseAndCheckBindings(code, lang, true);
+			IASTTranslationUnit tu = parseAndCheckBindings(code, lang, ScannerKind.GNU);
 			IASTFunctionDefinition fdef = getDeclaration(tu, 0);
 			IASTName name = fdef.getDeclarator().getName();
 			assertEquals(2, tu.getReferences(name.resolveBinding()).length);
@@ -5867,7 +5867,7 @@ public class AST2Tests extends AST2TestBase {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			intermittentTest(() -> {
 				long mem = memoryUsed();
-				IASTTranslationUnit tu = parse(code, lang, false, true, 0);
+				IASTTranslationUnit tu = parse(code, lang, ScannerKind.STD, true, 0);
 				long diff = memoryUsed() - mem;
 				// Allow a copy of the buffer, plus less than 1.5 bytes per initializer.
 				final int expected = code.length() * 2 + AMOUNT + AMOUNT / 2;
@@ -5895,7 +5895,7 @@ public class AST2Tests extends AST2TestBase {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			intermittentTest(() -> {
 				long mem = memoryUsed();
-				IASTTranslationUnit tu = parse(code, lang, false, true, 0);
+				IASTTranslationUnit tu = parse(code, lang, ScannerKind.STD, true, 0);
 				long diff = memoryUsed() - mem;
 				// Allow a copy of the buffer, plus less than 1.5 bytes per
 				// initializer.
@@ -5921,7 +5921,8 @@ public class AST2Tests extends AST2TestBase {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			intermittentTest(() -> {
 				long mem = memoryUsed();
-				IASTTranslationUnit tu = parse(code, lang, false, true, maximumTrivialExpressionsInInitializer);
+				IASTTranslationUnit tu = parse(code, lang, ScannerKind.STD, true,
+						maximumTrivialExpressionsInInitializer);
 				long diff = memoryUsed() - mem;
 				final int initializerSize = maximumTrivialExpressionsInInitializer * additionalBytesPerInitializer;
 				// Allow a copy of the buffer, plus less than 1.5 bytes per initializer.
@@ -6016,7 +6017,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testNonTrivialInitializer_253690() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(code, lang, false, true, 0);
+			IASTTranslationUnit tu = parse(code, lang, ScannerKind.STD, true, 0);
 			IASTSimpleDeclaration d = getDeclaration(tu, 0);
 			IBinding b = d.getDeclarators()[0].getName().resolveBinding();
 			IASTName[] refs = tu.getReferences(b);
@@ -6098,8 +6099,8 @@ public class AST2Tests extends AST2TestBase {
 	// extern __thread int k;
 	public void testThreadLocalVariables_260387() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	// void test() {
@@ -6109,7 +6110,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testAmbiguityResolutionInIfCondition_261043() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parseAndCheckBindings(code, lang, true);
+			IASTTranslationUnit tu = parseAndCheckBindings(code, lang, ScannerKind.GNU);
 			IASTFunctionDefinition fdef = getDeclaration(tu, 0);
 			IASTIfStatement ifstmt = getStatement(fdef, 1);
 			IASTExpression expr = ifstmt.getConditionExpression();
@@ -6124,7 +6125,7 @@ public class AST2Tests extends AST2TestBase {
 	// };
 	public void testAmbiguousDeclaration_259373() throws Exception {
 		final String code = getAboveComment();
-		IASTTranslationUnit tu = parseAndCheckBindings(code, C, true);
+		IASTTranslationUnit tu = parseAndCheckBindings(code, C, ScannerKind.GNU);
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, false);
 		ITypedef td = bh.assertNonProblem("TInt; //", 4);
 		IField f = bh.assertNonProblem("a;", 1);
@@ -6147,7 +6148,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testLocalVsGlobalStruct_255973() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parseAndCheckBindings(code, lang, true);
+			IASTTranslationUnit tu = parseAndCheckBindings(code, lang, ScannerKind.GNU);
 		}
 	}
 
@@ -6157,7 +6158,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testTypedefWithSameName() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parseAndCheckBindings(code, lang, true);
+			IASTTranslationUnit tu = parseAndCheckBindings(code, lang, ScannerKind.GNU);
 
 			BindingAssertionHelper ba = new AST2AssertionHelper(code, lang == CPP);
 			ITypedef t = ba.assertNonProblem("A;", 1);
@@ -6235,7 +6236,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testPointerOperatorsAsChildren_260461() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parseAndCheckBindings(code, lang, true);
+			IASTTranslationUnit tu = parseAndCheckBindings(code, lang, ScannerKind.GNU);
 			IASTSimpleDeclaration decl = getDeclaration(tu, 0);
 			IASTDeclarator dtor = decl.getDeclarators()[0];
 			IASTNode[] nodes = dtor.getChildren();
@@ -6622,7 +6623,7 @@ public class AST2Tests extends AST2TestBase {
 	//
 	public void testTypePromotion_longlongint() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit ast = parseAndCheckBindings(getAboveComment(), lang, true); // support for long long
+			IASTTranslationUnit ast = parseAndCheckBindings(getAboveComment(), lang, ScannerKind.GNU); // support for long long
 			IASTFunctionDefinition func = null;
 
 			for (IASTDeclaration d : ast.getDeclarations()) {
@@ -7095,7 +7096,7 @@ public class AST2Tests extends AST2TestBase {
 	//     structure.ptr = goo;
 	// }
 	public void testBindingsOnFields() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), C, false);
+		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.STD);
 		IASTCompoundStatement bodyStmt = (IASTCompoundStatement) ((IASTFunctionDefinition) tu.getDeclarations()[2])
 				.getBody();
 
@@ -7255,14 +7256,14 @@ public class AST2Tests extends AST2TestBase {
 	//	static a[2]= {0,0};
 	public void testSkipAggregateInitializer_297550() throws Exception {
 		final String code = getAboveComment();
-		IASTTranslationUnit tu = parseAndCheckBindings(code, C, false, 0);
+		IASTTranslationUnit tu = parseAndCheckBindings(code, C, ScannerKind.STD, 0);
 		assertTrue(tu.hasNodesOmitted());
 	}
 
 	//	static a[2]= {0,0};
 	public void testNoSkipTrivialAggregateInitializer_412380() throws Exception {
 		final String code = getAboveComment();
-		IASTTranslationUnit tu = parseAndCheckBindings(code, C, false);
+		IASTTranslationUnit tu = parseAndCheckBindings(code, C, ScannerKind.STD);
 		assertFalse(tu.hasNodesOmitted());
 	}
 
@@ -7270,7 +7271,7 @@ public class AST2Tests extends AST2TestBase {
 	//	static a[1]= {i};
 	public void testNoSkipNonTrivialAggregateInitializer_412380() throws Exception {
 		final String code = getAboveComment();
-		IASTTranslationUnit tu = parseAndCheckBindings(code, C, false, 0);
+		IASTTranslationUnit tu = parseAndCheckBindings(code, C, ScannerKind.STD, 0);
 		assertFalse(tu.hasNodesOmitted());
 	}
 
@@ -7312,8 +7313,8 @@ public class AST2Tests extends AST2TestBase {
 	// void f () __attribute__ ((int));
 	public void testAttributeSyntax_298841() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	//	void func(int* obj) {
@@ -7359,8 +7360,8 @@ public class AST2Tests extends AST2TestBase {
 	//	}
 	public void testFunctionNameExpression() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	//	#define MACRO
@@ -7389,8 +7390,8 @@ public class AST2Tests extends AST2TestBase {
 	//	}
 	public void testVaArgWithFunctionPtr_311030() throws Exception {
 		final String code = getAboveComment();
-		parseAndCheckBindings(code, C, true);
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 	}
 
 	//	void test() {
@@ -7433,7 +7434,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testPtrDiffRecursion_317004() throws Exception {
 		final String comment = getAboveComment();
 		String code = comment;
-		parseAndCheckBindings(code, C, true);
+		parseAndCheckBindings(code, C, ScannerKind.GNU);
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, false);
 		ITypedef td = bh.assertNonProblem("ptrdiff_t", 0);
 		assertEquals("long int", ASTTypeUtil.getType(td.getType()));
@@ -7441,7 +7442,7 @@ public class AST2Tests extends AST2TestBase {
 		assertEquals("unsigned long int", ASTTypeUtil.getType(td.getType()));
 
 		code = "namespace std {" + comment + "}";
-		parseAndCheckBindings(code, CPP, true);
+		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
 		bh = new AST2AssertionHelper(code, true);
 		td = bh.assertNonProblem("ptrdiff_t", 0);
 		assertEquals("long int", ASTTypeUtil.getType(td.getType()));
@@ -7544,12 +7545,12 @@ public class AST2Tests extends AST2TestBase {
 	//	  }
 	//	}
 	public void testGCCDecltype_397227() throws Exception {
-		parseAndCheckBindings(getAboveComment(), CPP, true);
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	// #define macro(R) #R""
 	public void testNoRawStringInPlainC_397127() throws Exception {
-		parseAndCheckBindings(getAboveComment(), C, true);
+		parseAndCheckBindings(getAboveComment(), C, ScannerKind.GNU);
 	}
 
 	// #define X
@@ -7629,7 +7630,7 @@ public class AST2Tests extends AST2TestBase {
 	//		return;
 	//	}
 	public void testExpressionLabelReference_84144() throws Exception {
-		parseAndCheckBindings(true);
+		parseAndCheckBindings(ScannerKind.GNU);
 	}
 
 	//	void f() {
@@ -7641,7 +7642,7 @@ public class AST2Tests extends AST2TestBase {
 	//	}
 	public void testExpressionLabelReferenceCast_486140a() throws Exception {
 		// Here, the cast-expression is the only valid parse.
-		parseAndCheckBindings(true);
+		parseAndCheckBindings(ScannerKind.GNU);
 	}
 
 	//	typedef unsigned long long ULL;
@@ -7655,7 +7656,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testExpressionLabelReferenceCast_486140b() throws Exception {
 		// Here, the cast-expression and the binary-expression are both
 		// syntactically valid, but the correct parse is the cast-expression.
-		parseAndCheckBindings(true);
+		parseAndCheckBindings(ScannerKind.GNU);
 	}
 
 	//	int test(int waldo, int other) {
@@ -7664,7 +7665,7 @@ public class AST2Tests extends AST2TestBase {
 	public void testBinaryExprNotMisparsedAsCast_486140() throws Exception {
 		// Again cast-expression and binary-expression are both syntactically
 		// valid, but this time the correct parse is binary-expression.
-		parseAndCheckBindings(true);
+		parseAndCheckBindings(ScannerKind.GNU);
 	}
 
 	//	int version = 0;
@@ -7672,7 +7673,7 @@ public class AST2Tests extends AST2TestBase {
 	//		return __atomic_add_fetch(&version, 1, 5);
 	//	}
 	public void testAtomicBuiltin_bug456131() throws Exception {
-		parseAndCheckBindings(true);
+		parseAndCheckBindings(ScannerKind.GNU);
 	}
 
 	//	void waldo(...);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2UtilTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2UtilTests.java
@@ -223,7 +223,7 @@ public class AST2UtilTests extends AST2TestBase {
 		buff.append("int foo(x, y) char x; int y; {}\n"); //$NON-NLS-1$
 		buff.append("int foo2(char x, int y) {}\n"); //$NON-NLS-1$
 
-		IASTTranslationUnit tu = parse(buff.toString(), ParserLanguage.C, true);
+		IASTTranslationUnit tu = parse(buff.toString(), ParserLanguage.C, ScannerKind.GNU);
 		IASTDeclaration[] d = tu.getDeclarations();
 
 		String fooSignature = ASTStringUtil.getSignatureString(((IASTFunctionDefinition) d[0]).getDeclarator());

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/CommentTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/CommentTests.java
@@ -33,14 +33,14 @@ public class CommentTests extends AST2TestBase {
 	}
 
 	public void testCountCommentsInHeaderFile() throws ParserException {
-		IASTTranslationUnit tu = parse(getHSource(), ParserLanguage.CPP, false, true);
+		IASTTranslationUnit tu = parse(getHSource(), ParserLanguage.CPP, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
 
 		assertEquals(9, comments.length);
 	}
 
 	public void testCommentsInHeaderFile() throws ParserException {
-		IASTTranslationUnit tu = parse(getHSource(), ParserLanguage.CPP, false, true);
+		IASTTranslationUnit tu = parse(getHSource(), ParserLanguage.CPP, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
 
 		assertEquals("/* A very cool class\n * isn't it?\n */", new String(comments[0].getComment()));
@@ -55,14 +55,14 @@ public class CommentTests extends AST2TestBase {
 	}
 
 	public void testCountCommentsInCPPFile() throws ParserException {
-		IASTTranslationUnit tu = parse(getCppSource(), ParserLanguage.CPP, false, true);
+		IASTTranslationUnit tu = parse(getCppSource(), ParserLanguage.CPP, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
 
 		assertEquals(10, comments.length);
 	}
 
 	public void testCommentsInCPPFile() throws ParserException {
-		IASTTranslationUnit tu = parse(getCppSource(), ParserLanguage.CPP, false, true);
+		IASTTranslationUnit tu = parse(getCppSource(), ParserLanguage.CPP, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
 
 		assertEquals("// Comment in cpp", new String(comments[0].getComment()));
@@ -78,14 +78,14 @@ public class CommentTests extends AST2TestBase {
 	}
 
 	public void testCountCommentsInCFile() throws ParserException {
-		IASTTranslationUnit tu = parse(getCSource(), ParserLanguage.C, false, true);
+		IASTTranslationUnit tu = parse(getCSource(), ParserLanguage.C, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
 
 		assertEquals(4, comments.length);
 	}
 
 	public void testCommentsInCFile() throws ParserException {
-		IASTTranslationUnit tu = parse(getCSource(), ParserLanguage.C, false, true);
+		IASTTranslationUnit tu = parse(getCSource(), ParserLanguage.C, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
 
 		assertEquals("//A little input/output programm", new String(comments[0].getComment()));
@@ -205,7 +205,7 @@ public class CommentTests extends AST2TestBase {
 	// #endif
 	public void testCommentsInInactiveCode_bug183930() throws Exception {
 		CharSequence code = getContents(1)[0];
-		IASTTranslationUnit tu = parse(code.toString(), ParserLanguage.CPP, false, true);
+		IASTTranslationUnit tu = parse(code.toString(), ParserLanguage.CPP, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
 
 		assertEquals(2, comments.length);
@@ -216,14 +216,14 @@ public class CommentTests extends AST2TestBase {
 	// //comment
 	public void testCommentLocation_bug186337() throws Exception {
 		CharSequence code = getContents(1)[0];
-		IASTTranslationUnit tu = parse(code.toString(), ParserLanguage.CPP, false, true);
+		IASTTranslationUnit tu = parse(code.toString(), ParserLanguage.CPP, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
 
 		assertEquals(1, comments.length);
 		assertNotNull(comments[0].getFileLocation());
 		assertNotNull(comments[0].getNodeLocations());
 
-		tu = parse(code.toString(), ParserLanguage.C, false, true);
+		tu = parse(code.toString(), ParserLanguage.C, ScannerKind.STD, true);
 		comments = tu.getComments();
 
 		assertEquals(1, comments.length);
@@ -239,7 +239,7 @@ public class CommentTests extends AST2TestBase {
 	// // TODO: shows up in task list
 	public void testCommentInDirectives_bug192546() throws Exception {
 		CharSequence code = getContents(1)[0];
-		IASTTranslationUnit tu = parse(code.toString(), ParserLanguage.CPP, false, false);
+		IASTTranslationUnit tu = parse(code.toString(), ParserLanguage.CPP, ScannerKind.STD, false);
 		IASTComment[] comments = tu.getComments();
 
 		assertEquals(5, comments.length);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/DOMLocationMacroTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/DOMLocationMacroTests.java
@@ -249,7 +249,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		String code = buffer.toString();
 
 		for (ParserLanguage language : languages) {
-			IASTTranslationUnit tu = parse(code, language, true, true);
+			IASTTranslationUnit tu = parse(code, language, ScannerKind.GNU, true);
 			final IASTPreprocessorMacroDefinition[] macroDefinitions = tu.getMacroDefinitions();
 			IASTPreprocessorObjectStyleMacroDefinition _PTR = (IASTPreprocessorObjectStyleMacroDefinition) macroDefinitions[0];
 			IASTPreprocessorFunctionStyleMacroDefinition _EXFUN = (IASTPreprocessorFunctionStyleMacroDefinition) macroDefinitions[2];

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/DOMLocationTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/DOMLocationTests.java
@@ -204,7 +204,7 @@ public class DOMLocationTests extends AST2TestBase {
 
 	public void testBug83664() throws Exception {
 		String code = "int foo(x) int x; {\n 	return x;\n   }\n"; //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(code, ParserLanguage.C, true);
+		IASTTranslationUnit tu = parse(code, ParserLanguage.C, ScannerKind.GNU);
 		IASTDeclaration[] declarations = tu.getDeclarations();
 		assertEquals(declarations.length, 1);
 		IASTFunctionDefinition definition = (IASTFunctionDefinition) declarations[0];
@@ -412,7 +412,7 @@ public class DOMLocationTests extends AST2TestBase {
 		buffer.append("int x;\n"); //$NON-NLS-1$
 		String code = buffer.toString();
 		for (ParserLanguage p : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(code, p, false, false);
+			IASTTranslationUnit tu = parse(code, p, ScannerKind.STD, false);
 			IASTDeclaration[] decls = tu.getDeclarations();
 			assertEquals(decls.length, 1);
 			IASTPreprocessorStatement[] statements = tu.getAllPreprocessorStatements();
@@ -439,7 +439,7 @@ public class DOMLocationTests extends AST2TestBase {
 		buffer.append("int x;\n"); //$NON-NLS-1$
 		String code = buffer.toString();
 		for (ParserLanguage p : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(code, p, false, false);
+			IASTTranslationUnit tu = parse(code, p, ScannerKind.STD, false);
 			IASTDeclaration[] decls = tu.getDeclarations();
 			IASTPreprocessorStatement[] statements = tu.getAllPreprocessorStatements();
 			IASTProblem[] problems = tu.getPreprocessorProblems();
@@ -462,7 +462,7 @@ public class DOMLocationTests extends AST2TestBase {
 		buffer.append("int x2;\n"); // [37-44]
 		String code = buffer.toString();
 		for (ParserLanguage p : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(code, p, false, false);
+			IASTTranslationUnit tu = parse(code, p, ScannerKind.STD, false);
 			IASTDeclaration[] decls = tu.getDeclarations();
 			IASTPreprocessorStatement[] statements = tu.getAllPreprocessorStatements();
 			IASTProblem[] problems = tu.getPreprocessorProblems();
@@ -483,7 +483,7 @@ public class DOMLocationTests extends AST2TestBase {
 		buffer.append("int x;\n");
 		String code = buffer.toString();
 		for (ParserLanguage p : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(code, p, false, false);
+			IASTTranslationUnit tu = parse(code, p, ScannerKind.STD, false);
 			IASTDeclaration[] decls = tu.getDeclarations();
 			IASTPreprocessorStatement[] statements = tu.getAllPreprocessorStatements();
 			IASTProblem[] problems = tu.getPreprocessorProblems();
@@ -502,7 +502,7 @@ public class DOMLocationTests extends AST2TestBase {
 		buffer.append("int x;\n");
 		String code = buffer.toString();
 		for (ParserLanguage p : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(code, p, false, false);
+			IASTTranslationUnit tu = parse(code, p, ScannerKind.STD, false);
 			IASTDeclaration[] decls = tu.getDeclarations();
 			IASTPreprocessorStatement[] statements = tu.getAllPreprocessorStatements();
 			IASTProblem[] problems = tu.getPreprocessorProblems();
@@ -521,7 +521,7 @@ public class DOMLocationTests extends AST2TestBase {
 		buffer.append("int x;\n");
 		String code = buffer.toString();
 		for (ParserLanguage p : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(code, p, false, false);
+			IASTTranslationUnit tu = parse(code, p, ScannerKind.STD, false);
 			IASTDeclaration[] decls = tu.getDeclarations();
 			IASTProblem[] problems = tu.getPreprocessorProblems();
 			assertEquals(1, decls.length);
@@ -597,7 +597,7 @@ public class DOMLocationTests extends AST2TestBase {
 	public void testBug157009_1() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#ifndef A\r\n#error X\r\n#else\r\n#error Y\r\n#endif");
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.CPP, false, false);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.CPP, ScannerKind.STD, false);
 
 		IASTProblem[] problems = tu.getPreprocessorProblems();
 		assertEquals(1, problems.length);
@@ -607,7 +607,7 @@ public class DOMLocationTests extends AST2TestBase {
 	public void testBug157009_2() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#ifndef A\n#error X\n#else\n#error Y\n#endif");
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.CPP, false, false);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.CPP, ScannerKind.STD, false);
 
 		IASTProblem[] problems = tu.getPreprocessorProblems();
 		assertEquals(1, problems.length);
@@ -618,7 +618,7 @@ public class DOMLocationTests extends AST2TestBase {
 		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=171520
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int i = sizeof(int);");
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.CPP, false, false);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.CPP, ScannerKind.STD, false);
 		IASTDeclaration[] decls = tu.getDeclarations();
 		assertEquals(1, decls.length);
 		assertSoleLocation(decls[0], 0, buffer.length());
@@ -646,7 +646,7 @@ public class DOMLocationTests extends AST2TestBase {
 		buffer.append("#unassert thisIsTrue(value)\n");
 		buffer.append("#invalid");
 		String code = buffer.toString();
-		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP, true, false);
+		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP, ScannerKind.GNU, false);
 
 		IASTProblem[] problems = tu.getPreprocessorProblems();
 		assertEquals(3, problems.length);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/DOMPreprocessorInformationTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/DOMPreprocessorInformationTest.java
@@ -95,7 +95,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 	public void testError() throws Exception {
 		String msg = "Message";
 		StringBuilder buffer = new StringBuilder("#error " + msg + "\n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.CPP, false, false);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.CPP, ScannerKind.STD, false);
 		IASTPreprocessorStatement[] st = tu.getAllPreprocessorStatements();
 		assertEquals(1, st.length);
 		assertTrue(st[0] instanceof IASTPreprocessorErrorStatement);
@@ -161,7 +161,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 	public void testErrorWithSpaces() throws Exception {
 		String msg = "Message";
 		StringBuilder buffer = new StringBuilder("#  error \t" + msg + " \n"); //$NON-NLS-1$
-		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.CPP, false, false);
+		IASTTranslationUnit tu = parse(buffer.toString(), ParserLanguage.CPP, ScannerKind.STD, false);
 		IASTPreprocessorStatement[] st = tu.getAllPreprocessorStatements();
 		assertEquals(1, st.length);
 		assertTrue(st[0] instanceof IASTPreprocessorErrorStatement);
@@ -175,7 +175,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 		sb.append("int x = add(foo, bar); \n");
 		String code = sb.toString();
 
-		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP, false, false);
+		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP, ScannerKind.STD, false);
 		IASTPreprocessorStatement[] st = tu.getAllPreprocessorStatements();
 		assertEquals(1, st.length);
 		assertTrue(st[0] instanceof IASTPreprocessorFunctionStyleMacroDefinition);
@@ -193,7 +193,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 	// #endif
 	public void testElifWithoutCondition_bug185324() throws Exception {
 		CharSequence code = getContents(1)[0];
-		IASTTranslationUnit tu = parse(code.toString(), ParserLanguage.CPP, false, false);
+		IASTTranslationUnit tu = parse(code.toString(), ParserLanguage.CPP, ScannerKind.STD, false);
 		IASTPreprocessorStatement[] st = tu.getAllPreprocessorStatements();
 		assertEquals(3, st.length);
 		assertTrue(st[0] instanceof IASTPreprocessorIfdefStatement);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/FaultToleranceTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/FaultToleranceTests.java
@@ -55,7 +55,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	public void testCompositeTypeWithoutSemi() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTCompositeTypeSpecifier def = getCompositeType(tu, 1);
 			IASTProblemDeclaration pdecl = getDeclaration(tu, 2);
 			IASTSimpleDeclaration sdecl = getDeclaration(tu, 3);
@@ -70,7 +70,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	public void testCompositeTypeWithDtorWithoutSemi() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTSimpleDeclaration sdecl = getDeclaration(tu, 1);
 			assertInstance(sdecl.getDeclSpecifier(), IASTCompositeTypeSpecifier.class);
 			assertEquals(1, sdecl.getDeclarators().length);
@@ -85,7 +85,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	public void testVariableWithoutSemi() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTSimpleDeclaration sdecl = getDeclaration(tu, 1);
 			assertEquals("int a", sdecl.getRawSignature());
 			IASTProblemDeclaration pdecl = getDeclaration(tu, 2);
@@ -99,7 +99,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	public void testPrototypeWithoutSemi() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTSimpleDeclaration sdecl = getDeclaration(tu, 1);
 			assertEquals("int a()", sdecl.getRawSignature());
 			IASTProblemDeclaration pdecl = getDeclaration(tu, 2);
@@ -114,7 +114,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	public void testExpressionWithoutSemi_314593() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTFunctionDefinition fdef = getDeclaration(tu, 0);
 			IASTStatement stmt = getStatement(fdef, 0);
 			assertEquals("int a= 1", stmt.getRawSignature());
@@ -130,7 +130,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	public void testIncompleteCompositeType() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTCompositeTypeSpecifier comp = getCompositeType(tu, 0);
 			IASTProblemDeclaration pdecl = getDeclaration(tu, 1);
 
@@ -143,7 +143,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	public void testIncompleteFunctionDefinition() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTFunctionDefinition fdef = getDeclaration(tu, 0);
 			IASTProblemDeclaration pdecl = getDeclaration(tu, 1);
 
@@ -155,7 +155,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	//   int a;
 	public void testIncompleteNamespace() throws Exception {
 		final String comment = getAboveComment();
-		IASTTranslationUnit tu = parse(comment, ParserLanguage.CPP, false, false);
+		IASTTranslationUnit tu = parse(comment, ParserLanguage.CPP, ScannerKind.STD, false);
 		ICPPASTNamespaceDefinition ns = getDeclaration(tu, 0);
 		IASTProblemDeclaration pdecl = getDeclaration(tu, 1);
 
@@ -166,7 +166,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	//   int a;
 	public void testIncompleteLinkageSpec() throws Exception {
 		final String comment = getAboveComment();
-		IASTTranslationUnit tu = parse(comment, ParserLanguage.CPP, false, false);
+		IASTTranslationUnit tu = parse(comment, ParserLanguage.CPP, ScannerKind.STD, false);
 		ICPPASTLinkageSpecification ls = getDeclaration(tu, 0);
 		IASTProblemDeclaration pdecl = getDeclaration(tu, 1);
 
@@ -179,7 +179,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	public void testRangeOfProblemNode_Bug238151() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTFunctionDefinition fdef = getDeclaration(tu, 0);
 			IASTProblemStatement pdecl = getStatement(fdef, 0);
 			assertEquals("int a= offsetof(struct mystruct, singlechar);", pdecl.getRawSignature());
@@ -194,7 +194,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	public void testProblemInIfExpression_Bug100321() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTFunctionDefinition fdef = getDeclaration(tu, 0);
 			IASTIfStatement ifstmt = getStatement(fdef, 0);
 			assertInstance(ifstmt.getConditionExpression(), IASTProblemExpression.class);
@@ -209,7 +209,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	public void testUndefinedMacrosInFunctionDeclarations_Bug234085() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTProblemDeclaration pd = getDeclaration(tu, 0);
 			assertEquals("_MYMACRO_", pd.getRawSignature());
 			IASTSimpleDeclaration sdecl = getDeclaration(tu, 1);
@@ -239,7 +239,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	public void testEnumProblem() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
-			IASTTranslationUnit tu = parse(comment, lang, false, false);
+			IASTTranslationUnit tu = parse(comment, lang, ScannerKind.STD, false);
 			IASTSimpleDeclaration e = getDeclaration(tu, 0);
 			IASTProblemDeclaration p = getDeclaration(tu, 1);
 			assertEquals("J, K };", p.getRawSignature());
@@ -254,7 +254,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	// };
 	public void testEnumError_Bug72685() throws Exception {
 		final String comment = getAboveComment();
-		IASTTranslationUnit tu = parse(comment, ParserLanguage.CPP, false, false);
+		IASTTranslationUnit tu = parse(comment, ParserLanguage.CPP, ScannerKind.STD, false);
 		IASTCompositeTypeSpecifier ct = getCompositeType(tu, 0);
 		IASTSimpleDeclaration e = getDeclaration(ct, 0);
 		IASTProblemDeclaration p = getDeclaration(ct, 1);
@@ -269,12 +269,12 @@ public class FaultToleranceTests extends AST2TestBase {
 	//	);
 	//	int d;
 	public void testErrorRecovery_273759() throws Exception {
-		IASTTranslationUnit tu = parse(getAboveComment(), ParserLanguage.C, false, false);
+		IASTTranslationUnit tu = parse(getAboveComment(), ParserLanguage.C, ScannerKind.STD, false);
 		IASTSimpleDeclaration s = getDeclaration(tu, 0);
 		IASTProblemDeclaration p = getDeclaration(tu, 1);
 		s = getDeclaration(tu, 2);
 
-		tu = parse(getAboveComment(), ParserLanguage.CPP, false, false);
+		tu = parse(getAboveComment(), ParserLanguage.CPP, ScannerKind.STD, false);
 		s = getDeclaration(tu, 0);
 		p = getDeclaration(tu, 1);
 		s = getDeclaration(tu, 2);
@@ -313,7 +313,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	//	    }
 	public void testPerformanceIssue_364108() throws Exception {
 		final String comment = getAboveComment();
-		parse(comment, ParserLanguage.CPP, false, false);
-		parse(comment, ParserLanguage.C, false, false);
+		parse(comment, ParserLanguage.CPP, ScannerKind.STD, false);
+		parse(comment, ParserLanguage.C, ScannerKind.STD, false);
 	}
 }

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/GCCCompleteParseExtensionsTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/GCCCompleteParseExtensionsTest.java
@@ -44,7 +44,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 	}
 
 	private IASTTranslationUnit parseGCC(String code) throws ParserException {
-		IASTTranslationUnit tu = parse(code, ParserLanguage.C, true, true);
+		IASTTranslationUnit tu = parse(code, ParserLanguage.C, ScannerKind.GNU, true);
 
 		CNameResolver resolver = new CNameResolver();
 		tu.accept(resolver);
@@ -56,7 +56,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 	}
 
 	private IASTTranslationUnit parseGPP(String code) throws ParserException {
-		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP, true, true);
+		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP, ScannerKind.GNU, true);
 
 		CPPNameResolver resolver = new CPPNameResolver();
 		tu.accept(resolver);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/TaskParserTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/TaskParserTest.java
@@ -39,7 +39,7 @@ public class TaskParserTest extends AST2TestBase {
 		String code = "/* TODO tag 1\n" + " * FIXME   tag 2\n" + " */\n" + "\n" + "// TODO(my name): tag 3\n"
 				+ "// TODO(his name): tag 4\n" + "// todo Not a tag\n" + "// TODO FIXME tag 5\n" + "\n"
 				+ "const char* x = \"TODO Not a tag\";";
-		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP, false, true);
+		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP, ScannerKind.STD, true);
 		TodoTaskParser parser = new TodoTaskParser(taskTags, taskPriorities, isTaskCaseSensitive);
 		Task[] tasks = parser.parse(tu.getComments());
 

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/VariableReadWriteFlagsTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/VariableReadWriteFlagsTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.Optional;
 
 import org.eclipse.cdt.core.dom.ast.IASTName;
+import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.internal.core.dom.parser.c.CVariableReadWriteFlags;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.CPPVariableReadWriteFlags;
 import org.eclipse.cdt.internal.core.parser.ParserException;
@@ -34,6 +35,10 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 	protected class AssertionHelper extends AST2AssertionHelper {
 		AssertionHelper(String contents, boolean isCPP) throws ParserException {
 			super(contents, isCPP);
+		}
+
+		AssertionHelper(String contents, ParserLanguage lang, ScannerKind scannerKind) throws ParserException {
+			super(contents, lang, scannerKind);
 		}
 
 		void assertReadWriteFlags(String context, String name, Optional<Integer> expectedFlags) throws Exception {
@@ -95,6 +100,11 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 		return new AssertionHelper(code, true);
 	}
 
+	protected AssertionHelper getCPP20AssertionHelper() throws ParserException, IOException {
+		String code = getAboveComment();
+		return new AssertionHelper(code, ParserLanguage.CPP, ScannerKind.STDCPP20);
+	}
+
 	//	int test(int a) {
 	//	  a = 2;
 	//	  a *= 3;
@@ -105,6 +115,14 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 		a.assertReadWriteFlags("a = 2", "a", WRITE);
 		a.assertReadWriteFlags("a *= 3", "a", READ | WRITE);
 		a.assertReadWriteFlags("a + 1", "a", READ);
+	}
+
+	//	auto test(int a) {
+	//	  return a <=> 1;
+	//	}
+	public void testThreeWayComparisonAccess() throws Exception {
+		AssertionHelper a = getCPP20AssertionHelper();
+		a.assertReadWriteFlags("a <=> 1", "a", READ);
 	}
 
 	//	class C {

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/astwriter/ASTWriterTestSourceFile.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/astwriter/ASTWriterTestSourceFile.java
@@ -15,6 +15,7 @@
 package org.eclipse.cdt.core.parser.tests.rewrite.astwriter;
 
 import org.eclipse.cdt.core.parser.ParserLanguage;
+import org.eclipse.cdt.core.parser.tests.ast2.AST2TestBase.ScannerKind;
 import org.eclipse.cdt.core.parser.tests.rewrite.TestSourceFile;
 
 /**
@@ -22,7 +23,7 @@ import org.eclipse.cdt.core.parser.tests.rewrite.TestSourceFile;
  */
 public class ASTWriterTestSourceFile extends TestSourceFile {
 	private ParserLanguage parserLanguage = ParserLanguage.CPP;
-	private boolean useGNUExtensions = false;
+	private ScannerKind scannerKind = ScannerKind.STD;
 
 	public ASTWriterTestSourceFile(String name) {
 		super(name);
@@ -36,11 +37,11 @@ public class ASTWriterTestSourceFile extends TestSourceFile {
 		return parserLanguage;
 	}
 
-	public boolean isUseGNUExtensions() {
-		return useGNUExtensions;
+	public ScannerKind getScannerKind() {
+		return scannerKind;
 	}
 
-	public void setUseGNUExtensions(boolean useGNUExtensions) {
-		this.useGNUExtensions = useGNUExtensions;
+	public void setScannerKind(ScannerKind scannerKind) {
+		this.scannerKind = scannerKind;
 	}
 }

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/astwriter/ASTWriterTester.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/astwriter/ASTWriterTester.java
@@ -32,6 +32,7 @@ import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.core.parser.ParserMode;
 import org.eclipse.cdt.core.parser.ScannerInfo;
 import org.eclipse.cdt.core.parser.tests.ast2.AST2TestBase;
+import org.eclipse.cdt.core.parser.tests.ast2.AST2TestBase.ScannerKind;
 import org.eclipse.cdt.core.parser.tests.rewrite.RewriteBaseTest;
 import org.eclipse.cdt.core.parser.tests.rewrite.TestHelper;
 import org.eclipse.cdt.core.parser.tests.rewrite.TestSourceFile;
@@ -94,16 +95,16 @@ public abstract class ASTWriterTester extends RewriteBaseTest {
 	protected ISourceCodeParser getParser(TestSourceFile testFile) throws Exception {
 		FileContent codeReader = FileContent.create(file);
 
-		ScannerInfo scannerInfo = new ScannerInfo();
 		ParserLanguage language = getLanguage(testFile);
-		boolean useGNUExtensions = getGNUExtension(testFile);
+		ScannerKind scannerKind = getScannerKind(testFile);
+		ScannerInfo scannerInfo = AST2TestBase.createScannerInfo(scannerKind);
 
 		IScanner scanner = AST2TestBase.createScanner(codeReader, language, ParserMode.COMPLETE_PARSE, scannerInfo);
 
 		ISourceCodeParser parser = null;
 		if (language == ParserLanguage.CPP) {
 			ICPPParserExtensionConfiguration config = null;
-			if (useGNUExtensions) {
+			if (scannerKind.isUseGNUExtensions()) {
 				config = new GPPParserExtensionConfiguration();
 			} else {
 				config = new ANSICPPParserExtensionConfiguration();
@@ -112,7 +113,7 @@ public abstract class ASTWriterTester extends RewriteBaseTest {
 		} else {
 			ICParserExtensionConfiguration config = null;
 
-			if (useGNUExtensions) {
+			if (scannerKind.isUseGNUExtensions()) {
 				config = new GCCParserExtensionConfiguration();
 			} else {
 				config = new ANSICParserExtensionConfiguration();
@@ -123,10 +124,10 @@ public abstract class ASTWriterTester extends RewriteBaseTest {
 		return parser;
 	}
 
-	private boolean getGNUExtension(TestSourceFile file) {
+	private ScannerKind getScannerKind(TestSourceFile file) {
 		if (file instanceof ASTWriterTestSourceFile)
-			return ((ASTWriterTestSourceFile) file).isUseGNUExtensions();
-		return false;
+			return ((ASTWriterTestSourceFile) file).getScannerKind();
+		return ScannerKind.STD;
 	}
 
 	private ParserLanguage getLanguage(TestSourceFile file) {

--- a/core/org.eclipse.cdt.core.tests/resources/rewrite/ASTWriterExpressionTestSource.awts
+++ b/core/org.eclipse.cdt.core.tests/resources/rewrite/ASTWriterExpressionTestSource.awts
@@ -84,6 +84,10 @@ bool b = 1 != x;
 int i = a.x;
 int i = a->x;
 
+//!CPP20BinaryExpression
+//%CPP20
+auto r = x <=> y;
+
 //!BinaryExpression with MacroExpansions
 //%CPP
 #define ZWO 2

--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core; singleton:=true
-Bundle-Version: 8.0.100.qualifier
+Bundle-Version: 8.1.0.qualifier
 Bundle-Activator: org.eclipse.cdt.core.CCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core/model/org/eclipse/cdt/internal/core/model/ASTStringUtil.java
+++ b/core/org.eclipse.cdt.core/model/org/eclipse/cdt/internal/core/model/ASTStringUtil.java
@@ -1167,6 +1167,8 @@ public class ASTStringUtil {
 			return Keywords.cpEQUAL;
 		case IASTBinaryExpression.op_notequals:
 			return Keywords.cpNOTEQUAL;
+		case IASTBinaryExpression.op_threewaycomparison:
+			return Keywords.cpTHREEWAYCOMPARISON;
 		case IASTBinaryExpression.op_max:
 			return Keywords.cpMAX;
 		case IASTBinaryExpression.op_min:

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/ASTSignatureUtil.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/ASTSignatureUtil.java
@@ -1311,6 +1311,9 @@ public class ASTSignatureUtil {
 		case IASTBinaryExpression.op_notequals:
 			opString = String.valueOf(Keywords.cpNOTEQUAL);
 			break;
+		case IASTBinaryExpression.op_threewaycomparison:
+			opString = String.valueOf(Keywords.cpTHREEWAYCOMPARISON);
+			break;
 		case IASTBinaryExpression.op_max:
 			opString = String.valueOf(Keywords.cpMAX);
 			break;

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/IASTBinaryExpression.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/IASTBinaryExpression.java
@@ -227,6 +227,13 @@ public interface IASTBinaryExpression extends IASTExpression {
 	public static final int op_ellipses = 34;
 
 	/**
+	 * For c++, only.
+	 * <code>op_threewaycompare</code> represents <code><=></code> three-way comparison operator.
+	 * @since 8.0
+	 */
+	public static final int op_threewaycomparison = 35;
+
+	/**
 	 * Get the first operand.
 	 *
 	 * @return <code>IASTExpression</code> representing operand 1.

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/IASTBinaryExpression.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/IASTBinaryExpression.java
@@ -229,7 +229,7 @@ public interface IASTBinaryExpression extends IASTExpression {
 	/**
 	 * For c++, only.
 	 * <code>op_threewaycompare</code> represents <code><=></code> three-way comparison operator.
-	 * @since 8.0
+	 * @since 8.1
 	 */
 	public static final int op_threewaycomparison = 35;
 

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/parser/IToken.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/parser/IToken.java
@@ -85,6 +85,8 @@ public interface IToken {
 	int tNOTEQUAL = 35;
 	int tNOT = 36;
 	int tEQUAL = 37;
+	/** @since 8.0 */
+	int tTHREEWAYCOMPARISON = 8001;
 	int tASSIGN = 38;
 	int tUNKNOWN_CHAR = 39;
 	int tSHIFTL = 40;

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/parser/IToken.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/parser/IToken.java
@@ -85,7 +85,7 @@ public interface IToken {
 	int tNOTEQUAL = 35;
 	int tNOT = 36;
 	int tEQUAL = 37;
-	/** @since 8.0 */
+	/** @since 8.1 */
 	int tTHREEWAYCOMPARISON = 8001;
 	int tASSIGN = 38;
 	int tUNKNOWN_CHAR = 39;

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/parser/Keywords.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/parser/Keywords.java
@@ -279,6 +279,7 @@ public class Keywords {
 	public static final char[] cpNOTEQUAL = "!=".toCharArray();
 	public static final char[] cpNOT = "!".toCharArray();
 	public static final char[] cpEQUAL = "==".toCharArray();
+	public static final char[] cpTHREEWAYCOMPARISON = "<=>".toCharArray();
 	public static final char[] cpASSIGN = "=".toCharArray();
 	public static final char[] cpSHIFTL = "<<".toCharArray();
 	public static final char[] cpLTEQUAL = "<=".toCharArray();

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/parser/Keywords.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/parser/Keywords.java
@@ -279,6 +279,7 @@ public class Keywords {
 	public static final char[] cpNOTEQUAL = "!=".toCharArray();
 	public static final char[] cpNOT = "!".toCharArray();
 	public static final char[] cpEQUAL = "==".toCharArray();
+	/** @since 8.1 */
 	public static final char[] cpTHREEWAYCOMPARISON = "<=>".toCharArray();
 	public static final char[] cpASSIGN = "=".toCharArray();
 	public static final char[] cpSHIFTL = "<<".toCharArray();

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/ASTAmbiguousBinaryVsCastExpression.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/ASTAmbiguousBinaryVsCastExpression.java
@@ -224,19 +224,21 @@ public abstract class ASTAmbiguousBinaryVsCastExpression extends ASTAmbiguousNod
 		case IASTBinaryExpression.op_max:
 		case IASTBinaryExpression.op_min:
 			return 7;
+		case IASTBinaryExpression.op_threewaycomparison:
+			return 8;
 		case IASTBinaryExpression.op_shiftLeft:
 		case IASTBinaryExpression.op_shiftRight:
-			return 8;
+			return 9;
 		case IASTBinaryExpression.op_plus:
 		case IASTBinaryExpression.op_minus:
-			return 9;
+			return 10;
 		case IASTBinaryExpression.op_multiply:
 		case IASTBinaryExpression.op_divide:
 		case IASTBinaryExpression.op_modulo:
-			return 10;
+			return 11;
 		case IASTBinaryExpression.op_pmarrow:
 		case IASTBinaryExpression.op_pmdot:
-			return 11;
+			return 12;
 		}
 		assert false;
 		return 0;

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/AbstractGNUSourceCodeParser.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/AbstractGNUSourceCodeParser.java
@@ -1123,6 +1123,9 @@ public abstract class AbstractGNUSourceCodeParser implements ISourceCodeParser {
 		case IToken.tNOTEQUAL:
 			op = IASTBinaryExpression.op_notequals;
 			break;
+		case IToken.tTHREEWAYCOMPARISON:
+			op = IASTBinaryExpression.op_threewaycomparison;
+			break;
 		case IToken.tGT:
 			op = IASTBinaryExpression.op_greaterThan;
 			break;
@@ -2731,6 +2734,7 @@ public abstract class AbstractGNUSourceCodeParser implements ISourceCodeParser {
 			case IToken.tDOT:
 			case IToken.tDOTSTAR:
 			case IToken.tEQUAL:
+			case IToken.tTHREEWAYCOMPARISON:
 			case IToken.tGT:
 			case IToken.tGT_in_SHIFTR:
 			case IToken.tGTEQUAL:

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/ValueFactory.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/ValueFactory.java
@@ -226,6 +226,7 @@ public class ValueFactory {
 			break;
 		case IASTBinaryExpression.op_threewaycomparison:
 			// TODO: implement for <=>
+			value = v1 < v2 ? -1l : (v1 > v2 ? 1l : 0);
 			break;
 		case IASTBinaryExpression.op_binaryAnd:
 			value = v1 & v2;

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/ValueFactory.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/ValueFactory.java
@@ -224,6 +224,9 @@ public class ValueFactory {
 		case IASTBinaryExpression.op_greaterEqual:
 			value = v1 >= v2 ? 1l : 0l;
 			break;
+		case IASTBinaryExpression.op_threewaycomparison:
+			// TODO: implement for <=>
+			break;
 		case IASTBinaryExpression.op_binaryAnd:
 			value = v1 & v2;
 			break;

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/VariableReadWriteFlags.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/VariableReadWriteFlags.java
@@ -439,6 +439,7 @@ public abstract class VariableReadWriteFlags {
 		case IASTBinaryExpression.op_notequals:
 		case IASTBinaryExpression.op_shiftLeft:
 		case IASTBinaryExpression.op_shiftRight:
+		case IASTBinaryExpression.op_threewaycomparison:
 			return Optional.of(READ);
 
 		case IASTBinaryExpression.op_minus:

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/c/CASTBinaryExpression.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/c/CASTBinaryExpression.java
@@ -234,6 +234,10 @@ public class CASTBinaryExpression extends ASTNode implements IASTBinaryExpressio
 		case op_notequals:
 			return new CBasicType(Kind.eInt, 0, this);
 
+		case op_threewaycomparison:
+			// TODO: implement for <=>
+			break;
+
 		case IASTBinaryExpression.op_plus:
 			if (type1 instanceof IArrayType) {
 				return Conversions.arrayTypeToPointerType((ICArrayType) type1);

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/c/GNUCSourceParser.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/c/GNUCSourceParser.java
@@ -548,6 +548,7 @@ public class GNUCSourceParser extends AbstractGNUSourceCodeParser {
 				break;
 			case IToken.tEQUAL:
 			case IToken.tNOTEQUAL:
+			case IToken.tTHREEWAYCOMPARISON:
 				lastOperator = new BinaryOperator(lastOperator, lastExpression, lt1, 80, 81);
 				break;
 			case IToken.tGT:

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/c/GNUCSourceParser.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/c/GNUCSourceParser.java
@@ -548,7 +548,6 @@ public class GNUCSourceParser extends AbstractGNUSourceCodeParser {
 				break;
 			case IToken.tEQUAL:
 			case IToken.tNOTEQUAL:
-			case IToken.tTHREEWAYCOMPARISON:
 				lastOperator = new BinaryOperator(lastOperator, lastExpression, lt1, 80, 81);
 				break;
 			case IToken.tGT:

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/GNUCPPSourceParser.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/GNUCPPSourceParser.java
@@ -1106,7 +1106,6 @@ public class GNUCPPSourceParser extends AbstractGNUSourceCodeParser {
 				break;
 			case IToken.tEQUAL:
 			case IToken.tNOTEQUAL:
-			case IToken.tTHREEWAYCOMPARISON:
 				lastOperator = new BinaryOperator(lastOperator, expr, lt1, 80, 81);
 				break;
 			case IToken.tGT:
@@ -1121,6 +1120,9 @@ public class GNUCPPSourceParser extends AbstractGNUSourceCodeParser {
 			case IGCCToken.tMAX:
 			case IGCCToken.tMIN:
 				lastOperator = new BinaryOperator(lastOperator, expr, lt1, 90, 91);
+				break;
+			case IToken.tTHREEWAYCOMPARISON:
+				lastOperator = new BinaryOperator(lastOperator, expr, lt1, 95, 96);
 				break;
 			case IToken.tGT_in_SHIFTR:
 				if (ctx == BinaryExprCtx.eInTemplateID) {

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/GNUCPPSourceParser.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/GNUCPPSourceParser.java
@@ -1106,6 +1106,7 @@ public class GNUCPPSourceParser extends AbstractGNUSourceCodeParser {
 				break;
 			case IToken.tEQUAL:
 			case IToken.tNOTEQUAL:
+			case IToken.tTHREEWAYCOMPARISON:
 				lastOperator = new BinaryOperator(lastOperator, expr, lt1, 80, 81);
 				break;
 			case IToken.tGT:

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/OverloadableOperator.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/OverloadableOperator.java
@@ -34,9 +34,9 @@ public enum OverloadableOperator {
 	GT(">"), LT("<"), NOT("!"), BITCOMPLEMENT("~"), BITOR("|"), AMPER("&"), XOR("^"), MOD("%"), DIV("/"), STAR("*"),
 	PLUS("+"), BRACKET("[]"), PAREN("()"), ARROW("->"), ARROWSTAR("->*"), COMMA(","), MINUS("-"), DECR("--"),
 	INCR("++"), OR("||"), AND("&&"), ASSIGN("="), GTEQUAL(">="), LTEQUAL("<="), NOTEQUAL("!="), EQUAL("=="),
-	SHIFTR(">>"), SHIFTL("<<"), SHIFTLASSIGN("<<="), SHIFTRASSIGN(">>="), BITORASSIGN("|="), AMPERASSIGN("&="),
-	XORASSIGN("^="), MODASSIGN("%="), DIVASSIGN("/="), STARASSIGN("*="), MINUSASSIGN("-="), PLUSASSIGN("+="),
-	NEW("new"), DELETE_ARRAY("delete[]"), DELETE("delete"), NEW_ARRAY("new[]"),
+	SHIFTR(">>"), SHIFTL("<<"), SHIFTLASSIGN("<<="), SHIFTRASSIGN(">>="), THREEWAYCOMPARISON("<=>"), BITORASSIGN("|="),
+	AMPERASSIGN("&="), XORASSIGN("^="), MODASSIGN("%="), DIVASSIGN("/="), STARASSIGN("*="), MINUSASSIGN("-="),
+	PLUSASSIGN("+="), NEW("new"), DELETE_ARRAY("delete[]"), DELETE("delete"), NEW_ARRAY("new[]"),
 
 	/**
 	 * Cannot be overloaded by the user, however overload resolution needs to be performed.
@@ -155,6 +155,8 @@ public enum OverloadableOperator {
 			return LT;
 		case IToken.tLTEQUAL:
 			return LTEQUAL;
+		case IToken.tTHREEWAYCOMPARISON:
+			return THREEWAYCOMPARISON;
 
 		// other
 		case IToken.tASSIGN:
@@ -247,6 +249,8 @@ public enum OverloadableOperator {
 			return LT;
 		case IASTBinaryExpression.op_lessEqual:
 			return LTEQUAL;
+		case IASTBinaryExpression.op_threewaycomparison:
+			return THREEWAYCOMPARISON;
 
 		// other
 		case IASTBinaryExpression.op_assign:

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/BuiltinOperators.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/BuiltinOperators.java
@@ -167,6 +167,10 @@ class BuiltinOperators {
 			comparison(true);
 			break;
 
+		case THREEWAYCOMPARISON:
+			// TODO: implement for <=>
+			break;
+
 		case GT:
 		case GTEQUAL:
 		case LT:

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/EvalBinary.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/EvalBinary.java
@@ -45,6 +45,7 @@ import static org.eclipse.cdt.core.dom.ast.IASTBinaryExpression.op_shiftLeft;
 import static org.eclipse.cdt.core.dom.ast.IASTBinaryExpression.op_shiftLeftAssign;
 import static org.eclipse.cdt.core.dom.ast.IASTBinaryExpression.op_shiftRight;
 import static org.eclipse.cdt.core.dom.ast.IASTBinaryExpression.op_shiftRightAssign;
+import static org.eclipse.cdt.core.dom.ast.IASTBinaryExpression.op_threewaycomparison;
 import static org.eclipse.cdt.core.dom.ast.IASTExpression.ValueCategory.LVALUE;
 import static org.eclipse.cdt.core.dom.ast.IASTExpression.ValueCategory.PRVALUE;
 import static org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.ExpressionTypes.glvalueType;
@@ -387,6 +388,10 @@ public class EvalBinary extends CPPDependentEvaluation {
 		case op_equals:
 		case op_notequals:
 			return CPPBasicType.BOOLEAN;
+
+		case op_threewaycomparison:
+			// TODO: implement for <=>
+			return ProblemType.UNKNOWN_FOR_EXPRESSION;
 
 		case op_plus:
 			if (type1 instanceof IPointerType) {

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/rewrite/astwriter/ExpressionWriter.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/rewrite/astwriter/ExpressionWriter.java
@@ -91,6 +91,7 @@ public class ExpressionWriter extends NodeWriter {
 	private static final String ELLIPSES = " ... "; //$NON-NLS-1$
 	private static final String NOT_EQUALS_OP = " != "; //$NON-NLS-1$
 	private static final String EQUALS_OP = " == "; //$NON-NLS-1$
+	private static final String THREEWAYCOMPARISON_OP = " <=> "; //$NON-NLS-1$
 	private static final String BINARY_OR_ASSIGN = " |= "; //$NON-NLS-1$
 	private static final String BINARY_XOR_ASSIGN_OP = " ^= "; //$NON-NLS-1$
 	private static final String BINARY_AND_ASSIGN_OP = " &= "; //$NON-NLS-1$
@@ -226,6 +227,8 @@ public class ExpressionWriter extends NodeWriter {
 			return EQUALS_OP;
 		case IASTBinaryExpression.op_notequals:
 			return NOT_EQUALS_OP;
+		case IASTBinaryExpression.op_threewaycomparison:
+			return THREEWAYCOMPARISON_OP;
 		case ICPPASTBinaryExpression.op_pmdot:
 			return PMDOT_OP;
 		case ICPPASTBinaryExpression.op_pmarrow:

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/parser/scanner/CPreprocessor.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/parser/scanner/CPreprocessor.java
@@ -99,6 +99,7 @@ public class CPreprocessor implements ILexerLog, IScanner, IAdaptable {
 	private static final int ORIGIN_INACTIVE_CODE = OffsetLimitReachedException.ORIGIN_INACTIVE_CODE;
 
 	private static final char[] ONE = "1".toCharArray(); //$NON-NLS-1$
+	private static final char[] CPP_IMPL_THREE_WAY_COMPARISON = "__cpp_impl_three_way_comparison".toCharArray(); //$NON-NLS-1$
 
 	// Standard built-ins
 	private static final ObjectStyleMacro __CDT_PARSER__ = new ObjectStyleMacro("__CDT_PARSER__".toCharArray(), //$NON-NLS-1$
@@ -351,6 +352,10 @@ public class CPreprocessor implements ILexerLog, IScanner, IAdaptable {
 		}
 		fIncludeSearchPath = configureIncludeSearchPath(new File(contextPath).getParentFile(), info);
 		setupMacroDictionary(configuration, info, language);
+
+		if (fMacroDictionary.containsKey(CPP_IMPL_THREE_WAY_COMPARISON)) {
+			fLexOptions.fSupportThreeWayComparisonOperator = true;
+		}
 
 		ILocationCtx ctx = fLocationMap.pushTranslationUnit(fRootContent.getFileLocation(), fRootContent.getSource());
 		Lexer lexer = new Lexer(fRootContent.getSource(), fLexOptions, this, this);

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/parser/scanner/Lexer.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/parser/scanner/Lexer.java
@@ -63,6 +63,7 @@ final public class Lexer implements ITokenSequence {
 		public boolean fSupportRawStringLiterals = false;
 		public boolean fSupportUserDefinedLiterals = false;
 		public boolean fSupportDigitSeparators = false;
+		public boolean fSupportThreeWayComparisonOperator = false;
 		public IncludeExportPatterns fIncludeExportPatterns;
 
 		@Override
@@ -641,7 +642,13 @@ final public class Lexer implements ITokenSequence {
 
 				switch (d) {
 				case '=':
-					nextCharPhase3();
+					final int se = nextCharPhase3();
+					if (fOptions.fSupportThreeWayComparisonOperator) {
+						if (se == '>') {
+							nextCharPhase3();
+							return newToken(IToken.tTHREEWAYCOMPARISON, start);
+						}
+					}
 					return newToken(IToken.tLTEQUAL, start);
 				case '<':
 					final int e = nextCharPhase3();

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/parser/scanner/TokenUtil.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/parser/scanner/TokenUtil.java
@@ -78,6 +78,7 @@ public class TokenUtil {
 		case IToken.tGTEQUAL:
 		case IToken.tLT:
 		case IToken.tLTEQUAL:
+		case IToken.tTHREEWAYCOMPARISON:
 
 			// other
 		case IToken.tASSIGN:
@@ -164,6 +165,8 @@ public class TokenUtil {
 			return Keywords.cpNOT;
 		case IToken.tEQUAL:
 			return Keywords.cpEQUAL;
+		case IToken.tTHREEWAYCOMPARISON:
+			return Keywords.cpTHREEWAYCOMPARISON;
 		case IToken.tASSIGN:
 			return Keywords.cpASSIGN;
 		case IToken.tSHIFTL:

--- a/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/debug/dwarf/DwarfConstants.java
+++ b/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/debug/dwarf/DwarfConstants.java
@@ -209,7 +209,7 @@ public class DwarfConstants {
 	 */
 	public final static int DW_FORM_flag_present = 0x19;
 	/**
-	 * @since 8.0
+	 * @since 8.1
 	 */
 	public final static int DW_FORM_line_strp = 0x1f;
 	/**

--- a/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/refactoring/includes/BindingClassifier.java
+++ b/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/refactoring/includes/BindingClassifier.java
@@ -650,6 +650,11 @@ public class BindingClassifier {
 						}
 					}
 
+					if (binaryExpression.getOperator() == IASTBinaryExpression.op_threewaycomparison) {
+						// TODO: implement for three-way comparison operator x <=> y
+						return PROCESS_CONTINUE;
+					}
+
 					IType operand1Type = binaryExpression.getOperand1().getExpressionType();
 					IASTInitializerClause operand2 = binaryExpression.getInitOperand2();
 					IType operand2Type;


### PR DESCRIPTION
This adds initial support for `operator<=>`, corresponding Lexer option is enabled if `__cpp_impl_three_way_comparison` feature-test macro is found.

Support is very rudimentary (e.g. return type deduction is not implemented, expression evaluation is not handled etc..)