### PR TITLE
c++ apply integer conversions add tests

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
@@ -13821,4 +13821,28 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		// Invalid argument (not null pointer constant)
 		assertTrue(collector.getName(callIndexStart + 13).resolveBinding() instanceof IProblemBinding);
 	}
+
+	//  template <typename SignedType, typename UnsignedType>
+	//  constexpr bool calculate(SignedType x, UnsignedType y) {
+	//    if (sizeof(x) == sizeof(y)) {
+	//      return x - y >= 0;
+	//    } else {
+	//      return true;
+	//    }
+	//  }
+	//
+	//	constexpr auto test_32 = calculate<signed long, unsigned int>(1, 2);
+	//	constexpr auto test_64 = calculate<signed long long, unsigned long>(1, 2);
+	public void testArithmeticConversionIssue_265() throws Exception {
+		// Depending on size of integer types above it may happen that the rank of unsigned type operand
+		// is less than rank of signed type operand, and both types are of same size.
+		// If so the conversion is to unsigned integer type corresponding to the type of the operand
+		// with signed integer type, and calculated result cannot be less than zero - check it.
+		// 32-bit case used to fail with signed long and unsigned int,
+		// 64-bit case used to fail with signed long long and unsigned long.
+		parseAndCheckBindings();
+		BindingAssertionHelper helper = getAssertionHelper();
+		helper.assertVariableValue("test_32", 1);
+		helper.assertVariableValue("test_64", 1);
+	}
 }

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
@@ -12793,6 +12793,66 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		helper.assertVariableValue("waldo", 0);
 	}
 
+	//	constexpr int int_from_positive_long = (1L << 32) + 1;
+	//	constexpr short short_from_positive_long = (1L << 32) + 1;
+	//	constexpr unsigned int uint_from_positive_long = (1L << 32) + 1;
+	//	constexpr unsigned short ushort_from_positive_long = (1L << 32) + 1;
+	//
+	//	constexpr int int_from_negative_long = -((1L << 32) + 1);
+	//	constexpr short short_from_negative_long = -((1L << 32) + 1);
+	//	constexpr unsigned int uint_from_negative_long = -((1L << 32) + 1);
+	//	constexpr unsigned short ushort_from_negative_long = -((1L << 32) + 1);
+	public void testIntegerImplicitConversions() throws Exception {
+		BindingAssertionHelper helper = getAssertionHelper();
+
+		helper.assertVariableValue("int_from_positive_long", 1);
+		helper.assertVariableValue("short_from_positive_long", 1);
+		helper.assertVariableValue("uint_from_positive_long", 1);
+		helper.assertVariableValue("ushort_from_positive_long", 1);
+
+		helper.assertVariableValue("int_from_negative_long", -1);
+		helper.assertVariableValue("short_from_negative_long", -1);
+		helper.assertVariableValue("uint_from_negative_long", (1L << 32) - 1);
+		helper.assertVariableValue("ushort_from_negative_long", (1L << 16) - 1);
+	}
+
+	//	constexpr bool bool_from_int_positive = 2;
+	//	constexpr bool bool_from_int_negative = -2;
+	//	constexpr bool bool_from_int_0 = 0;
+	//	constexpr bool bool_from_int_expr = int(0x100000001L) < 2;
+	//	constexpr bool bool_from_short_expr = short(0x100010001L) < 2;
+	//	constexpr int int_from_cast_to_int = (int)((1L << 32) + 1);
+	public void testIntegerTrunctatingConversions() throws Exception {
+		BindingAssertionHelper helper = getAssertionHelper();
+		helper.assertVariableValue("bool_from_int_positive", 1);
+		helper.assertVariableValue("bool_from_int_negative", 1);
+		helper.assertVariableValue("bool_from_int_0", 0);
+		helper.assertVariableValue("bool_from_int_expr", 1);
+		helper.assertVariableValue("bool_from_short_expr", 1);
+		helper.assertVariableValue("int_from_cast_to_int", 1);
+	}
+
+	//	constexpr unsigned int uint_from_ulong_literal = -1UL;
+	//	constexpr unsigned int uint_from_ulong_negation = -(1UL);
+	//	constexpr unsigned short ushort_from_ulong_literal = -1UL;
+	//	constexpr unsigned short ushort_from_ulong_negation = -(1UL);
+	//
+	//	constexpr unsigned int uint_from_uint_literal_negation = -(1U);
+	//	constexpr unsigned int uint_from_uint_cast_negation = -(1U);
+	//	constexpr unsigned short ushort_from_ushort_cast_negation = -((unsigned short)1);
+	public void testUnsignedIntegerUnaryMinus() throws Exception {
+		BindingAssertionHelper helper = getAssertionHelper();
+
+		helper.assertVariableValue("uint_from_ulong_literal", (1L << 32) - 1);
+		helper.assertVariableValue("uint_from_ulong_negation", (1L << 32) - 1);
+		helper.assertVariableValue("ushort_from_ulong_literal", (1L << 16) - 1);
+		helper.assertVariableValue("ushort_from_ulong_negation", (1L << 16) - 1);
+
+		helper.assertVariableValue("uint_from_uint_literal_negation", (1L << 32) - 1);
+		helper.assertVariableValue("uint_from_uint_cast_negation", (1L << 32) - 1);
+		helper.assertVariableValue("ushort_from_ushort_cast_negation", (1L << 16) - 1);
+	}
+
 	//  namespace x {
 	//  	void foo();
 	//	}

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/ArithmeticConversion.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/ArithmeticConversion.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2015 Wind River Systems, Inc. and others.
+ * Copyright (c) 2009, 2015, 2023 Wind River Systems, Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -76,6 +76,14 @@ public abstract class ArithmeticConversion {
 			// Gcc's minimum/maximum operators
 		case IASTBinaryExpression.op_max:
 		case IASTBinaryExpression.op_min:
+			return convert(op1, op2);
+		// Relational operators
+		case IASTBinaryExpression.op_lessEqual:
+		case IASTBinaryExpression.op_lessThan:
+		case IASTBinaryExpression.op_greaterEqual:
+		case IASTBinaryExpression.op_greaterThan:
+		case IASTBinaryExpression.op_equals:
+		case IASTBinaryExpression.op_notequals:
 			return convert(op1, op2);
 
 		case IASTBinaryExpression.op_shiftLeft:

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/EvalBinary.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/EvalBinary.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2017 Wind River Systems, Inc. and others.
+ * Copyright (c) 2012, 2017, 2023 Wind River Systems, Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -240,7 +240,7 @@ public class EvalBinary extends CPPDependentEvaluation {
 
 			Number num2 = v2.numberValue();
 			if (num2 != null) {
-				return ValueFactory.evaluateBinaryExpression(fOperator, v1, v2);
+				return ValueFactory.evaluateBinaryExpression(fOperator, v1, v2, getType());
 			}
 		}
 		return DependentValue.create(this);

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/EvalUnary.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/EvalUnary.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014 Wind River Systems, Inc. and others.
+ * Copyright (c) 2012, 2014, 2023 Wind River Systems, Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -357,7 +357,7 @@ public class EvalUnary extends CPPDependentEvaluation {
 		if (val == null)
 			return IntegralValue.UNKNOWN;
 
-		return ValueFactory.evaluateUnaryExpression(fOperator, val);
+		return ValueFactory.evaluateUnaryExpression(fOperator, val, getType());
 	}
 
 	@Override


### PR DESCRIPTION
This change fixes a few places where integer conversion was missing, and adds a few tests using corrected evaluation results.

I do use these primarily for constexpr evaluations in CDT UI so there are probably more cases where integer conversions are missing (e.g. I did not looked at C code at all.)