### PR TITLE
Restore counting iterations in computeContainsDeclaration cycle detector

### DIFF
--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/index/IndexFileSet.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/index/IndexFileSet.java
@@ -100,6 +100,11 @@ public class IndexFileSet implements IIndexFileSet {
 					Set<Long> visited = null;
 					long nameRecord;
 					while ((nameRecord = nameIterator.next()) != 0) {
+						if (++iterationCount >= 1000 && visited == null) {
+							// Iteration count is suspiciously high. Start keeping track of visited names
+							// to be able to detect a cycle.
+							visited = new HashSet<>();
+						}
 						if (visited != null && !visited.add(nameRecord)) {
 							// Cycle detected!
 							logInvalidNameChain(pdom, binding);
@@ -113,12 +118,6 @@ public class IndexFileSet implements IIndexFileSet {
 										binding.getClass().getSimpleName(), iterationCount));
 							}
 							return true;
-						}
-						if (iterationCount >= 1000 && visited == null) {
-							// Iteration count is suspiciously high. Start keeping track of visited names
-							// to be able to detect a cycle.
-							visited = new HashSet<>();
-							visited.add(nameRecord);
 						}
 					}
 				}


### PR DESCRIPTION
A follow-up change to [bug 509898](https://bugs.eclipse.org/bugs/show_bug.cgi?id=509898) missed actually incrementing the counter, restore it now.

Fixes: 5462bac381 ("Bug 509898 - IndexFileSet.containsDeclaration is slow and is causing UI freezes")