### PR TITLE
[#390] Fix API errors for Deduction Guides #390

### DIFF
--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/IScope.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/IScope.java
@@ -173,7 +173,7 @@ public interface IScope {
 			fArgumentDependent = argumentDependent;
 		}
 
-		/** @since 8.1 */
+		/** @since 8.2 */
 		public final void setDeductionGuidesOnly(boolean deductionGuidesOnly) {
 			fDeductionGuidesOnly = deductionGuidesOnly;
 		}
@@ -207,7 +207,7 @@ public interface IScope {
 			return fArgumentDependent;
 		}
 
-		/** @since 8.1 */
+		/** @since 8.2 */
 		public final boolean isDeductionGuidesOnly() {
 			return fDeductionGuidesOnly;
 		}

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPASTDeductionGuide.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPASTDeductionGuide.java
@@ -16,7 +16,7 @@ package org.eclipse.cdt.core.dom.ast.cpp;
 /**
  * Deduction guide, introduced in C++17.
  *
- * @since 8.1
+ * @since 8.2
  * @noextend This interface is not intended to be extended by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPClassConstructorDeductionGuide.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPClassConstructorDeductionGuide.java
@@ -16,7 +16,7 @@ package org.eclipse.cdt.core.dom.ast.cpp;
 /**
  * Marker for deduction guide synthesized from class constructor
  *
- * @since 8.1
+ * @since 8.2
  * @noextend This interface is not intended to be extended by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPClassConstructorTemplateDeductionGuide.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPClassConstructorTemplateDeductionGuide.java
@@ -16,7 +16,7 @@ package org.eclipse.cdt.core.dom.ast.cpp;
 /**
  * Marker for deduction guide synthesized from class constructor template
  *
- * @since 8.1
+ * @since 8.2
  * @noextend This interface is not intended to be extended by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPCopyDeductionCandidate.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPCopyDeductionCandidate.java
@@ -16,7 +16,7 @@ package org.eclipse.cdt.core.dom.ast.cpp;
 /**
  * Marker for copy deduction candidate used with Class Template Argument Deduction, introduced in C++17.
  *
- * @since 8.1
+ * @since 8.2
  * @noextend This interface is not intended to be extended by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPDeductionGuide.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPDeductionGuide.java
@@ -16,7 +16,7 @@ package org.eclipse.cdt.core.dom.ast.cpp;
 /**
  * Deduction guide, introduced in C++17.
  *
- * @since 8.1
+ * @since 8.2
  * @noextend This interface is not intended to be extended by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPNodeFactory.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPNodeFactory.java
@@ -254,7 +254,7 @@ public interface ICPPNodeFactory extends INodeFactory {
 			IASTExpression rhs);
 
 	/**
-	 * @since 8.1
+	 * @since 8.2
 	 */
 	public ICPPASTDeductionGuide newDeductionGuide();
 

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPUserDefinedDeductionGuide.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/cpp/ICPPUserDefinedDeductionGuide.java
@@ -16,7 +16,7 @@ package org.eclipse.cdt.core.dom.ast.cpp;
 /**
  * Marker for user-defined deduction guide for Class Template Argument Deduction, introduced in C++17.
  *
- * @since 8.1
+ * @since 8.2
  * @noextend This interface is not intended to be extended by clients.
  * @noimplement This interface is not intended to be implemented by clients.
  */


### PR DESCRIPTION
Update `@since` tag value from 8.1 to 8.2

Fixes https://github.com/eclipse-cdt/cdt/issues/390