### PR TITLE
Update to using direct from maven dependencies where possible

### DIFF
--- a/build/org.eclipse.cdt.managedbuilder.core.tests/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.managedbuilder.core.tests/META-INF/MANIFEST.MF
@@ -14,7 +14,6 @@ Export-Package: org.eclipse.cdt.managedbuilder.core.tests,
  org.eclipse.cdt.projectmodel.tests
 Require-Bundle: org.eclipse.core.runtime,
  org.junit,
- org.junit.jupiter.api,
  org.eclipse.core.resources,
  org.eclipse.ui,
  org.eclipse.ui.ide,
@@ -26,4 +25,6 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.cdt.managedbuilder.core.tests
-Import-Package: com.google.gson
+Import-Package: com.google.gson,
+ org.junit.jupiter.api;version="[5.9.3,6.0.0)",
+ org.junit.jupiter.api.function;version="[5.9.3,6.0.0)"

--- a/cmake/org.eclipse.cdt.cmake.core.tests/META-INF/MANIFEST.MF
+++ b/cmake/org.eclipse.cdt.cmake.core.tests/META-INF/MANIFEST.MF
@@ -4,10 +4,10 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.cmake.core.tests
 Bundle-Version: 1.0.0.qualifier
 Fragment-Host: org.eclipse.cdt.cmake.core;bundle-version="1.5.0"
+Import-Package: org.assertj.core.api;version="[3.24.2,4.0.0)",
+ org.junit.jupiter.api;version="[5.9.3,6.0.0)"
 Automatic-Module-Name: org.eclipse.cdt.cmake.core.tests
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Copyright: %Bundle-Copyright
-Require-Bundle: org.junit,
- org.junit.jupiter.api,
- org.assertj;bundle-version="3.14.0"
+Require-Bundle: org.junit
 

--- a/cmake/org.eclipse.cdt.cmake.core.tests/src/org/eclipse/cdt/cmake/core/internal/CMakePropertiesEvolutionTest.java
+++ b/cmake/org.eclipse.cdt.cmake.core.tests/src/org/eclipse/cdt/cmake/core/internal/CMakePropertiesEvolutionTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.eclipse.cdt.cmake.core.internal.properties.CMakePropertiesBean;
 import org.eclipse.cdt.cmake.core.properties.CMakeGenerator;
 import org.junit.Test;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
 
@@ -56,7 +57,7 @@ public class CMakePropertiesEvolutionTest {
 		extraArgs.add("arg2");
 		props.setExtraArguments(extraArgs);
 
-		Yaml yaml = new Yaml(new CustomClassLoaderConstructor(this.getClass().getClassLoader()));
+		Yaml yaml = new Yaml(new CustomClassLoaderConstructor(this.getClass().getClassLoader(), new LoaderOptions()));
 		String output = yaml.dump(props);
 
 		// try to load as evolved properties..

--- a/cmake/org.eclipse.cdt.cmake.core/META-INF/MANIFEST.MF
+++ b/cmake/org.eclipse.cdt.cmake.core/META-INF/MANIFEST.MF
@@ -12,8 +12,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.cdt.core;bundle-version="5.12.0",
  org.eclipse.tools.templates.freemarker;bundle-version="1.2.200",
  com.google.gson,
- org.eclipse.cdt.jsoncdb.core,
- org.yaml.snakeyaml;bundle-version="[1.14.0,2.0.0)"
+ org.eclipse.cdt.jsoncdb.core
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.cdt.cmake.core,
@@ -21,4 +20,6 @@ Export-Package: org.eclipse.cdt.cmake.core,
  org.eclipse.cdt.cmake.core.properties
 Automatic-Module-Name: org.eclipse.cdt.cmake.core
 Bundle-Localization: plugin
-Import-Package: org.eclipse.core.variables
+Import-Package: org.eclipse.core.variables,
+ org.yaml.snakeyaml;version="[2.0.0,3.0.0)",
+ org.yaml.snakeyaml.constructor;version="[2.0.0,3.0.0)"

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakePropertiesController.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakePropertiesController.java
@@ -27,6 +27,7 @@ import org.eclipse.cdt.cmake.core.internal.properties.CMakePropertiesBean;
 import org.eclipse.cdt.cmake.core.properties.CMakeGenerator;
 import org.eclipse.cdt.cmake.core.properties.ICMakeProperties;
 import org.eclipse.cdt.cmake.core.properties.ICMakePropertiesController;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
 
@@ -66,8 +67,9 @@ class CMakePropertiesController implements ICMakePropertiesController {
 		CMakePropertiesBean props = null;
 		if (Files.exists(storageFile)) {
 			try (InputStream is = Files.newInputStream(storageFile)) {
-				props = new Yaml(new CustomClassLoaderConstructor(this.getClass().getClassLoader())).loadAs(is,
-						CMakePropertiesBean.class);
+				var classLoader = this.getClass().getClassLoader();
+				var clConstructor = new CustomClassLoaderConstructor(classLoader, new LoaderOptions());
+				props = new Yaml(clConstructor).loadAs(is, CMakePropertiesBean.class);
 				// props is null here if if no document was available in the file
 			}
 		}

--- a/jenkins/pod-templates/cdt-full-pod-plus-eclipse-install.yaml
+++ b/jenkins/pod-templates/cdt-full-pod-plus-eclipse-install.yaml
@@ -20,6 +20,11 @@ spec:
       readOnly: true
     - name: m2-repo
       mountPath: /home/jenkins/.m2/repository
+    - name: "jenkins-home"
+      mountPath: "/home/jenkins"
+      readOnly: false
+    - name: tools
+      mountPath: /jipp/tools
   - name: jnlp
     resources:
       requests:
@@ -37,3 +42,8 @@ spec:
         path: settings.xml
   - name: m2-repo
     emptyDir: {}
+  - name: "jenkins-home"
+    emptyDir: {}
+  - name: tools
+    persistentVolumeClaim:
+      claimName: tools-claim-jiro-cdt

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 			 runs with. It may work with older versions, but this is not
 			 tested or supported. -->
 		<required-maven-version>3.6.3</required-maven-version>
-		<tycho-version>3.0.3</tycho-version>
+		<tycho-version>3.0.5</tycho-version>
 		<cbi-plugins.version>1.3.4</cbi-plugins.version>
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
 		<cdt-site>http://ci.eclipse.org/cdt/job/cdt-master/lastSuccessfulBuild/artifact/releng/org.eclipse.cdt.repo/target/repository</cdt-site>
@@ -986,6 +986,23 @@
 						<phase>compile</phase>
 						<configuration>
 							<executionEnvironment>JavaSE-11</executionEnvironment>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-gpg-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>pgpsigner</id>
+						<goals>
+						<goal>sign-p2-artifacts</goal>
+						</goals>
+						<configuration>
+							<keyname>4F23165B6AC51B15</keyname>
+							<skipIfJarsigned>false</skipIfJarsigned>
 						</configuration>
 					</execution>
 				</executions>

--- a/releng/CDT.setup
+++ b/releng/CDT.setup
@@ -246,7 +246,7 @@
         <repository
             url="https://download.eclipse.org/tools/orbit/downloads/drops/R20201118194144/repository"/>
         <repository
-            url="https://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
+            url="https://download.eclipse.org/oomph/simrel-orbit/milestone/latest/"/>
         <repository
             url="https://download.eclipse.org/technology/swtbot/releases/latest"/>
         <repository

--- a/releng/org.eclipse.cdt.repo/pom.xml
+++ b/releng/org.eclipse.cdt.repo/pom.xml
@@ -28,4 +28,19 @@
 	<build>
 		<finalName>${project.artifactId}</finalName>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>production</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-gpg-plugin</artifactId>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 </project>

--- a/releng/org.eclipse.cdt.target/cdt.target
+++ b/releng/org.eclipse.cdt.target/cdt.target
@@ -1,101 +1,101 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="cdt" sequenceNumber="138">
+<target name="cdt" sequenceNumber="135">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
-			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/cbi/updates/license/" />
+			<unit id="org.eclipse.license.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.28/R-4.28-202306050440"/>
-			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
-			<unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.test.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.unittest.ui" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.28/R-4.28-202306050440" />
+			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.jdt.annotation" version="0.0.0" />
+			<unit id="org.eclipse.sdk.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.test.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.unittest.ui" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/egit/updates"/>
-			<unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/egit/updates" />
+			<unit id="org.eclipse.egit.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/linuxtools/updates-docker-nightly/"/>
-			<unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/linuxtools/updates-docker-nightly/" />
+			<unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/lsp4e/snapshots/"/>
-			<unit id="org.eclipse.lsp4e" version="0.0.0"/>
-			<unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/lsp4e/snapshots/" />
+			<unit id="org.eclipse.lsp4e" version="0.0.0" />
+			<unit id="org.eclipse.lsp4e.debug" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/latest/"/>
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/latest/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/technology/swtbot/releases/latest"/>
-			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/technology/swtbot/releases/latest" />
+			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tm4e/snapshots/"/>
-			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
-			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/tm4e/snapshots/" />
+			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0" />
+			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/cdt/releases/latest"/>
+			<repository location="https://download.eclipse.org/tools/cdt/releases/latest" />
 			<!-- We explicitly have CDT in target platform so that developers can develop org.eclipse.cdt.core/ui without requiring all the projects from CDT in their workspace. -->
-			<unit id="org.eclipse.cdt.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/0.15.0/"/>
-			<unit id="org.eclipse.wildwebdeveloper.embedder.node.feature.feature.group" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/0.15.0/" />
+			<unit id="org.eclipse.wildwebdeveloper.embedder.node.feature.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository/"/>
-			<unit id="com.google.gson" version="0.0.0"/>
-			<unit id="com.sun.xml.bind" version="2.3.3.v20221203-1659"/>
-			<unit id="javax.activation" version="1.2.2.v20221203-1659"/>
-			<unit id="jakarta.xml.bind" version="2.3.3.v20221203-1659"/>
-			<unit id="org.antlr.runtime" version="0.0.0"/>
-			<unit id="org.apache.commons.compress" version="0.0.0"/>
-			<unit id="org.assertj" version="0.0.0"/>
-			<unit id="org.freemarker" version="0.0.0"/>
-			<unit id="org.hamcrest" version="0.0.0"/>
-			<unit id="org.hamcrest.core" version="0.0.0"/>
-			<unit id="org.junit" version="0.0.0"/>
-			<unit id="org.junit.jupiter.api" version="0.0.0"/>
-			<unit id="org.mockito.mockito-core" version="0.0.0"/>
-			<unit id="org.yaml.snakeyaml" version="0.0.0"/>
-			<unit id="com.sun.jna" version="5.8.0.v20210503-0343"/>
-			<unit id="com.sun.jna.platform" version="5.8.0.v20221112-0806"/>
-			<unit id="javax.activation" version="2.0.0.v20221203-1659"/>
-			<unit id="javax.xml" version="1.4.1.v20220503-2331"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230302014618/repository/" />
+			<unit id="com.google.gson" version="0.0.0" />
+			<unit id="com.sun.xml.bind" version="2.3.3.v20221203-1659" />
+			<unit id="javax.activation" version="1.2.2.v20221203-1659" />
+			<unit id="jakarta.xml.bind" version="2.3.3.v20221203-1659" />
+			<unit id="org.antlr.runtime" version="0.0.0" />
+			<unit id="org.apache.commons.compress" version="0.0.0" />
+			<unit id="org.assertj" version="0.0.0" />
+			<unit id="org.freemarker" version="0.0.0" />
+			<unit id="org.hamcrest" version="0.0.0" />
+			<unit id="org.hamcrest.core" version="0.0.0" />
+			<unit id="org.junit" version="0.0.0" />
+			<unit id="org.junit.jupiter.api" version="0.0.0" />
+			<unit id="org.mockito.mockito-core" version="0.0.0" />
+			<unit id="org.yaml.snakeyaml" version="0.0.0" />
+			<unit id="com.sun.jna" version="5.8.0.v20210503-0343" />
+			<unit id="com.sun.jna.platform" version="5.8.0.v20221112-0806" />
+			<unit id="javax.activation" version="2.0.0.v20221203-1659" />
+			<unit id="javax.xml" version="1.4.1.v20220503-2331" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20201118194144/repository/"/>
-			<unit id="javax.xml.stream" version="0.0.0"/>
-			<unit id="net.sourceforge.lpg.lpgjavaruntime" version="0.0.0"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20201118194144/repository/" />
+			<unit id="javax.xml.stream" version="0.0.0" />
+			<unit id="net.sourceforge.lpg.lpgjavaruntime" version="0.0.0" />
 		</location>
-		
-	    <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
-		  <dependencies>
-			  <dependency>
-				  <groupId>org.slf4j</groupId>
-				  <artifactId>slf4j-api</artifactId>
-				  <version>1.7.36</version>
-				  <type>jar</type>
-			  </dependency>
-			  <!-- slf4j-api requires 1 impl, providing a dummy one... -->
-			  <dependency>
-				  <groupId>org.slf4j</groupId>
-				  <artifactId>slf4j-nop</artifactId>
-				  <version>1.7.36</version>
-				  <type>jar</type>
-			  </dependency>
-		  </dependencies>
-	    </location>
+
+		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="error" type="Maven">
+			<dependencies>
+				<dependency>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+					<version>1.7.36</version>
+					<type>jar</type>
+				</dependency>
+				<!-- slf4j-api requires 1 impl, providing a dummy one... -->
+				<dependency>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-nop</artifactId>
+					<version>1.7.36</version>
+					<type>jar</type>
+				</dependency>
+			</dependencies>
+		</location>
 	</locations>
-	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17" />
 	<launcherArgs>
 		<vmArgs>-Xms40m&#13;
 		-Xmx512M&#13;

--- a/releng/org.eclipse.cdt.target/cdt.target
+++ b/releng/org.eclipse.cdt.target/cdt.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="cdt" sequenceNumber="135">
+<target name="cdt" sequenceNumber="139">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/" />
@@ -51,23 +51,13 @@
 			<unit id="org.eclipse.wildwebdeveloper.embedder.node.feature.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230302014618/repository/" />
-			<unit id="com.google.gson" version="0.0.0" />
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/latest-R/" />
 			<unit id="com.sun.xml.bind" version="2.3.3.v20221203-1659" />
 			<unit id="javax.activation" version="1.2.2.v20221203-1659" />
 			<unit id="jakarta.xml.bind" version="2.3.3.v20221203-1659" />
-			<unit id="org.antlr.runtime" version="0.0.0" />
-			<unit id="org.apache.commons.compress" version="0.0.0" />
-			<unit id="org.assertj" version="0.0.0" />
-			<unit id="org.freemarker" version="0.0.0" />
-			<unit id="org.hamcrest" version="0.0.0" />
-			<unit id="org.hamcrest.core" version="0.0.0" />
-			<unit id="org.junit" version="0.0.0" />
-			<unit id="org.junit.jupiter.api" version="0.0.0" />
-			<unit id="org.mockito.mockito-core" version="0.0.0" />
-			<unit id="org.yaml.snakeyaml" version="0.0.0" />
-			<unit id="com.sun.jna" version="5.8.0.v20210503-0343" />
-			<unit id="com.sun.jna.platform" version="5.8.0.v20221112-0806" />
+			<unit id="org.hamcrest" version="2.2.0.v20210711-0821" />
+			<unit id="org.hamcrest.core" version="1.3.0.v20180420-1519" />
+			<unit id="org.junit" version="4.13.2.v20211018-1956" />
 			<unit id="javax.activation" version="2.0.0.v20221203-1659" />
 			<unit id="javax.xml" version="1.4.1.v20220503-2331" />
 		</location>
@@ -90,6 +80,66 @@
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-nop</artifactId>
 					<version>1.7.36</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>com.google.code.gson</groupId>
+					<artifactId>gson</artifactId>
+					<version>2.10.1</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-compress</artifactId>
+					<version>1.23.0</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.assertj</groupId>
+					<artifactId>assertj-core</artifactId>
+					<version>3.24.2</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.freemarker</groupId>
+					<artifactId>freemarker</artifactId>
+					<version>2.3.32</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.junit.jupiter</groupId>
+					<artifactId>junit-jupiter-api</artifactId>
+					<version>5.9.3</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.junit.jupiter</groupId>
+					<artifactId>junit-jupiter-engine</artifactId>
+					<version>5.9.3</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-core</artifactId>
+					<version>5.3.1</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>org.yaml</groupId>
+					<artifactId>snakeyaml</artifactId>
+					<version>2.0</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>net.java.dev.jna</groupId>
+					<artifactId>jna-platform</artifactId>
+					<version>5.13.0</version>
+					<type>jar</type>
+				</dependency>
+				<dependency>
+					<groupId>net.java.dev.jna</groupId>
+					<artifactId>jna</artifactId>
+					<version>5.13.0</version>
 					<type>jar</type>
 				</dependency>
 			</dependencies>

--- a/releng/org.eclipse.cdt.target/pom.xml
+++ b/releng/org.eclipse.cdt.target/pom.xml
@@ -31,7 +31,7 @@
 			<plugin>
 			<groupId>org.codehaus.mojo</groupId>
 			<artifactId>build-helper-maven-plugin</artifactId>
-			<version>3.3.0</version>
+			<version>3.4.0</version>
 				<executions>
 					<execution>
 						<id>attach-artifacts</id>

--- a/terminal/plugins/org.eclipse.tm.terminal.test/META-INF/MANIFEST.MF
+++ b/terminal/plugins/org.eclipse.tm.terminal.test/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Require-Bundle: org.junit,
  org.eclipse.tm.terminal.control;bundle-version="4.5.0",
  org.eclipse.core.runtime,
  org.eclipse.ui,
- org.junit.jupiter.api,
  org.opentest4j
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.tm.internal.terminal.connector;x-internal:=true,
@@ -21,4 +20,6 @@ Export-Package: org.eclipse.tm.internal.terminal.connector;x-internal:=true,
  org.eclipse.tm.internal.terminal.textcanvas;x-internal:=true,
  org.eclipse.tm.terminal.model,
  org.eclipse.tm.terminal.test
+Import-Package: org.junit.jupiter.api;version="[5.9.3,6.0.0)",
+ org.junit.jupiter.api.function;version="[5.9.3,6.0.0)"
 Automatic-Module-Name: org.eclipse.tm.terminal.test


### PR DESCRIPTION
This is the next step in modernization and moving on from Orbit.

All the bundles that have fully OSGi bundles in maven are included in this update.

This PR contains the other update needed for 2023-06 M2

Part of #320 