### PR TITLE
Postpone build container creation to build start. Fixes possible Ecli…

### DIFF
--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core; singleton:=true
-Bundle-Version: 8.2.100.qualifier
+Bundle-Version: 8.2.200.qualifier
 Bundle-Activator: org.eclipse.cdt.core.CCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
…pse freeze.

The creation of the build container for Core Build projects is postponed to the start of the build process.

StandardBuildConfiguration getBuildContainer and setBuildContainer have been cleaned up.

CBuildConfiguration creation is started via
CBuildConfigurationManager.getBuildConfiguration(IBuildConfiguration) which holds a lock on the HashMap 'configs'. Creation of StandardBuildConfiguration triggered, via applyProperties and getBuildContainer(), a Folder.create which loops back to CBuildConfigurationManager.getBuildConfiguration(). For detailed traces see https://github.com/eclipse-cdt/cdt/issues/424

Fixes #424