### PR TITLE
Set tool prefix for spawning GNU tool processes

### DIFF
--- a/build/org.eclipse.cdt.managedbuilder.core/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.managedbuilder.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.managedbuilder.core; singleton:=true
-Bundle-Version: 9.5.100.qualifier
+Bundle-Version: 9.6.0.qualifier
 Bundle-Activator: org.eclipse.cdt.managedbuilder.core.ManagedBuilderCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/macros/AbstractGnuToolPrefixMacro.java
+++ b/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/macros/AbstractGnuToolPrefixMacro.java
@@ -1,0 +1,50 @@
+package org.eclipse.cdt.managedbuilder.macros;
+
+import org.eclipse.cdt.core.cdtvariables.CdtVariableException;
+import org.eclipse.cdt.core.cdtvariables.ICdtVariableStatus;
+import org.eclipse.cdt.managedbuilder.core.BuildException;
+import org.eclipse.cdt.managedbuilder.core.IOption;
+import org.eclipse.cdt.utils.IGnuToolFactory;
+import org.eclipse.core.runtime.Status;
+
+/**
+ * A CDT build variable defining the GNU tool prefix for use by
+ * an {@link org.eclipse.cdt.utils.IGnuToolFactory} implementation.
+ *
+ * @since 9.6
+ */
+public abstract class AbstractGnuToolPrefixMacro implements IBuildMacro {
+
+	@Override
+	public String getName() {
+		return IGnuToolFactory.GNU_TOOL_PREFIX_VARIABLE;
+	}
+
+	@Override
+	public int getValueType() {
+		return IBuildMacro.VALUE_TEXT;
+	}
+
+	@Override
+	public int getMacroValueType() {
+		return getValueType();
+	}
+
+	@Override
+	public abstract String getStringValue() throws BuildMacroException;
+
+	@Override
+	public String[] getStringListValue() throws BuildMacroException {
+		throw new BuildMacroException(
+				new CdtVariableException(ICdtVariableStatus.TYPE_MACRO_NOT_STRINGLIST, getName(), null, getName()));
+	}
+
+	protected String getStringValue(IOption option) throws BuildMacroException {
+		try {
+			return option.getStringValue();
+		} catch (BuildException e) {
+			throw new BuildMacroException(Status.error("Error getting macro value: " + getName(), e)); //$NON-NLS-1$
+		}
+	}
+
+}

--- a/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/IGnuToolFactory.java
+++ b/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/IGnuToolFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2009 QNX Software Systems and others.
+ * Copyright (c) 2005, 2023 QNX Software Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     QNX Software Systems - initial API and implementation
+ *     John Dallaway - support GNU tool prefix lookup (#361)
  *******************************************************************************/
 /*
  * Created on Jul 5, 2004
@@ -26,6 +27,9 @@ import org.eclipse.core.runtime.IPath;
  * @noimplement This interface is not intended to be implemented by clients.
  */
 public interface IGnuToolFactory {
+
+	/** @since 8.2 */
+	public static final String GNU_TOOL_PREFIX_VARIABLE = "gnu_tool_prefix"; //$NON-NLS-1$
 
 	Addr2line getAddr2line(IPath path);
 

--- a/cross/org.eclipse.cdt.build.crossgcc/plugin.xml
+++ b/cross/org.eclipse.cdt.build.crossgcc/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <!--
-# Copyright (c) 2009, 2011 Wind River Systems, Inc. and others.
+# Copyright (c) 2009, 2023 Wind River Systems, Inc. and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
 # Contributors:
 # Doug Schaefer   (Wind River)     - initial API and implementation 
 # Anna Dushistova (Mentor Graphics)- [329531][crossgcc] crossgcc fails to build a project
+# John Dallaway - enable GNU tool prefix lookup (#361)
 -->
 <plugin>
 
@@ -24,6 +25,7 @@
       <toolChain
             archList="all"
             configurationEnvironmentSupplier="org.eclipse.cdt.internal.build.crossgcc.CrossEnvironmentVariableSupplier"
+            configurationMacroSupplier="org.eclipse.cdt.internal.build.crossgcc.CrossBuildMacroSupplier"
             id="cdt.managedbuild.toolchain.gnu.cross.base"
             isAbstract="false"
             languageSettingsProviders="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser;org.eclipse.cdt.build.crossgcc.CrossGCCBuiltinSpecsDetector"
@@ -32,7 +34,7 @@
             targetTool="cdt.managedbuild.tool.gnu.cross.c.linker;cdt.managedbuild.tool.gnu.cross.cpp.linker;cdt.managedbuild.tool.gnu.archiver">
          <targetPlatform
                archList="all"
-               binaryParser="org.eclipse.cdt.core.ELF"
+               binaryParser="org.eclipse.cdt.core.GNU_ELF"
                id="cdt.managedbuild.targetPlatform.gnu.cross"
                isAbstract="false"
                osList="all">

--- a/cross/org.eclipse.cdt.build.crossgcc/src/org/eclipse/cdt/internal/build/crossgcc/CrossBuildMacroSupplier.java
+++ b/cross/org.eclipse.cdt.build.crossgcc/src/org/eclipse/cdt/internal/build/crossgcc/CrossBuildMacroSupplier.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2023 John Dallaway and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     John Dallaway - initial API and implementation (#361)
+ *******************************************************************************/
+package org.eclipse.cdt.internal.build.crossgcc;
+
+import org.eclipse.cdt.managedbuilder.core.IConfiguration;
+import org.eclipse.cdt.managedbuilder.core.IOption;
+import org.eclipse.cdt.managedbuilder.macros.AbstractGnuToolPrefixMacro;
+import org.eclipse.cdt.managedbuilder.macros.BuildMacroException;
+import org.eclipse.cdt.managedbuilder.macros.IBuildMacro;
+import org.eclipse.cdt.managedbuilder.macros.IBuildMacroProvider;
+import org.eclipse.cdt.managedbuilder.macros.IConfigurationBuildMacroSupplier;
+import org.eclipse.cdt.utils.IGnuToolFactory;
+import org.eclipse.core.runtime.Status;
+
+public class CrossBuildMacroSupplier implements IConfigurationBuildMacroSupplier {
+
+	private static class GnuToolPrefixMacro extends AbstractGnuToolPrefixMacro {
+
+		private static final String GNU_TOOL_PREFIX_OPTION = "cdt.managedbuild.option.gnu.cross.prefix"; //$NON-NLS-1$
+		private final IConfiguration configuration;
+
+		public GnuToolPrefixMacro(IConfiguration configuration) {
+			this.configuration = configuration;
+		}
+
+		@Override
+		public String getStringValue() throws BuildMacroException {
+			final IOption option = configuration.getToolChain().getOptionBySuperClassId(GNU_TOOL_PREFIX_OPTION);
+			if (null == option) {
+				throw new BuildMacroException(Status.error("Toolchain option not found: " + GNU_TOOL_PREFIX_OPTION)); //$NON-NLS-1$
+			}
+			return getStringValue(option);
+		}
+
+	}
+
+	@Override
+	public IBuildMacro getMacro(String macroName, IConfiguration configuration, IBuildMacroProvider provider) {
+		if (IGnuToolFactory.GNU_TOOL_PREFIX_VARIABLE.equals(macroName)) {
+			return new GnuToolPrefixMacro(configuration);
+		}
+		return null;
+	}
+
+	@Override
+	public IBuildMacro[] getMacros(IConfiguration configuration, IBuildMacroProvider provider) {
+		final IBuildMacro macro = getMacro(IGnuToolFactory.GNU_TOOL_PREFIX_VARIABLE, configuration, provider);
+		return (null == macro) ? new IBuildMacro[0] : new IBuildMacro[] { macro };
+	}
+
+}


### PR DESCRIPTION
Allows the GNU tool prefix to be specified by a CDT build variable.

Modifies the Cross GCC toolchain description to provide the GNU tool prefix.

Part of #361