### PR TITLE
Option to override the matching of macro defines for the Core Build GCC

### DIFF
--- a/NewAndNoteworthy/CDT-11.1.md
+++ b/NewAndNoteworthy/CDT-11.1.md
@@ -12,6 +12,9 @@ This is the New & Noteworthy page for CDT 11.1 which is part of Eclipse 2023-03 
 
 Please see [CHANGELOG-API](CHANGELOG-API.md) for details on the breaking API changes in this release as well as future planned API changes.
 
+## GCCToolchain allows custom parsing of `#define` lines
+
+See new method `matchDefines` introduced in `GCCToolChain`.
 # Noteworthy Issues and Pull Requests
 
 See [Noteworthy issues and PRs](https://github.com/eclipse-cdt/cdt/issues?q=is%3Aclosed+label%3Anoteworthy+milestone%3A11.1.0) for this release in the issue/PR tracker.

--- a/build/org.eclipse.cdt.build.gcc.core/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.build.gcc.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.build.gcc.core;singleton:=true
-Bundle-Version: 2.0.100.qualifier
+Bundle-Version: 2.1.0.qualifier
 Bundle-Activator: org.eclipse.cdt.build.gcc.core.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,


### PR DESCRIPTION
toolchain. This may be needed for custom compilers.