### PR TITLE
Mark DocCommentHighlightingTest as a flaky test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -84,7 +84,7 @@ These tags can only be applied to JUnit5 (aka Jupiter) tests. If a test needs co
 
 ## Converting tests to JUnit5
 
-To take advantage of new features, such as excluding flaky and slow tests, individual tests need to JUnit5 (aka Jupiter). If a test is currently written in JUnit4 or JUnit3 style it needs to be converted to JUnit5 first. Those tests that currently derive from `org.eclipse.cdt.core.testplugin.util.BaseTestCase` can change to `org.eclipse.cdt.core.testplugin.util.BaseTestCase5` and make further adjustments. Common adjustments are:
+To take advantage of new features, such as excluding flaky and slow tests, individual tests need to JUnit5 (aka Jupiter). If a test is currently written in JUnit4 or JUnit3 style it needs to be converted to JUnit5 first. Those tests that currently derive from `org.eclipse.cdt.core.testplugin.util.BaseTestCase` (or `org.eclipse.cdt.ui.tests.BaseUITestCase` for UI tests) can change to `org.eclipse.cdt.core.testplugin.util.BaseTestCase5` (`org.eclipse.cdt.ui.tests.BaseUITestCase5` for UI tests) and make further adjustments. Common adjustments are:
 - refactoring `setUp`/`tearDown` methods to use `@BeforeEach` and `@AfterEach` annotations
 - refactor complicated uses of TestSuites in JUnit3 that were workarounds for the lack of JUnit features like `@BeforeAll` and `@AfterAll`.
 - add `@Test` annotation (make sure to use `org.junit.jupiter.api.Test` and not JUnit4's `org.junit.Test`)

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/BaseUITestCase5.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/BaseUITestCase5.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 Wind River Systems, Inc. and others.
+ * Copyright (c) 2006, 2023 Wind River Systems, Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,11 @@
  *******************************************************************************/
 package org.eclipse.cdt.ui.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +26,7 @@ import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.index.IIndex;
 import org.eclipse.cdt.core.model.CModelException;
 import org.eclipse.cdt.core.model.ICProject;
-import org.eclipse.cdt.core.testplugin.util.BaseTestCase;
+import org.eclipse.cdt.core.testplugin.util.BaseTestCase5;
 import org.eclipse.cdt.core.testplugin.util.TestSourceReader;
 import org.eclipse.cdt.ui.testplugin.CTestPlugin;
 import org.eclipse.cdt.ui.testplugin.util.StringAsserts;
@@ -53,23 +58,14 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.internal.WorkbenchPartReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
-/**
- * @deprecated Use {@link BaseUITestCase5} for new code. See TESTING.md for details on converting to JUnit5
- */
-@Deprecated
-public abstract class BaseUITestCase extends BaseTestCase {
-	public BaseUITestCase() {
-		super();
-	}
+public abstract class BaseUITestCase5 extends BaseTestCase5 {
 
-	public BaseUITestCase(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@BeforeEach
+	protected void setupBaseUI(TestInfo testInfo) throws Exception {
 
 		final IWorkbenchPage activePage = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
 		IViewPart view = activePage.findView("org.eclipse.cdt.ui.tests.DOMAST.DOMAST");
@@ -78,10 +74,9 @@ public abstract class BaseUITestCase extends BaseTestCase {
 		}
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@AfterEach
+	protected void tearDownBaseUI() throws Exception {
 		runEventQueue(0);
-		super.tearDown();
 	}
 
 	/**
@@ -291,8 +286,8 @@ public abstract class BaseUITestCase extends BaseTestCase {
 			}
 			runEventQueue(10);
 		}
-		assertNotNull("No tree in viewpart", tree);
-		assertNotNull("Tree node " + label + "{" + i0 + "} does not exist!", root);
+		assertNotNull(tree, "No tree in viewpart");
+		assertNotNull(root, "Tree node " + label + "{" + i0 + "} does not exist!");
 		assertEquals(label, cands.toString());
 		return root;
 	}
@@ -352,7 +347,7 @@ public abstract class BaseUITestCase extends BaseTestCase {
 		}
 
 		if (label == null) {
-			assertFalse("Tree node {" + i0 + "," + i1 + "} exists but shouldn't!", nodePresent);
+			assertFalse(nodePresent, "Tree node {" + i0 + "," + i1 + "} exists but shouldn't!");
 		} else {
 			fail("Tree node " + label + "{" + i0 + "," + i1 + "} does not exist!");
 		}

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/text/doctools/DocCommentHighlightingTest.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/text/doctools/DocCommentHighlightingTest.java
@@ -80,8 +80,6 @@ public class DocCommentHighlightingTest extends BaseUITestCase {
 	private ICProject fCProject;
 	private final String fTestFilename = "/" + PROJECT + "/src/this.cpp";
 
-	private static SourceViewer fSourceViewer;
-
 	public static Test suite() {
 		return new TestSuite(DocCommentHighlightingTest.class);
 	}
@@ -99,11 +97,11 @@ public class DocCommentHighlightingTest extends BaseUITestCase {
 		preferenceStore.setValue(PreferenceConstants.EDITOR_FOLDING_ENABLED, false);
 		AbstractTextEditor fEditor = (CEditor) EditorTestHelper.openInEditor(ResourceTestHelper.findFile(fTestFilename),
 				true);
-		fSourceViewer = EditorTestHelper.getSourceViewer(fEditor);
+		SourceViewer sourceViewer = EditorTestHelper.getSourceViewer(fEditor);
 		// Source positions depend on Windows line separator
-		adjustLineSeparator(fSourceViewer.getDocument(), "\r\n");
+		adjustLineSeparator(sourceViewer.getDocument(), "\r\n");
 		fEditor.doSave(new NullProgressMonitor());
-		assertTrue(EditorTestHelper.joinReconciler(fSourceViewer, 0, 10000, 100));
+		assertTrue(EditorTestHelper.joinReconciler(sourceViewer, 0, 10000, 100));
 	}
 
 	@Override

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/text/doctools/DocCommentHighlightingTest.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/text/doctools/DocCommentHighlightingTest.java
@@ -14,6 +14,9 @@
  *******************************************************************************/
 package org.eclipse.cdt.ui.tests.text.doctools;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,7 +29,7 @@ import org.eclipse.cdt.ui.PreferenceConstants;
 import org.eclipse.cdt.ui.testplugin.Accessor;
 import org.eclipse.cdt.ui.testplugin.EditorTestHelper;
 import org.eclipse.cdt.ui.testplugin.ResourceTestHelper;
-import org.eclipse.cdt.ui.tests.BaseUITestCase;
+import org.eclipse.cdt.ui.tests.BaseUITestCase5;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.BadLocationException;
@@ -44,12 +47,11 @@ import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.Assert;
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
-public class DocCommentHighlightingTest extends BaseUITestCase {
+public class DocCommentHighlightingTest extends BaseUITestCase5 {
 	private static final DocCommentOwnerManager DCMAN = DocCommentOwnerManager.getInstance();
 	private static final String LINKED_FOLDER = "resources/docComments";
 	private static final String PROJECT = "DocCommentTests";
@@ -80,17 +82,8 @@ public class DocCommentHighlightingTest extends BaseUITestCase {
 	private ICProject fCProject;
 	private final String fTestFilename = "/" + PROJECT + "/src/this.cpp";
 
-	public static Test suite() {
-		return new TestSuite(DocCommentHighlightingTest.class);
-	}
-
-	public DocCommentHighlightingTest(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@BeforeEach
+	protected void setupTest() throws Exception {
 		fCProject = EditorTestHelper.createCProject(PROJECT, LINKED_FOLDER);
 		IPreferenceStore preferenceStore = CUIPlugin.getDefault().getPreferenceStore();
 		preferenceStore.setValue(PreferenceConstants.REMOVE_TRAILING_WHITESPACE, false);
@@ -104,8 +97,8 @@ public class DocCommentHighlightingTest extends BaseUITestCase {
 		assertTrue(EditorTestHelper.joinReconciler(sourceViewer, 0, 10000, 100));
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@AfterEach
+	protected void tearDownTest() throws Exception {
 		EditorTestHelper.closeAllEditors();
 
 		if (fCProject != null)
@@ -114,7 +107,6 @@ public class DocCommentHighlightingTest extends BaseUITestCase {
 		IPreferenceStore preferenceStore = CUIPlugin.getDefault().getPreferenceStore();
 		preferenceStore.setToDefault(PreferenceConstants.REMOVE_TRAILING_WHITESPACE);
 		preferenceStore.setToDefault(PreferenceConstants.EDITOR_FOLDING_ENABLED);
-		super.tearDown();
 	}
 
 	/**
@@ -166,12 +158,13 @@ public class DocCommentHighlightingTest extends BaseUITestCase {
 	private List<Position> mkPositions(int[][] raw) {
 		List<Position> result = new ArrayList<>();
 		for (int i = 0; i < raw.length; i++) {
-			Assert.assertEquals(2, raw[i].length);
+			assertEquals(2, raw[i].length);
 			result.add(new Position(raw[i][0], raw[i][1]));
 		}
 		return result;
 	}
 
+	@Test
 	public void testDCOM_A() throws BadLocationException, InterruptedException {
 		DCMAN.setCommentOwner(fCProject.getProject(), DCMAN.getOwner("org.cdt.test.ownerA"), true);
 		runEventQueue(1000);
@@ -179,6 +172,7 @@ public class DocCommentHighlightingTest extends BaseUITestCase {
 		assertEquals(expected, findRangesColored(TestGenericTagConfiguration.DEFAULTRGB));
 	}
 
+	@Test
 	public void testDCOM_B() throws BadLocationException, InterruptedException {
 		DCMAN.setCommentOwner(fCProject.getProject(), DCMAN.getOwner("org.cdt.test.ownerB"), true);
 		runEventQueue(1000);
@@ -186,6 +180,7 @@ public class DocCommentHighlightingTest extends BaseUITestCase {
 		assertEquals(expected, findRangesColored(TestGenericTagConfiguration.DEFAULTRGB));
 	}
 
+	@Test
 	public void testDCOM_C() throws BadLocationException, InterruptedException {
 		DCMAN.setCommentOwner(fCProject.getProject(), DCMAN.getOwner("org.cdt.test.ownerC"), true);
 		runEventQueue(1000);
@@ -193,6 +188,7 @@ public class DocCommentHighlightingTest extends BaseUITestCase {
 		assertEquals(expected, findRangesColored(TestGenericTagConfiguration.DEFAULTRGB));
 	}
 
+	@Test
 	public void testDCOM_ABC() throws BadLocationException, InterruptedException {
 		DCMAN.setCommentOwner(fCProject.getProject(), DCMAN.getOwner("org.cdt.test.ownerABC"), true);
 		runEventQueue(1000);
@@ -201,6 +197,7 @@ public class DocCommentHighlightingTest extends BaseUITestCase {
 		assertEquals(expected, findRangesColored(TestGenericTagConfiguration.DEFAULTRGB));
 	}
 
+	@Test
 	public void testDCOM_BDFG() throws BadLocationException, InterruptedException {
 		DCMAN.setCommentOwner(fCProject.getProject(), DCMAN.getOwner("org.cdt.test.ownerBDFG"), true);
 		runEventQueue(1000);
@@ -209,6 +206,7 @@ public class DocCommentHighlightingTest extends BaseUITestCase {
 		assertEquals(expected, findRangesColored(TestGenericTagConfiguration.DEFAULTRGB));
 	}
 
+	@Test
 	public void testDCOM_PUNC() throws BadLocationException, InterruptedException {
 		DCMAN.setCommentOwner(fCProject.getProject(), DCMAN.getOwner("org.cdt.test.ownerPUNC"), true);
 		runEventQueue(1000);

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/text/doctools/DocCommentHighlightingTest.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/text/doctools/DocCommentHighlightingTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.eclipse.cdt.core.model.ICProject;
 import org.eclipse.cdt.core.testplugin.CProjectHelper;
+import org.eclipse.cdt.core.testplugin.util.BaseTestCase5;
 import org.eclipse.cdt.internal.ui.editor.CEditor;
 import org.eclipse.cdt.internal.ui.text.doctools.DocCommentOwnerManager;
 import org.eclipse.cdt.ui.CUIPlugin;
@@ -49,8 +50,10 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag(BaseTestCase5.FLAKY_TEST_TAG)
 public class DocCommentHighlightingTest extends BaseUITestCase5 {
 	private static final DocCommentOwnerManager DCMAN = DocCommentOwnerManager.getInstance();
 	private static final String LINKED_FOLDER = "resources/docComments";


### PR DESCRIPTION
This test has been failing a lot recently on GitHub CI, but not on Jenkins or local dev. Therefore [mark this test as flaky](https://github.com/eclipse-cdt/cdt/blob/main/BUILDING.md#excludedgroups-to-skip-slow-or-flaky-tests) so that PRs don't fail due to unrelated test failures.

Fixes #259 