### PR TITLE
Prevent CME in LaunchBarManager

### DIFF
--- a/launchbar/org.eclipse.launchbar.core/META-INF/MANIFEST.MF
+++ b/launchbar/org.eclipse.launchbar.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.launchbar.core;singleton:=true
-Bundle-Version: 2.5.0.qualifier
+Bundle-Version: 2.5.100.qualifier
 Bundle-Activator: org.eclipse.launchbar.core.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,


### PR DESCRIPTION
This change synchronizes access to `LaunchBarManager.descriptors`, to avoid a `ConcurrentModificationException` when adding descriptors for 2 launches at the same time.

Fixes: #262