### PR TITLE
Comment listing #warning as an extension is not up-to-date

### DIFF
--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core; singleton:=true
-Bundle-Version: 8.0.0.qualifier
+Bundle-Version: 8.0.100.qualifier
 Bundle-Activator: org.eclipse.cdt.core.CCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/parser/IPreprocessorDirective.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/parser/IPreprocessorDirective.java
@@ -100,7 +100,7 @@ public interface IPreprocessorDirective {
 	public static final int ppImport = 12;
 
 	/**
-	 * GNU preprocessor extension <code>#warning</code>.
+	 * C23 and C++23 preprocessor directive <code>#warning</code>.
 	 * Similar to <code>#error</code>.
 	 */
 	public static final int ppWarning = 13;


### PR DESCRIPTION
Small patch to rewrite a comment in IPreprocessorDirective in light of C23 and C++23