### PR TITLE
Wrong active build configuration for Core Build projects.

### DIFF
--- a/debug/org.eclipse.cdt.debug.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.cdt.debug.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.core; singleton:=true
-Bundle-Version: 8.8.0.qualifier
+Bundle-Version: 8.8.100.qualifier
 Bundle-Activator: org.eclipse.cdt.debug.core.CDebugCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/core/launch/CoreBuildLaunchBarTracker.java
+++ b/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/core/launch/CoreBuildLaunchBarTracker.java
@@ -100,6 +100,7 @@ public class CoreBuildLaunchBarTracker implements ILaunchBarListener, ILaunchTar
 		}
 
 		if (project == null || !configManager.supports(project)) {
+			// The project is not a Core Build project.
 			return;
 		}
 
@@ -109,7 +110,23 @@ public class CoreBuildLaunchBarTracker implements ILaunchBarListener, ILaunchTar
 		lastDescriptor = descriptor;
 		lastTarget = target;
 
-		// Pick build config based on toolchain for target
+		/*
+		 * Core build projects do not work with the concept of active build
+		 * configurations, like managed build projects. Instead they rely
+		 * on the launch mode set in the launchBar. A core build launch
+		 * configuration looks at the launchBar mode to pick the build
+		 * configuration. Core build projects still have an active build
+		 * configuration, but it is hidden for the user and ignored for
+		 * launching.
+		 *
+		 * Core build launch configurations have no options to set, so it is
+		 * likely that users will use non core build launch configurations to
+		 * launch a core build project binary. Non core build launch
+		 * configurations typically launch the active build configuration. The
+		 * active build configuration needs to match the launchBar mode.
+		 */
+
+		// Pick core build config based on launch mode and toolchain for target
 		// Since this may create a new config, need to run it in a Job
 		Job job = new Job(InternalDebugCoreMessages.CoreBuildLaunchBarTracker_Job) {
 			@Override
@@ -120,11 +137,12 @@ public class CoreBuildLaunchBarTracker implements ILaunchBarListener, ILaunchTar
 					Collection<IToolChain> tcs = toolChainManager.getToolChainsMatching(properties);
 					ICBuildConfiguration buildConfig = null;
 					if (!tcs.isEmpty()) {
-						// First, see if any existing non default build configs match the target properties
 						configs: for (IBuildConfiguration config : finalProject.getBuildConfigs()) {
-							if (!config.getName().equals(IBuildConfiguration.DEFAULT_CONFIG_NAME)) {
-								ICBuildConfiguration testConfig = configManager.getBuildConfiguration(config);
-								if (testConfig != null && !(testConfig instanceof ErrorBuildConfiguration)) {
+							ICBuildConfiguration testConfig = configManager.getBuildConfiguration(config);
+							if (testConfig != null && !(testConfig instanceof ErrorBuildConfiguration)) {
+								// Match launch mode run/debug.
+								if (testConfig.getLaunchMode().equals(lastMode.getIdentifier())) {
+									// Match toolchain.
 									for (IToolChain tc : tcs) {
 										if (testConfig.getToolChain().equals(tc)) {
 											buildConfig = testConfig;

--- a/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/core/launch/CoreBuildLaunchBarTracker.java
+++ b/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/core/launch/CoreBuildLaunchBarTracker.java
@@ -113,17 +113,18 @@ public class CoreBuildLaunchBarTracker implements ILaunchBarListener, ILaunchTar
 		/*
 		 * Core build projects do not work with the concept of active build
 		 * configurations, like managed build projects. Instead they rely
-		 * on the launch mode set in the launchBar. A core build launch
-		 * configuration looks at the launchBar mode to pick the build
-		 * configuration. Core build projects still have an active build
-		 * configuration, but it is hidden for the user and ignored for
+		 * on the launch mode and launch target set in the launchBar. A core
+		 * build launch configuration looks at the launchBar launch mode
+		 * and then the set of toolchains associated with the launch target
+		 * to pick the build configuration. Core build projects still have an
+		 * active build configuration, but it is hidden for the user and ignored for
 		 * launching.
 		 *
 		 * Core build launch configurations have no options to set, so it is
-		 * likely that users will use non core build launch configurations to
+		 * possible that users will use non core build launch configurations to
 		 * launch a core build project binary. Non core build launch
 		 * configurations typically launch the active build configuration. The
-		 * active build configuration needs to match the launchBar mode.
+		 * active build configuration needs to match the launchBar launch mode.
 		 */
 
 		// Pick core build config based on launch mode and toolchain for target


### PR DESCRIPTION
The CoreBuildLaunchBar tracker always made a non default build configuration the active build configuration. In other words, it always made the debug build configuration active.
This caused wrong build flags if a non core build launch configuration was used to launch a core build project binary.

Fixed the CoreBuildLaunchBar tracker to set the build configuration to active that matches the launchBar mode.

Fixes #378