### PR TITLE
Use PE64 class for machine type validation

### DIFF
--- a/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/coff/parser/PEParser64.java
+++ b/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/coff/parser/PEParser64.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 Space Codesign Systems and others.
+ * Copyright (c) 2000, 2023 Space Codesign Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     Space Codesign Systems - Initial API and implementation
  *     QNX Software Systems - Initial PEParser class
+ *     John Dallaway - Use PE64 class for machine type validation (#411)
  *******************************************************************************/
 
 package org.eclipse.cdt.utils.coff.parser;
@@ -24,7 +25,6 @@ import org.eclipse.cdt.core.IBinaryParser;
 import org.eclipse.cdt.utils.AR;
 import org.eclipse.cdt.utils.coff.PE64;
 import org.eclipse.cdt.utils.coff.PE64.Attribute;
-import org.eclipse.cdt.utils.coff.PEConstants;
 import org.eclipse.core.runtime.IPath;
 
 /**
@@ -99,28 +99,7 @@ public class PEParser64 extends AbstractCExtension implements IBinaryParser {
 		// It maybe an object file try the known machine types.
 		if (!isBin && array.length > 1) {
 			int f_magic = (((array[1] & 0xff) << 8) | (array[0] & 0xff));
-			switch (f_magic) {
-			case PEConstants.IMAGE_FILE_MACHINE_ALPHA:
-			case PEConstants.IMAGE_FILE_MACHINE_ARM:
-			case PEConstants.IMAGE_FILE_MACHINE_ALPHA64:
-			case PEConstants.IMAGE_FILE_MACHINE_I386:
-			case PEConstants.IMAGE_FILE_MACHINE_IA64:
-			case PEConstants.IMAGE_FILE_MACHINE_M68K:
-			case PEConstants.IMAGE_FILE_MACHINE_MIPS16:
-			case PEConstants.IMAGE_FILE_MACHINE_MIPSFPU:
-			case PEConstants.IMAGE_FILE_MACHINE_MIPSFPU16:
-			case PEConstants.IMAGE_FILE_MACHINE_POWERPC:
-			case PEConstants.IMAGE_FILE_MACHINE_R3000:
-			case PEConstants.IMAGE_FILE_MACHINE_R4000:
-			case PEConstants.IMAGE_FILE_MACHINE_R10000:
-			case PEConstants.IMAGE_FILE_MACHINE_SH3:
-			case PEConstants.IMAGE_FILE_MACHINE_SH4:
-			case PEConstants.IMAGE_FILE_MACHINE_THUMB:
-			case PEConstants.IMAGE_FILE_MACHINE_ARM2:
-				// Ok;
-				isBin = true;
-				break;
-			}
+			isBin = PE64.isValidMachine(f_magic);
 		}
 		return isBin;
 	}


### PR DESCRIPTION
The PEParser64 class is modified to use the list of valid machine types maintained by the PE class. Critically, this includes the AMD64 machine type, allowing PEParser64 to recognize object files generated by a MinGW 64-bit toolchain as being binary files.