### PR TITLE
CDT 11.1 branch stable dependency URLs

### DIFF
--- a/releng/org.eclipse.cdt.target/cdt.target
+++ b/releng/org.eclipse.cdt.target/cdt.target
@@ -7,7 +7,7 @@
 			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.27-I-builds/I20230302-0300/"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.27/R-4.27-202303020300/"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
@@ -19,7 +19,7 @@
 			<unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/linuxtools/update-2023-03-docker-rc1"/>
+			<repository location="https://download.eclipse.org/linuxtools/update-2023-03-docker-rc2/"/>
 			<unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -42,7 +42,7 @@
 			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/cdt/releases/latest"/>
+			<repository location="https://download.eclipse.org/tools/cdt/releases/11.1"/>
 			<!-- We explicitly have CDT in target platform so that developers can develop org.eclipse.cdt.core/ui without requiring all the projects from CDT in their workspace. -->
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0"/>
 		</location>


### PR DESCRIPTION
Another update may be needed when/if Linuxtools does a permanent URL for the 2023-03 release.