### PR TITLE
Process ELF files without file suffix as binary content

### DIFF
--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core; singleton:=true
-Bundle-Version: 8.2.0.qualifier
+Bundle-Version: 8.2.100.qualifier
 Bundle-Activator: org.eclipse.cdt.core.CCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core/plugin.properties
+++ b/core/org.eclipse.cdt.core/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2003, 2014 IBM Corporation and others.
+# Copyright (c) 2003, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
 #     IBM Corporation - initial API and implementation
 #     Anton Leherbauer (Wind River Systems)
 #     Martin Oberhuber (Wind River) - [303083] Split out the Spawner
+#     John Dallaway - Add ELF file content type (#409)
 ###############################################################################
 pluginName=C/C++ Development Tools Core
 providerName=Eclipse CDT
@@ -41,8 +42,8 @@ CTaskName=C/C++ Task
 
 IndexerMarker=Indexer Marker
 
-ElfParser.name=Elf Parser
-GNUElfParser.name=GNU Elf Parser
+ElfParser.name=ELF Parser
+GNUElfParser.name=GNU ELF Parser
 PEWindowsParser.name=PE Windows Parser (Deprecated)
 PE64WindowsParser.name=PE64 Windows Parser
 GNUPE64WindowsParser.name=GNU PE64 Windows Parser
@@ -100,6 +101,7 @@ cxxSourceName=C++ Source File
 cxxHeaderName=C++ Header File
 asmSourceName=Assembly Source File
 binaryFileName=Binary File
+elfFileName=ELF File
 
 cdt_pathentry_var.description=CDT PathEntry variable
 config_name_var.description=The name of the active configuration for the project specified as an argument

--- a/core/org.eclipse.cdt.core/plugin.xml
+++ b/core/org.eclipse.cdt.core/plugin.xml
@@ -568,6 +568,30 @@
    </extension>
 
 <!-- =================================================================================== -->
+<!-- Binary file content types                                                           -->
+<!-- =================================================================================== -->
+   <extension point="org.eclipse.core.contenttype.contentTypes">
+      <content-type
+            id="binaryFile"
+            name="%binaryFileName"
+            priority="high"/>
+      <content-type
+            base-type="org.eclipse.cdt.core.binaryFile"
+            id="elfFile"
+            name="%elfFileName"
+            priority="low">
+         <describer
+               class="org.eclipse.core.runtime.content.BinarySignatureDescriber"
+               plugin="org.eclipse.core.contenttype">
+            <parameter name="signature" value="7F 45 4C 46"/>
+         </describer>
+      </content-type>
+      <file-association
+            content-type="org.eclipse.cdt.core.elfFile"
+            file-patterns="[^.]+"/> <!-- no file extension -->
+   </extension>
+
+<!-- =================================================================================== -->
 <!-- .cproject Content Type                                                              -->
 <!-- =================================================================================== -->
    <extension point="org.eclipse.core.contenttype.contentTypes">
@@ -602,8 +626,6 @@
       <content-type id="asmSource" name="%asmSourceName" 
           base-type="org.eclipse.core.runtime.text"
           file-extensions="S,s,asm,ASM"
-          priority="high"/>
-      <content-type id="binaryFile" name="%binaryFileName"
           priority="high"/>
    </extension>
 


### PR DESCRIPTION
Creates an association between ELF files that have no file extension and the existing `org.eclipse.cdt.core.binaryFile` content type. This allows such files to be opened using the _Default Binary File Viewer_ by double-clicking in the _Project Explorer_ view.

ELF files that have a file extension (eg `.elf`, `.o`) are associated by other mechanisms and we avoid the overhead associated with file content signature matching by not including them here.