### PR TITLE
Allow binary operator templates

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
@@ -4221,6 +4221,22 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		helper.assertVariableValue("greater10", 1);
 	}
 
+	// template<typename T1, typename T2>
+	// constexpr int operator |(T1 t1, T2 t2) {
+	//    return t1 + t2;
+	// }
+	//
+	// enum X {
+	//    V1 = 17,
+	//    V2 = 25,
+	// };
+	//
+	// constexpr auto value = V1 | V2;
+	public void testBinaryOperatorOverloadTemplate() throws Exception {
+		BindingAssertionHelper helper = getAssertionHelper(CPP);
+		helper.assertVariableValue("value", 42);
+	}
+
 	// typedef int I;
 	// typedef int I;
 	// typedef I I;

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/CPPSemantics.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/CPPSemantics.java
@@ -4099,9 +4099,10 @@ public class CPPSemantics {
 							ICPPFunctionType ft = func.getType();
 							IType[] pts = ft.getParameterTypes();
 							if ((enum1 != null && pts.length > 0
-									&& enum1.isSameType(getUltimateTypeUptoPointers(pts[0])))
-									|| (enum2 != null && pts.length > 1
-											&& enum2.isSameType(getUltimateTypeUptoPointers(pts[1])))) {
+									&& (CPPTemplates.isDependentType(pts[0])
+											|| enum1.isSameType(getUltimateTypeUptoPointers(pts[0]))))
+									|| (enum2 != null && pts.length > 1 && (CPPTemplates.isDependentType(pts[1])
+											|| enum2.isSameType(getUltimateTypeUptoPointers(pts[1]))))) {
 								items[j++] = object;
 							}
 						}


### PR DESCRIPTION
This change fixes second issue looking at GDB sources where lots of binary operators are overloaded with templates.