### PR TITLE
Lock snakeyaml to expected 1.x version

### DIFF
--- a/cmake/org.eclipse.cdt.cmake.core/META-INF/MANIFEST.MF
+++ b/cmake/org.eclipse.cdt.cmake.core/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.tools.templates.freemarker;bundle-version="1.2.200",
  com.google.gson,
  org.eclipse.cdt.jsoncdb.core,
- org.yaml.snakeyaml;bundle-version="1.14.0"
+ org.yaml.snakeyaml;bundle-version="[1.14.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.cdt.cmake.core,


### PR DESCRIPTION
Snakeyml recentlyish came out with 2.0 version and more recently TM4E started using the 2.0 version. As TM4E snapshots are in our target platform we started failing as we started wiring to the newer version due to a missing underbound on our dependency.

A separate task of updating to recent snakeyaml will be done as part of #387