### PR TITLE
Add .clangd file to simplify project sharing with non-CDT

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -152,6 +152,7 @@ test_commands text
 # Other special files
 cdtOptions text
 .clang-format text
+.clangd text
 .contentsettings text
 *.csv text
 *.dia binary

--- a/cmake/org.eclipse.cdt.cmake.core/META-INF/MANIFEST.MF
+++ b/cmake/org.eclipse.cdt.cmake.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.cmake.core;singleton:=true
-Bundle-Version: 1.5.0.qualifier
+Bundle-Version: 1.5.100.qualifier
 Bundle-Activator: org.eclipse.cdt.cmake.core.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/cmake/org.eclipse.cdt.cmake.core/templates/simple/.clangd
+++ b/cmake/org.eclipse.cdt.cmake.core/templates/simple/.clangd
@@ -1,0 +1,4 @@
+CompileFlags:
+	# When using clangd update this entry to point at the desired
+	# configuration directory to pick up the compile_commands.json
+    CompilationDatabase: build/default

--- a/cmake/org.eclipse.cdt.cmake.core/templates/simple/manifest.xml
+++ b/cmake/org.eclipse.cdt.cmake.core/templates/simple/manifest.xml
@@ -1,4 +1,6 @@
 <templateManifest>
+	<file src="/templates/simple/.clangd"
+		dest="/${projectName}/.clangd"/>
 	<file src="/templates/simple/CMakeLists.txt"
 		dest="/${projectName}/CMakeLists.txt"/>
 	<file src="/templates/simple/config.h.in"


### PR DESCRIPTION
In the example CMake project add a .clangd to enable pointing clangd at the appropriate compilation database without having to make a copy of it.