### PR TITLE
Fix copyright header typo

### DIFF
--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/EvalPackAccess.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/EvalPackAccess.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2016,2022 Institute for Software, HSR Hochschule fuer Technik and others
+* Copyright (c) 2016,2022 Institute for Software, HSR Hochschule fuer Technik
 * Rapperswil, University of applied sciences and others
 *
 * This program and the accompanying materials


### PR DESCRIPTION
... ` and others` clause is already there on the following line.