### PR TITLE
Fix maven at 3.8.7

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,6 +31,10 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+    - name: Setup Maven
+      uses: stCarolas/setup-maven@v.4.5
+      with:
+        maven-version: 3.8.7
     - name: Install GCC & GDB & other build essentials
       run: |
         sudo apt-get -y install build-essential gcc g++ gdb gdbserver

--- a/.github/workflows/code-cleanliness.yml
+++ b/.github/workflows/code-cleanliness.yml
@@ -21,6 +21,10 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+    - name: Setup Maven
+      uses: stCarolas/setup-maven@v.4.5
+      with:
+        maven-version: 3.8.7
     - name: Install dependencies
       run: |
         sudo apt-get update && sudo apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Until we update Tycho to 3.0.3+ we use the older Maven

Thanks to @ghentschke for figuring this out in
https://github.com/Bachmann-electronic-GmbH/eclipse-cdt-lsp/commit/f7761791be51f27fcc364e14b3f0eafff9a6235b

Fixes #308