### PR TITLE
Re-read the makefile targets when a project becomes eligible

### DIFF
--- a/build/org.eclipse.cdt.make.core/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.make.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.make.core; singleton:=true
-Bundle-Version: 7.6.0.qualifier
+Bundle-Version: 7.6.100.qualifier
 Bundle-Activator: org.eclipse.cdt.make.core.MakeCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/build/org.eclipse.cdt.make.core/src/org/eclipse/cdt/make/internal/core/MakeTargetManager.java
+++ b/build/org.eclipse.cdt.make.core/src/org/eclipse/cdt/make/internal/core/MakeTargetManager.java
@@ -259,6 +259,8 @@ public class MakeTargetManager implements IMakeTargetManager, IResourceChangeLis
 				if (deltaKind == IResourceDelta.ADDED) {
 					if (hasTargetBuilder(project) && !fProjects.contains(project)) {
 						fProjects.add(project);
+						// Need to re-read the target settings, clear the cached version
+						projectMap.remove(project);
 						notifyListeners(
 								new MakeTargetEvent(MakeTargetManager.this, MakeTargetEvent.PROJECT_ADDED, project));
 					}
@@ -278,6 +280,8 @@ public class MakeTargetManager implements IMakeTargetManager, IResourceChangeLis
 									project));
 						} else if (!fProjects.contains(project) && hasTargetBuilder(project)) {
 							fProjects.add(project);
+							// Need to re-read the target settings, clear the cached version
+							projectMap.remove(project);
 							notifyListeners(new MakeTargetEvent(MakeTargetManager.this, MakeTargetEvent.PROJECT_ADDED,
 									project));
 						}
@@ -290,6 +294,8 @@ public class MakeTargetManager implements IMakeTargetManager, IResourceChangeLis
 									project));
 						} else if (project.isOpen() && hasTargetBuilder(project) && !fProjects.contains(project)) {
 							fProjects.add(project);
+							// Need to re-read the target settings, clear the cached version
+							projectMap.remove(project);
 							notifyListeners(new MakeTargetEvent(MakeTargetManager.this, MakeTargetEvent.PROJECT_ADDED,
 									project));
 						}


### PR DESCRIPTION
Without this change when the project is not a "hasTargetBuilder" then the projectMap will contain an entry mapping the project to an empty set of makefile targets. So when we get a project added, make sure to re-read the target settings by clearing the cached versions.

Fixes #244