### PR TITLE
Handle invalid empty c++17 fold expression early

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/FoldExpressionTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/FoldExpressionTests.java
@@ -164,13 +164,14 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//      (... + 1 * vals);
 	//      (vals + ... + 1 * 2);
 	//      (1 * 2 + ... + vals);
+	//      (...);
 	//  }
 	public void testFoldExpressionErrors() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.STD, false);
 		ICPPASTTemplateDeclaration tdef = getDeclaration(tu, 0);
 		IASTFunctionDefinition fdef = (IASTFunctionDefinition) tdef.getDeclaration();
-		for (int i = 0; i < 13; ++i) {
+		for (int i = 0; i < 14; ++i) {
 			IASTProblemExpression e = getExpressionOfStatement(fdef, i);
 		}
 	}

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/GNUCPPSourceParser.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/GNUCPPSourceParser.java
@@ -1287,7 +1287,7 @@ public class GNUCPPSourceParser extends AbstractGNUSourceCodeParser {
 
 	@Override
 	public final IASTExpression buildExpression(BinaryOperator leftChain, IASTInitializerClause expr) {
-		if (supportFoldExpression && leftChain != null && expr != null) {
+		if (supportFoldExpression && expr != null) {
 			int foldCount = 0;
 			int foldOpToken = 0;
 
@@ -1321,7 +1321,7 @@ public class GNUCPPSourceParser extends AbstractGNUSourceCodeParser {
 
 			// Valid fold-expression has single ellipsis.
 
-			if (foldCount == 1) {
+			if (foldCount == 1 && leftChain != null) {
 				BinaryOperator rightChain;
 				if (foldOp == null) {
 					// unary right fold, remove expression and use left chain as is


### PR DESCRIPTION
One of Qt sample snippets contain `(...)` as placeholder for actual user code. Parsing that leads to invalid class cast because buildExpression would return fold expression token marker and not a proper ICPPASTexpression.

Fix that by handling this error early as invalid fold expression.