### PR TITLE
parse more c++ expression alternatives

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateTests.java
@@ -11419,4 +11419,78 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 		helper.assertVariableValue("val1", 4);
 		helper.assertVariableValue("val2", 8);
 	}
+
+	//	template <typename T>
+	//	inline constexpr bool V = true;
+	//
+	//	template<typename T> bool f() {
+	//	  return V<T> + V<T>;
+	//	}
+	public void testBinaryExpressionWithVariableTemplateVsPlusUnaryExpression() throws Exception {
+		parseAndCheckBindings();
+	}
+
+	//	template <typename T>
+	//	inline constexpr bool V = true;
+	//
+	//	template<typename T> bool f() {
+	//	  return V<T> || V<T>;
+	//	}
+	public void testBinaryExpressionWithVariableTemplate() throws Exception {
+		parseAndCheckBindings();
+	}
+
+	//	template <typename T>
+	//	inline constexpr bool V = true;
+	//
+	//	template<typename T> bool f() {
+	//	  return V<T> && V<T>; // can be parsed as V < T > &&V<T>
+	//	}
+	public void testBinaryExpressionWithVariableTemplateAmbiguousLabelReference() throws Exception {
+		parseAndCheckBindings();
+	}
+
+	//	template <typename T>
+	//	inline constexpr bool W = true;
+	//	template <typename T>
+	//	inline constexpr bool X = true;
+	//	template <typename T>
+	//	inline constexpr bool Y = true;
+	//	template <typename T>
+	//	inline constexpr bool Z = true;
+	//
+	//	template<typename T> bool f() {
+	//	  return W<T> && X<T> && Y<T> && Z<T>; // can be parsed as (W) < (T) > (&&X<T>) ...
+	//	}
+	public void testBinaryExpressionWithVariableTemplateDeep() throws Exception {
+		parseAndCheckBindings();
+	}
+
+	//	constexpr int factorial(int n) {
+	//		return n < 2 ? 1 : n * factorial(n - 1);
+	//	}
+	//
+	//	int f();
+	//
+	//	template <int>
+	//	class A {
+	//		template <int> class Waldo {
+	//			static void f();
+	//		};
+	//	};
+	//
+	//	template <>
+	//	class A<120> {
+	//	public:
+	//		static int Waldo;
+	//	};
+	//
+	//	int main() {
+	//		// This requires constexpr evaluation to find that return type of factorial(5) is int
+	//		// to decide if A<int>::Waldo is a template
+	//		A<factorial(5)>::Waldo<0>::f();
+	//	}
+	public void testBinaryExpressionWithVariableTemplate_bug497931_comment8() throws Exception {
+		parseAndCheckBindings();
+	}
 }

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/GNUCPPSourceParser.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/GNUCPPSourceParser.java
@@ -650,11 +650,14 @@ public class GNUCPPSourceParser extends AbstractGNUSourceCodeParser {
 		case IToken.tLPAREN: // 'ft<int>(args)' or 'c<1 && 2 > (x+y)'
 			return AMBIGUOUS_TEMPLATE_ID;
 
-		// Start of unary expression
+		// Can be start of unary expression or binary expression with a template-id
 		case IToken.tMINUS:
 		case IToken.tPLUS:
 		case IToken.tAMPER:
 		case IToken.tSTAR:
+		case IToken.tAND:
+			return AMBIGUOUS_TEMPLATE_ID;
+
 		case IToken.tNOT:
 		case IToken.tBITCOMPLEMENT:
 		case IToken.tINCR:

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/NameOrTemplateIDVariants.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/NameOrTemplateIDVariants.java
@@ -150,8 +150,8 @@ public class NameOrTemplateIDVariants {
 
 	public Variant selectFallback() {
 		// Search for an open variant, with a small right offset and a large left offset
+		Variant best = null;
 		for (BranchPoint p = fFirst; p != null; p = p.getNext()) {
-			Variant best = null;
 			for (Variant v = p.getFirstVariant(); v != null; v = v.getNext()) {
 				if (v.getTargetOperator() == null) {
 					if (best == null || v.fRightOffset < best.fRightOffset) {
@@ -159,10 +159,10 @@ public class NameOrTemplateIDVariants {
 					}
 				}
 			}
-			if (best != null) {
-				remove(best);
-				return best;
-			}
+		}
+		if (best != null) {
+			remove(best);
+			return best;
 		}
 		return null;
 	}


### PR DESCRIPTION
If parsing expression part for an alternative terminates with `BacktrackException`, `selectFallback()` would short-circuit to the longest remaining variant. If that happens to successfully complete parsing till the end of expression token sequence, all of remaining variants are discarded, including the first found alternative which was to parse identifier as template name.

This causes `expression()` to only consider one branchpoint out of all possible variants. Allow it to find more variants by scanning through all branchpoints looking for the alternative with leftmost parsed boundary.

To make it work add these operators to possible end-of-template-id markers due to variants with start of unary expression: `+` `-` `&` `*` for unary ops and `&&` for unary op with label reference extension.

This is probably still not ideal but fixes this common std library construct:
```C++
  template <typename T>
  inline constexpr bool X = true;
  template <typename T>
  inline constexpr bool Y = true;

  template<typename T> bool predicate() {
    return X<T> && Y<T>; // CDT finds this one: (X) < (T) > (&&Y<T>)
                         // Fix it to also consider (X<T>) && (Y<T>)
  }
```

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=497931