### PR TITLE
The "depth" to a content type matters when deciding the best one

### DIFF
--- a/core/org.eclipse.cdt.core/plugin.xml
+++ b/core/org.eclipse.cdt.core/plugin.xml
@@ -585,7 +585,7 @@
           priority="high"/>
 	  <!-- declares a content type for C++ header files -->
       <content-type id="cxxHeader" name="%cxxHeaderName" 
-          base-type="org.eclipse.cdt.core.cxxSource"
+          base-type="org.eclipse.cdt.core.cSource"
 		  file-extensions="h,hpp,hh,hxx,inc"          
           priority="high"/>
 	  <!-- declares a content type for ASM Source files -->


### PR DESCRIPTION
Although not obviously documented, the "depth" of a content type (how many base-types there are, recursively) matters to choosing which content type to use. See the code in platform that has been like this since ~2005.

Therefore, change the definition of cxxSource to make it the same depth as the other types in CDT.

This solves the practical case where TM4E provides content types for C++ file types, but the priority there is low, but because to the lesser depth it takes priority.

platform: https://github.com/eclipse-platform/eclipse.platform/blob/9839c18f52687db6f949bdb56a59a5d20cd7c938/runtime/bundles/org.eclipse.core.contenttype/src/org/eclipse/core/internal/content/ContentTypeCatalog.java#L43-L60
tm4e: https://github.com/eclipse/tm4e/blob/99a5df037be1e3114f7f88115f46c34b1d27a297/org.eclipse.tm4e.language_pack/plugin.xml#L69

Fixes https://github.com/eclipse/tm4e/issues/499