### PR TITLE
Enable toggling breakpoints in LSP CEditor

### DIFF
--- a/debug/org.eclipse.cdt.debug.ui/src/org/eclipse/cdt/debug/internal/ui/breakpoints/ToggleCBreakpointTester.java
+++ b/debug/org.eclipse.cdt.debug.ui/src/org/eclipse/cdt/debug/internal/ui/breakpoints/ToggleCBreakpointTester.java
@@ -28,6 +28,7 @@ import org.eclipse.cdt.internal.ui.editor.CEditor;
 import org.eclipse.cdt.internal.ui.editor.asm.AsmTextEditor;
 import org.eclipse.core.expressions.PropertyTester;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.ui.editors.text.TextEditor;
 
 /**
  * Toggle breakpoint factor enablement tester for editors and IDeclaration.
@@ -117,6 +118,14 @@ public class ToggleCBreakpointTester extends PropertyTester {
 					}
 				}
 			}
+
+			// Test for LSP based C/C++ Editor
+		} else if ("isCEditorSupportsCBreakpoint".equals(property) && (receiver instanceof TextEditor)) { //$NON-NLS-1$
+			var editor = (TextEditor) receiver;
+			if (editor.getEditorSite() == null || !editor.getEditorSite().getId().equals("org.eclipse.cdt.lsp.CEditor")) //$NON-NLS-1$
+				return false;
+			if (!CDebugUtils.isCustomToggleBreakpointFactory())
+				return true;
 		}
 
 		return false;


### PR DESCRIPTION
This is an example of where we have somewhat an inversion of dependencies. The existing CDT code assumes it knows about all types of editors at compile time. In this case the LSP C Editor is a new type. However, rather than creating a new extension mechanism here we are simply adding the LSP C Editor to the known list as the LSP C Editor is (or will soon be) part of CDT itself anyway (see #354)

By itself this change doesn't do anything, it needs the change in https://github.com/Bachmann-electronic-GmbH/eclipse-cdt-lsp/pull/46/

Also-by: Gesa HENTSCHKE <Gesa.HENTSCHKE@bachmann.info>