### PR TITLE
Fix broken composites on archive.eclipse.org

### DIFF
--- a/releng/download/releases/9.4/compositeArtifacts.xml
+++ b/releng/download/releases/9.4/compositeArtifacts.xml
@@ -5,7 +5,7 @@
   <properties size='1'>
     <property name='p2.timestamp' value='1673888544650'/>
   </properties>
-  <children size='5'>
+  <children size='2'>
     <child location='../../launchbar/oxygen.2'/>
     <child location='cdt-9.4.3'/>
   </children>


### PR DESCRIPTION
This is a fixup on the previous fix. Although p2 doesn't use the "size" property, it is good form to have it correct.

Fixes #235