### PR TITLE
Implement the object file buid artifact mentioned in #394

### DIFF
--- a/build/org.eclipse.cdt.managedbuilder.core/plugin.xml
+++ b/build/org.eclipse.cdt.managedbuilder.core/plugin.xml
@@ -296,6 +296,10 @@
             property="org.eclipse.cdt.build.core.buildArtefactType" 
             id="org.eclipse.cdt.build.core.buildArtefactType.sharedLib" 
             name="%BuildProperty.type.name.sharedLibrary"/>
+      <propertyValue
+            property="org.eclipse.cdt.build.core.buildArtefactType"
+            id="org.eclipse.cdt.build.core.buildArtefactType.objectFile"
+            name="%BuildProperty.type.name.objectFile"/>
 
       </extension>
       

--- a/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/core/ManagedBuildManager.java
+++ b/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/core/ManagedBuildManager.java
@@ -190,6 +190,7 @@ public class ManagedBuildManager extends AbstractCExtension {
 	public static final String BUILD_ARTEFACT_TYPE_PROPERTY_EXE = "org.eclipse.cdt.build.core.buildArtefactType.exe"; //$NON-NLS-1$
 	public static final String BUILD_ARTEFACT_TYPE_PROPERTY_STATICLIB = "org.eclipse.cdt.build.core.buildArtefactType.staticLib"; //$NON-NLS-1$
 	public static final String BUILD_ARTEFACT_TYPE_PROPERTY_SHAREDLIB = "org.eclipse.cdt.build.core.buildArtefactType.sharedLib"; //$NON-NLS-1$
+	public static final String BUILD_ARTEFACT_TYPE_PROPERTY_OBJECTFILE = "org.eclipse.cdt.build.core.buildArtefactType.objectFile"; //$NON-NLS-1$
 
 	public static final String CFG_DATA_PROVIDER_ID = ManagedBuilderCorePlugin.PLUGIN_ID + ".configurationDataProvider"; //$NON-NLS-1$
 

--- a/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/makegen/gnu/GnuMakefileGenerator.java
+++ b/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/makegen/gnu/GnuMakefileGenerator.java
@@ -1739,6 +1739,12 @@ public class GnuMakefileGenerator implements IManagedBuilderMakefileGenerator2 {
 		} else {
 			getRuleList().add(buildRule);
 			buffer.append(buildRule).append(NEWLINE);
+
+			IBuildPropertyValue value = config.getBuildArtefactType();
+			if (value.getId().equals(ManagedBuildManager.BUILD_ARTEFACT_TYPE_PROPERTY_OBJECTFILE)) {
+				return true;
+			}
+
 			if (bTargetTool) {
 				buffer.append(TAB).append(AT).append(escapedEcho(MESSAGE_START_BUILD + WHITESPACE + OUT_MACRO));
 			}

--- a/build/org.eclipse.cdt.managedbuilder.gnu.ui/plugin.xml
+++ b/build/org.eclipse.cdt.managedbuilder.gnu.ui/plugin.xml
@@ -968,6 +968,9 @@
 	            <value id="org.eclipse.cdt.build.core.buildType.debug"/>
     	        <value id="org.eclipse.cdt.build.core.buildType.release"/>
             </property>
+            <property id="org.eclipse.cdt.build.core.buildArtefactType">
+    	        <value id="org.eclipse.cdt.build.core.buildArtefactType.objectFile"/>
+            </property>
             </supportedProperties>
          <envVarBuildPath 
          	pathType="buildpathInclude"
@@ -3017,6 +3020,50 @@
          </configuration>                  
       </projectType>
       
+      <projectType
+            isAbstract="false"
+            isTest="false"
+            buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.objectFile"
+            id="cdt.managedbuild.target.gnu.object">
+         <configuration
+               name="%ConfigName.Dbg"
+               id="cdt.managedbuild.config.gnu.object.debug"
+               buildProperties="org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug"
+               cleanCommand="rm -rf">
+               <toolChain
+                     superClass="cdt.managedbuild.toolchain.gnu.base"
+                     id="cdt.managedbuild.toolchain.gnu.object.debug">
+		          <targetPlatform
+		              id="cdt.managedbuild.target.gnu.platform.object.debug"
+		              superClass="cdt.managedbuild.target.gnu.platform.base">
+		          </targetPlatform>
+				  <builder
+				      superClass="cdt.managedbuild.target.gnu.builder.base"
+				      id="cdt.managedbuild.target.gnu.builder.object.debug">
+				  </builder>
+               </toolChain>
+         </configuration>
+         <configuration
+               name="%ConfigName.Rel"
+               id="cdt.managedbuild.config.gnu.object.release"
+               buildProperties="org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.release"
+               parent="cdt.managedbuild.config.gnu.base"
+               cleanCommand="rm -rf">
+               <toolChain
+                     superClass="cdt.managedbuild.toolchain.gnu.base"
+                     id="cdt.managedbuild.toolchain.gnu.object.release">
+		          <targetPlatform
+		              id="cdt.managedbuild.target.gnu.platform.object.release"
+		              superClass="cdt.managedbuild.target.gnu.platform.base">
+		          </targetPlatform>
+				  <builder
+				      superClass="cdt.managedbuild.target.gnu.builder.base"
+				      id="cdt.managedbuild.target.gnu.builder.object.release">
+				  </builder>
+               </toolChain>
+         </configuration>
+      </projectType>
+
       <configuration
             artifactExtension="exe"
             cleanCommand="rm -rf"

--- a/cross/org.eclipse.cdt.build.crossgcc/plugin.xml
+++ b/cross/org.eclipse.cdt.build.crossgcc/plugin.xml
@@ -14,6 +14,7 @@
 # Doug Schaefer   (Wind River)     - initial API and implementation 
 # Anna Dushistova (Mentor Graphics)- [329531][crossgcc] crossgcc fails to build a project
 # John Dallaway - enable GNU tool prefix lookup (#361)
+# Ruiqi Bao       (Eswin Computing)- Add object file build artifact (#394)
 -->
 <plugin>
 
@@ -221,6 +222,37 @@
 			</toolChain>                                                                                				                    
          </configuration>         
       </projectType>
+
+      <projectType
+	        buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.objectFile"
+	        id="cdt.managedbuild.target.gnu.cross.object"
+	        isAbstract="false"
+	        isTest="false"
+	        >
+	     <configuration
+	           name="Debug"
+	           cleanCommand="rm -rf"
+	           id="cdt.managedbuild.config.gnu.cross.object.debug"
+	           parent="cdt.managedbuild.config.gnu.base"
+	           buildProperties="org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug">
+	           <toolChain
+	           		 superClass="cdt.managedbuild.toolchain.gnu.cross.base"
+	                 id="cdt.managedbuild.toolchain.gnu.cross.object.debug">
+	           </toolChain>
+	     </configuration>
+	     <configuration
+	           name="Release"
+	           cleanCommand="rm -rf"
+	           id="cdt.managedbuild.config.gnu.cross.object.release"
+	           parent="cdt.managedbuild.config.gnu.base"
+	           buildProperties="org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.release">
+	           <toolChain
+	                 superClass="cdt.managedbuild.toolchain.gnu.cross.base"
+	                 id="cdt.managedbuild.toolchain.gnu.cross.object.release">
+	           </toolChain>
+	     </configuration>
+	  </projectType>
+
    </extension>
    <extension
          point="org.eclipse.cdt.core.templateAssociations">
@@ -260,6 +292,12 @@
          </toolchain>
          <toolchain
                toolchainID="cdt.managedbuild.toolchain.gnu.cross.lib.release">
+         </toolchain>
+         <toolchain
+               toolchainID="cdt.managedbuild.toolchain.gnu.cross.object.debug">
+         </toolchain>
+         <toolchain
+               toolchainID="cdt.managedbuild.toolchain.gnu.cross.object.release">
          </toolchain>
       </wizardPage>
    </extension>


### PR DESCRIPTION
Hi, all

As mentioned in #394 , an entry is left for the object file just with a name, but the specific implementation of such build artifact of is not given.

Although, I don't think it's a necessary feature, but it might serve some purpose. For example, compiling only can save some link time while checking for errors, and sometimes users may want to use object files to link external libraries.

My idea is rather simple. 
First, create the connection between property name and buildArtefactType by adding an entry to the configuration file of the managedbuild.core module,
Then, adapt the project property page to support the new buildArtefactType,
Finally, in GnuMakefileGenerator, skip the subsequent generation steps if buildArtefactType is judged to be an object file.

Since I don't have a deep understanding of cdt, this is a relatively simple solution I can think of so far. If there is a better implementation solution, please discuss and improve it together.

Thank you!