### PR TITLE
Fix c++17 fold expression in variable template specialization

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/FoldExpressionTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/FoldExpressionTests.java
@@ -186,4 +186,40 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 		IASTFunctionDefinition fdef = (IASTFunctionDefinition) tdef.getDeclaration();
 		IASTProblemExpression e1 = getExpressionOfStatement(fdef, 0);
 	}
+
+	//  template <typename T> struct predicate {
+	//    static constexpr bool evaluated = true;
+	//  };
+	//
+	//  template<bool arg> struct condition {
+	//    static constexpr bool value = arg;
+	//  };
+	//
+	//  template<typename... TP>
+	//  struct fold_condition {
+	//    static constexpr bool value = condition<(predicate<TP>::evaluated && ...)>::value;
+	//  };
+	//
+	//  constexpr bool result = fold_condition<int, double>::value;
+	public void testFoldExpressionInClassTemplateArguments() throws Exception {
+		BindingAssertionHelper helper = getAssertionHelper();
+		helper.assertVariableValue("result", 1);
+	}
+
+	//  template<typename T1> constexpr bool predicate = true;
+	//
+	//  template<bool arg> struct condition {
+	//    static constexpr bool value = arg;
+	//  };
+	//
+	//  template<typename... TP>
+	//  struct fold_condition {
+	//    static constexpr bool value = condition<(predicate<TP> && ...)>::value;
+	//  };
+	//
+	//  constexpr bool result = fold_condition<int, double>::value;
+	public void testFoldExpressionInVariableTemplateArguments() throws Exception {
+		BindingAssertionHelper helper = getAssertionHelper();
+		helper.assertVariableValue("result", 1);
+	}
 }

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/CPPASTFoldExpression.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/CPPASTFoldExpression.java
@@ -19,14 +19,17 @@ import org.eclipse.cdt.core.dom.ast.ASTVisitor;
 import org.eclipse.cdt.core.dom.ast.IASTExpression;
 import org.eclipse.cdt.core.dom.ast.IASTImplicitDestructorName;
 import org.eclipse.cdt.core.dom.ast.IASTNode;
+import org.eclipse.cdt.core.dom.ast.IASTTypeId;
 import org.eclipse.cdt.core.dom.ast.IType;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTExpression;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTFoldExpression;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTPackExpansionExpression;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPParameterPackType;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPTemplateParameter;
 import org.eclipse.cdt.internal.core.dom.parser.ASTNode;
 import org.eclipse.cdt.internal.core.dom.parser.IASTAmbiguityParent;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.CPPEvaluation;
+import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.CPPVisitor;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.DestructorCallCollector;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalFixed;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalFoldExpression;
@@ -103,6 +106,7 @@ public class CPPASTFoldExpression extends ASTNode implements ICPPASTFoldExpressi
 		public UnexpandedParameterPackCounter() {
 			super(false);
 			shouldVisitExpressions = true;
+			shouldVisitTypeIds = true;
 			count = 0;
 		}
 
@@ -119,6 +123,21 @@ public class CPPASTFoldExpression extends ASTNode implements ICPPASTFoldExpressi
 			IType type = expression.getExpressionType();
 			if (type instanceof ICPPParameterPackType) {
 				++count;
+			}
+			return PROCESS_CONTINUE;
+		}
+
+		@Override
+		public int visit(IASTTypeId typeId) {
+			IType type = CPPVisitor.createType(typeId);
+			if (type instanceof ICPPTemplateParameter templateParameter) {
+				if (templateParameter.isParameterPack()) {
+					++count;
+				} else {
+					boolean notParameterPack = true;
+				}
+			} else {
+				boolean notTemplateParameter = true;
 			}
 			return PROCESS_CONTINUE;
 		}

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/CPPTemplates.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/CPPTemplates.java
@@ -1278,6 +1278,16 @@ public class CPPTemplates {
 				if (r < 0)
 					return r;
 			}
+		} else if (binding instanceof ICPPDeferredVariableInstance dvi) {
+			if (dvi.getTemplateDefinition() instanceof ICPPTemplateTemplateParameter) {
+				r = combinePackSize(r, determinePackSize((ICPPUnknownBinding) dvi.getTemplateDefinition(), tpMap));
+			}
+			ICPPTemplateArgument[] args = dvi.getTemplateArguments();
+			for (ICPPTemplateArgument arg : args) {
+				r = combinePackSize(r, determinePackSize(arg, tpMap));
+				if (r < 0)
+					return r;
+			}
 		}
 		IBinding ownerBinding = binding.getOwner();
 		if (ownerBinding instanceof IType)

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/EvalFoldExpression.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/EvalFoldExpression.java
@@ -84,9 +84,6 @@ public class EvalFoldExpression extends CPPDependentEvaluation {
 
 	@Override
 	public boolean isTypeDependent() {
-		if (fType != null) {
-			return fType instanceof TypeOfDependentExpression;
-		}
 		return containsDependentType(fPackEvals) || (fInitEval != null && fInitEval.isTypeDependent());
 	}
 
@@ -122,7 +119,7 @@ public class EvalFoldExpression extends CPPDependentEvaluation {
 	@Override
 	public IType getType() {
 		if (fType == null) {
-			if (isTypeDependent()) {
+			if (isTypeDependent() || isValueDependent()) {
 				fType = new TypeOfDependentExpression(this);
 			} else {
 				fType = computeEvaluation().getType();


### PR DESCRIPTION
This change fixes an issue where variable template specialization requires calculating a fold over predicates from parameter pack. Added a couple of tests showing this common pattern in libstdc++-v3.