### PR TITLE
Improved getting resources from the gcc commandline.

### DIFF
--- a/build/org.eclipse.cdt.build.gcc.core/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.build.gcc.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.build.gcc.core;singleton:=true
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 2.1.100.qualifier
 Bundle-Activator: org.eclipse.cdt.build.gcc.core.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,


### PR DESCRIPTION
The old method assumed all resources were at the end of the line, optionally followed by option -o.
Now the complete line is scanned for valid resource file extensions.