### PR TITLE
[#457] Fix partial specialisation matching for deduced primitive types

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateTests.java
@@ -6903,6 +6903,37 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 		assertTrue(varIp.getType().isSameType(varJp.getType()));
 	}
 
+	// template <typename A, typename B = typename A::t1>
+	// struct C {
+	// };
+	//
+	// template <typename A>
+	// struct C<A, decltype(typename A::t1())> {
+	//     int ccc1;
+	//     using t = int;
+	// };
+	//
+	// template <typename A>
+	// struct C<A, decltype(typename A::t2())> {
+	// 	int ccc2;
+	// };
+	//
+	// struct marker {
+	//     using t1 = int;
+	//     using t2 = long;
+	// };
+	//
+	// int b1 = C<marker>().ccc1;
+	// C<marker>::t b2;
+	public void testSfinae_d() throws Exception {
+		BindingAssertionHelper bh = getAssertionHelper();
+
+		IVariable varB1 = bh.assertNonProblem("b1");
+		IVariable varB2 = bh.assertNonProblem("b2");
+		assertFalse(varB1.getInitialValue() instanceof IProblemBinding);
+		assertTrue(varB1.getType().isSameType(varB2.getType()));
+	}
+
 	//	template<typename T>
 	//	struct is_pod {
 	//	  static const bool value = __is_pod(T);

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/TemplateArgumentDeduction.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/TemplateArgumentDeduction.java
@@ -1044,11 +1044,13 @@ public class TemplateArgumentDeduction {
 
 				// Verify that the resolved binding matches the argument type.
 				InstantiationContext context = InstantiationContext.forDeduction(fDeducedArgs);
-				IBinding binding = CPPTemplates.resolveUnknown((ICPPUnknownBinding) p, context);
-				if (binding instanceof ICPPUnknownBinding)
+				CPPTemplates.BindingOrType bindingType = CPPTemplates
+						.resolveUnknownBindingOrType((ICPPUnknownBinding) p, context);
+				if (bindingType.getBinding() instanceof ICPPUnknownBinding)
 					return true; // An unknown type may match anything.
-
-				return binding instanceof IType && ((IType) binding).isSameType(a);
+				if (bindingType.getType() != null) {
+					return bindingType.getType().isSameType(a);
+				}
 			} else {
 				return p.isSameType(a);
 			}


### PR DESCRIPTION
Current partial specialisation selection matches deduced type by IBinding, not by IType, meaning that it can't work for types (such as primitive types) that aren't represented by an IBinding. Fix that by wrapping the result of resolution in a type which can handle either.