### PR TITLE
Binary not found in Core Build Makefile project

### DIFF
--- a/build/org.eclipse.cdt.make.core/src/org/eclipse/cdt/make/core/MakefileProjectGenerator.java
+++ b/build/org.eclipse.cdt.make.core/src/org/eclipse/cdt/make/core/MakefileProjectGenerator.java
@@ -84,7 +84,7 @@ public class MakefileProjectGenerator extends FMProjectGenerator {
 			}
 		}
 
-		entries.add(CoreModel.newOutputEntry(buildFolder.getFullPath()));
+		entries.add(CoreModel.newOutputEntry(project.getFullPath()));
 		CoreModel.getDefault().create(project).setRawPathEntries(entries.toArray(new IPathEntry[entries.size()]),
 				monitor);
 	}


### PR DESCRIPTION
Fixed the problem for Core Build Makefile projects that the output binary could not be found during launching when the user set the Build Output Location to "Build in project directory". The project was only looking for binaries in the "build" folder.