### PR TITLE
Remove reference to Navigator view that has been removed

### DIFF
--- a/core/org.eclipse.cdt.ui/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.ui; singleton:=true
-Bundle-Version: 8.0.100.qualifier
+Bundle-Version: 8.0.200.qualifier
 Bundle-Activator: org.eclipse.cdt.ui.CUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/editor/CEditor.java
+++ b/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/editor/CEditor.java
@@ -1568,10 +1568,8 @@ public class CEditor extends TextEditor
 		} else if (adapterClass.isAssignableFrom(IShowInTargetList.class)) {
 			return (T) new IShowInTargetList() {
 				@Override
-				@SuppressWarnings("deprecation")
 				public String[] getShowInTargetIds() {
-					return new String[] { IPageLayout.ID_PROJECT_EXPLORER, IPageLayout.ID_OUTLINE,
-							IPageLayout.ID_RES_NAV };
+					return new String[] { IPageLayout.ID_PROJECT_EXPLORER, IPageLayout.ID_OUTLINE };
 				}
 			};
 		} else if (adapterClass.isAssignableFrom(IShowInSource.class)) {


### PR DESCRIPTION
The long deprecated for removal navigator view has been removed from upcoming Eclipse Platform.

I don't know if there are other locations in CDT that are affected, but this change covers the compilation failure of the removal.

xref: https://github.com/eclipse-platform/eclipse.platform.ui/issues/644