### PR TITLE
Guard if no editor is associated with the hover

### DIFF
--- a/debug/org.eclipse.cdt.debug.ui/src/org/eclipse/cdt/debug/ui/editors/AbstractDebugTextHover.java
+++ b/debug/org.eclipse.cdt.debug.ui/src/org/eclipse/cdt/debug/ui/editors/AbstractDebugTextHover.java
@@ -239,7 +239,9 @@ public abstract class AbstractDebugTextHover implements ICEditorTextHover, IText
 	 *         validated
 	 */
 	private String getExpressionTextFromAST(IDocument document, final IRegion hoverRegion) {
-		ICElement cElement = CDTUITools.getEditorInputCElement(getEditor().getEditorInput());
+		ICElement cElement = getEditor() == null ? null
+				: CDTUITools.getEditorInputCElement(getEditor().getEditorInput());
+
 		if (!(cElement instanceof ITranslationUnit)) {
 			return null;
 		}


### PR DESCRIPTION
To implement [cdt-lsp/issues/70](https://github.com/eclipse-cdt/cdt-lsp/issues/70), we need to delegate to the cdt debug hover mechanism. This leads to a NPE in `AbstractDebugTextHover`
```
java.lang.NullPointerException: Cannot invoke "org.eclipse.ui.IEditorPart.getEditorInput()" because the return value of "org.eclipse.cdt.debug.ui.editors.AbstractDebugTextHover.getEditor()" is null
	at org.eclipse.cdt.debug.ui.editors.AbstractDebugTextHover.getExpressionTextFromAST(AbstractDebugTextHover.java:242)
	at org.eclipse.cdt.debug.ui.editors.AbstractDebugTextHover.getExpressionText(AbstractDebugTextHover.java:217)
	at org.eclipse.cdt.debug.ui.editors.AbstractDebugTextHover.getHoverInfo(AbstractDebugTextHover.java:164)
	at org.eclipse.cdt.dsf.debug.ui.AbstractDsfDebugTextHover.getHoverInfo2(AbstractDsfDebugTextHover.java:220)
	at org.eclipse.cdt.lsp.editor.DebugHoverProvider.lambda$3(DebugHoverProvider.java:35)
	at java.base/java.util.Optional.map(Optional.java:260)
	at org.eclipse.cdt.lsp.editor.DebugHoverProvider.getHoverInfo2(DebugHoverProvider.java:35)
	at org.eclipse.ui.internal.genericeditor.hover.CompositeTextHover.getHoverInfo2(CompositeTextHover.java:59)
	at org.eclipse.jface.text.TextViewerHoverManager$1.run(TextViewerHoverManager.java:155)
```

This PR fixes the NPE.