### PR TITLE
Handle case where AST name has no location

### DIFF
--- a/debug/org.eclipse.cdt.debug.ui/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.cdt.debug.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.ui; singleton:=true
-Bundle-Version: 8.5.0.qualifier
+Bundle-Version: 8.5.100.qualifier
 Bundle-Activator: org.eclipse.cdt.debug.ui.CDebugUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.cdt.debug.ui/src/org/eclipse/cdt/debug/ui/editors/AbstractDebugTextHover.java
+++ b/debug/org.eclipse.cdt.debug.ui/src/org/eclipse/cdt/debug/ui/editors/AbstractDebugTextHover.java
@@ -347,6 +347,25 @@ public abstract class AbstractDebugTextHover implements ICEditorTextHover, IText
 							if (nameOffset < startOffset && nameOffset > macroOffset) {
 								startOffset = nameOffset;
 							}
+						} else if (name.getNodeLocations() != null && name.getNodeLocations().length == 1
+								&& name.getNodeLocations()[0] instanceof IASTMacroExpansionLocation expansionLocation) {
+							// Node is completely generated within a macro expansion
+							IASTPreprocessorMacroExpansion expansion = expansionLocation.getExpansion();
+							if (expansion != null) {
+								IASTName[] nestedMacroReferences = expansion.getNestedMacroReferences();
+
+								if (nestedMacroReferences != null && nestedMacroReferences.length == 1) {
+									IASTImageLocation imageLocation = nestedMacroReferences[0].getImageLocation();
+
+									if (imageLocation != null) {
+										final int nameOffset = imageLocation.getNodeOffset();
+										// offset should be inside macro expansion
+										if (nameOffset < startOffset && nameOffset > macroOffset) {
+											startOffset = nameOffset;
+										}
+									}
+								}
+							}
 						}
 					}
 				}

--- a/debug/org.eclipse.cdt.debug.ui/src/org/eclipse/cdt/debug/ui/editors/AbstractDebugTextHover.java
+++ b/debug/org.eclipse.cdt.debug.ui/src/org/eclipse/cdt/debug/ui/editors/AbstractDebugTextHover.java
@@ -296,6 +296,9 @@ public abstract class AbstractDebugTextHover implements ICEditorTextHover, IText
 
 			private void computeMacroArgumentExtent(IASTName name, Position pos) {
 				IASTImageLocation imageLoc = name.getImageLocation();
+				if (imageLoc == null) {
+					return;
+				}
 				int startOffset = imageLoc.getNodeOffset();
 				int endOffset = startOffset + imageLoc.getNodeLength();
 				// do some black magic to consider field reference expressions
@@ -314,10 +317,12 @@ public abstract class AbstractDebugTextHover implements ICEditorTextHover, IText
 					if (ownerExpr instanceof IASTIdExpression) {
 						IASTName ownerName = ((IASTIdExpression) ownerExpr).getName();
 						IASTImageLocation ownerImageLoc = ownerName.getImageLocation();
-						final int nameOffset = ownerImageLoc.getNodeOffset();
-						// offset should be inside macro expansion
-						if (nameOffset < startOffset && nameOffset > macroOffset) {
-							startOffset = nameOffset;
+						if (ownerImageLoc != null) {
+							final int nameOffset = ownerImageLoc.getNodeOffset();
+							// offset should be inside macro expansion
+							if (nameOffset < startOffset && nameOffset > macroOffset) {
+								startOffset = nameOffset;
+							}
 						}
 					}
 				}

--- a/debug/org.eclipse.cdt.debug.ui/src/org/eclipse/cdt/debug/ui/editors/AbstractDebugTextHover.java
+++ b/debug/org.eclipse.cdt.debug.ui/src/org/eclipse/cdt/debug/ui/editors/AbstractDebugTextHover.java
@@ -294,6 +294,30 @@ public abstract class AbstractDebugTextHover implements ICEditorTextHover, IText
 				return Status.OK_STATUS;
 			}
 
+			/**
+			 * Attempt to locate extent of the expression that name is part of.
+			 *
+			 * If name is a field or array reference, then try to find the
+			 * parent expression that contains the field.
+			 *
+			 * For example, if name is f and f is a field of a structure, try
+			 * to get the location of the variable containing the field.
+			 *
+			 * Given:
+			 * <pre>
+			 * struct s { int f1234; };
+			 * #define macro(a) a
+			 * struct s myvar;
+			 * macro(myvar.f1234);
+			 * </pre>
+			 *
+			 * if the name is f1234 from the last line, try to get the location
+			 * corresponding to myvar.f1234
+			 *
+			 * @param name the name to find extent for
+			 * @param pos out parameter for the the found position, or untouched
+			 * if no new information is available.
+			 */
 			private void computeMacroArgumentExtent(IASTName name, Position pos) {
 				IASTImageLocation imageLoc = name.getImageLocation();
 				if (imageLoc == null) {


### PR DESCRIPTION
In cases where an IASTName has no image location we were getting NPEs in this code. See javadoc for getImageLocation for cases when image location can be null. See #251's description for a full case of when this can happen.

All other calls to IASTName.getImageLocation in CDT were also checked and this was the only place in the code where the return value was not checked for null.

Fixes #251