### PR TITLE
Allow disambiguating class constructor definition followed by semicolon

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateTests.java
@@ -11531,4 +11531,14 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	public void testResolveFunctionTemplateInDeferredBaseArg() throws Exception {
 		parseAndCheckBindings();
 	}
+
+	//	template<typename T>
+	//	struct S {
+	//		S(T) {};
+	//	};
+	//
+	//	S<int> s(1);
+	public void testRecognizeConstructorWithSemicolonAfterBody() throws Exception {
+		parseAndCheckImplicitNameBindings();
+	}
 }

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/c/GNUCSourceParser.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/c/GNUCSourceParser.java
@@ -2224,4 +2224,10 @@ public class GNUCSourceParser extends AbstractGNUSourceCodeParser {
 			IASTAlignmentSpecifier typeId) {
 		return new CASTAmbiguousAlignmentSpecifier(expression, typeId);
 	}
+
+	@Override
+	protected boolean maybeDeclaresNonStaticMemberOfSameClass(final DeclarationOptions option,
+			final IASTDeclSpecifier declSpec, final IASTDeclarator dtor) {
+		return false;
+	}
 }

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/GNUCPPSourceParser.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/GNUCPPSourceParser.java
@@ -4256,6 +4256,22 @@ public class GNUCPPSourceParser extends AbstractGNUSourceCodeParser {
 		return dtor;
 	}
 
+	@Override
+	protected boolean maybeDeclaresNonStaticMemberOfSameClass(final DeclarationOptions option,
+			final IASTDeclSpecifier declSpec, final IASTDeclarator dtor) {
+		if (option == DeclarationOptions.CPP_MEMBER && currentClassName != null
+				&& declSpec.getStorageClass() != IASTDeclSpecifier.sc_static && dtor != null
+				&& dtor.getPointerOperators().length == 0
+				&& declSpec instanceof ICPPASTNamedTypeSpecifier namedTypeSpec) {
+			IASTName name = namedTypeSpec.getName();
+			if (CharArrayUtils.equals(name.getLookupKey(), currentClassName)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	/**
 	 * Tries to detect illegal versions of declarations
 	 */


### PR DESCRIPTION
In this case member variable declaration would be longer (including trailing semicolon) but it is not valid since a class C shall not contain a non-static member of class C:

```C++
template<typename T>
struct S {
	S(T) {}; // was recognized as declaration of variable T of type S before this change
};

S<int> s(1); // declared constructor was not found
```