### PR TITLE
Fix rebase error for pr #234 - C++ Fold Expressions

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/FoldExpressionTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/FoldExpressionTests.java
@@ -105,7 +105,7 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//  }
 	public void testFoldExpressionRecognition1() throws Exception {
 		final String code = getAboveComment();
-		IASTTranslationUnit tu = parse(code, CPP, false, false);
+		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.STD, false);
 		ICPPASTTemplateDeclaration tdef = getDeclaration(tu, 0);
 		IASTFunctionDefinition fdef = (IASTFunctionDefinition) tdef.getDeclaration();
 		IASTProblemStatement p1 = getStatement(fdef, 0);
@@ -117,7 +117,7 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//  }
 	public void testFoldExpressionRecognition2() throws Exception {
 		final String code = getAboveComment();
-		IASTTranslationUnit tu = parse(code, CPP, false, false);
+		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.STD, false);
 		ICPPASTTemplateDeclaration tdef = getDeclaration(tu, 0);
 		IASTFunctionDefinition fdef = (IASTFunctionDefinition) tdef.getDeclaration();
 		IASTProblemStatement p1 = getStatement(fdef, 0);

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPASTFoldExpression.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPASTFoldExpression.java
@@ -16,7 +16,7 @@ package org.eclipse.cdt.core.dom.ast.cpp;
 /**
  * Fold expression, introduced in C++17.
  *
- * @since 8.0
+ * @since 8.1
  * @noextend This interface is not intended to be extended by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */


### PR DESCRIPTION
PR #234 had a compilation error once it was rebased which wasn't identified until after it was rebased and merged to main causing build to fail.

This PR is to fix that rebase error.