### PR TITLE
Allow symmetrical patterns inside for replace keys

### DIFF
--- a/core/org.eclipse.cdt.core/templateengine/org/eclipse/cdt/core/templateengine/process/ProcessHelper.java
+++ b/core/org.eclipse.cdt.core/templateengine/org/eclipse/cdt/core/templateengine/process/ProcessHelper.java
@@ -97,7 +97,7 @@ public class ProcessHelper {
 		int start = 0;
 		int end = 0;
 		while ((start = str.indexOf(startPattern, start)) >= 0) {
-			end = str.indexOf(endPattern, start);
+			end = str.indexOf(endPattern, start + startPattern.length());
 			if (end != -1) {
 				replaceStrings.add(str.substring(start + startPattern.length(), end));
 				start = end + endPattern.length();


### PR DESCRIPTION
Update ProcessHelper#getReplaceKeys to allow for patterns with identical start and end delimiters. Previously, `%%key%%` would throw and OutOfBoundsException instead of matching the key inside the delimiters.