### PR TITLE
Dispose image

### DIFF
--- a/terminal/plugins/org.eclipse.tm.terminal.view.ui/src/org/eclipse/tm/terminal/view/ui/panels/AbstractExtendedConfigurationPanel.java
+++ b/terminal/plugins/org.eclipse.tm.terminal.view.ui/src/org/eclipse/tm/terminal/view/ui/panels/AbstractExtendedConfigurationPanel.java
@@ -36,6 +36,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -397,8 +398,9 @@ public abstract class AbstractExtendedConfigurationPanel extends AbstractConfigu
 			// deleteHostButton.setText(Messages.AbstractConfigurationPanel_delete);
 
 			ISharedImages workbenchImages = PlatformUI.getWorkbench().getSharedImages();
-			deleteHostButton.setImage(workbenchImages.getImageDescriptor(ISharedImages.IMG_TOOL_DELETE).createImage());
-
+			Image deleteHostButtonImage = workbenchImages.getImageDescriptor(ISharedImages.IMG_TOOL_DELETE)
+					.createImage();
+			deleteHostButton.setImage(deleteHostButtonImage);
 			deleteHostButton.setToolTipText(Messages.AbstractConfigurationPanel_deleteButtonTooltip);
 			deleteHostButton.addSelectionListener(new SelectionListener() {
 
@@ -422,6 +424,9 @@ public abstract class AbstractExtendedConfigurationPanel extends AbstractConfigu
 					widgetSelected(e);
 				}
 			});
+			if (deleteHostButtonImage != null) {
+				deleteHostButton.addListener(SWT.Dispose, (e) -> deleteHostButtonImage.dispose());
+			}
 
 			if (separator) {
 				Label sep = new Label(parent, SWT.SEPARATOR | SWT.HORIZONTAL);


### PR DESCRIPTION
Fixes cases that cause stack trace like this when opening terminal connection dialog and selecting ssh type:

```java
!ENTRY org.eclipse.ui.ide 4 4 2023-04-13 15:57:20.632
!MESSAGE Not properly disposed SWT resource
!STACK 0
java.lang.Error: SWT Resource was not properly disposed
	at org.eclipse.swt.graphics.Resource.initNonDisposeTracking(Resource.java:172)
	at org.eclipse.swt.graphics.Resource.<init>(Resource.java:120)
	at org.eclipse.swt.graphics.Image.<init>(Image.java:605)
	at org.eclipse.jface.resource.URLImageDescriptor.createImage(URLImageDescriptor.java:300)
	at org.eclipse.jface.resource.DeferredImageDescriptor.createImage(DeferredImageDescriptor.java:85)
	at org.eclipse.jface.resource.ImageDescriptor.createImage(ImageDescriptor.java:290)
	at org.eclipse.jface.resource.ImageDescriptor.createImage(ImageDescriptor.java:268)
	at org.eclipse.tm.terminal.view.ui.panels.AbstractExtendedConfigurationPanel.createHostsUI(AbstractExtendedConfigurationPanel.java:400)
	at org.eclipse.tm.terminal.connector.ssh.controls.SshWizardConfigurationPanel.setupPanel(SshWizardConfigurationPanel.java:79)
	at org.eclipse.tm.terminal.view.ui.internal.dialogs.LaunchTerminalSettingsDialog$SettingsPanelControl.showConfigurationPanel(LaunchTerminalSettingsDialog.java:124)
	at org.eclipse.tm.terminal.view.ui.internal.dialogs.LaunchTerminalSettingsDialog$1.widgetSelected(LaunchTerminalSettingsDialog.java:317)
```