### PR TITLE
Fix assertion evaluating binary shifts of comparison op results

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
@@ -96,6 +96,7 @@ import org.eclipse.cdt.core.dom.ast.IScope;
 import org.eclipse.cdt.core.dom.ast.ISemanticProblem;
 import org.eclipse.cdt.core.dom.ast.IType;
 import org.eclipse.cdt.core.dom.ast.ITypedef;
+import org.eclipse.cdt.core.dom.ast.IValue;
 import org.eclipse.cdt.core.dom.ast.IVariable;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTBinaryExpression;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTCastExpression;
@@ -147,6 +148,7 @@ import org.eclipse.cdt.core.parser.IProblem;
 import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.core.parser.util.AttributeUtil;
 import org.eclipse.cdt.core.parser.util.CharArrayUtils;
+import org.eclipse.cdt.internal.core.dom.parser.IntegralValue;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTNameBase;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPBasicType;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPClassInstance;
@@ -13844,5 +13846,30 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("test_32", 1);
 		helper.assertVariableValue("test_64", 1);
+	}
+
+	//  constexpr auto shiftdouble = (1. << 1);
+	public void testArithmeticEvaluationWithDoubleShiftOp() throws Exception {
+		BindingAssertionHelper helper = getAssertionHelper();
+		IVariable shiftdouble = helper.assertNonProblem("shiftdouble = ", 11);
+		IValue value = shiftdouble.getInitialValue();
+		assertTrue(IntegralValue.ERROR.equals(value) || IntegralValue.UNKNOWN.equals(value));
+	}
+
+	//  constexpr auto shiftdouble = (1. <<= 1);
+	public void testArithmeticEvaluationWithDoubleShiftAssignOp() throws Exception {
+		BindingAssertionHelper helper = getAssertionHelper();
+		IVariable shiftdouble = helper.assertNonProblem("shiftdouble = ", 11);
+		IValue value = shiftdouble.getInitialValue();
+		assertTrue(IntegralValue.ERROR.equals(value) || IntegralValue.UNKNOWN.equals(value));
+	}
+
+	//  enum Shift { Horizontal, Vertical };
+	//  constexpr double zero = 0.;
+	//  constexpr double x = 1., y = 1.;
+	//  constexpr int shiftpack = ((x > zero) << Horizontal) | ((y > zero) << Vertical);
+	public void testArithmeticEvaluationOfRelationalOps() throws Exception {
+		BindingAssertionHelper helper = getAssertionHelper();
+		helper.assertVariableValue("shiftpack", 3);
 	}
 }

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/ArithmeticConversion.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/ArithmeticConversion.java
@@ -87,7 +87,12 @@ public abstract class ArithmeticConversion {
 			return convert(op1, op2);
 
 		case IASTBinaryExpression.op_shiftLeft:
+		case IASTBinaryExpression.op_shiftLeftAssign:
 		case IASTBinaryExpression.op_shiftRight:
+		case IASTBinaryExpression.op_shiftRightAssign:
+			if (!isIntegralOrUnscopedEnum(op1) || !isIntegralOrUnscopedEnum(op2)) {
+				return null;
+			}
 			return promote(op1, getDomain(op1));
 
 		default:


### PR DESCRIPTION
Currently CDT evaluates result type of comparison ops to the converted type of their operands. When floating point values are compared and then the result is binary shifted this trips an assertion trying to promote floating point value.

Fix this by limiting operand types of binary shifts to integral or unscoped enumerations. Additionally fix return type of comparison op to be boolean value.

Issue found looking at Qt code, similar to this https://github.com/qt/qt/blob/4.8/src/gui/painting/qpainterpath.cpp#L1824-L1834