### PR TITLE
Update to Tycho 4.0.1

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,6 +27,10 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+      with:
+        maven-version: 3.9.2
     - name: Install GCC & GDB & other build essentials
       run: |
         sudo apt-get -y install build-essential gcc g++ gdb gdbserver

--- a/.github/workflows/code-cleanliness.yml
+++ b/.github/workflows/code-cleanliness.yml
@@ -17,6 +17,10 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+      with:
+        maven-version: 3.9.2
     - name: Install dependencies
       run: |
         sudo apt-get update && sudo apt-get install -y --no-install-recommends \

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>3.0.3</version>
+    <version>4.0.1</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,8 @@
 	<name>CDT Parent</name>
 
 	<properties>
-		<!-- Maven 3.6.1 and 3.6.2 do not work with Tycho, see Bug 551674
-		     CDT enforces a minimum of 3.6.3 because that is what CDT's CI
-			 runs with. It may work with older versions, but this is not
-			 tested or supported. -->
-		<required-maven-version>3.6.3</required-maven-version>
-		<tycho-version>3.0.5</tycho-version>
+		<required-maven-version>3.9.1</required-maven-version>
+		<tycho-version>4.0.1</tycho-version>
 		<cbi-plugins.version>1.3.4</cbi-plugins.version>
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
 		<cdt-site>http://ci.eclipse.org/cdt/job/cdt-master/lastSuccessfulBuild/artifact/releng/org.eclipse.cdt.repo/target/repository</cdt-site>
@@ -619,7 +615,7 @@
 								<version>${required-maven-version}</version>
 							</requireMavenVersion>
 							<requireJavaVersion>
-								<version>11</version>
+								<version>17</version>
 							</requireJavaVersion>
 						</rules>
 						<fail>true</fail>

--- a/releng/org.eclipse.cdt.repo/category.xml
+++ b/releng/org.eclipse.cdt.repo/category.xml
@@ -185,10 +185,6 @@
    <bundle id="org.eclipse.cdt.remote.core" version="0.0.0"/>
    <bundle id="org.eclipse.cdt.remote.core.source" version="0.0.0"/>
    <bundle id="com.sun.xml.bind" version="0.0.0"/>
-   <bundle id="javax.activation" version="0.0.0"/>
-   <bundle id="javax.xml" version="0.0.0"/>
-   <bundle id="jakarta.xml.bind" version="0.0.0"/>
-   <bundle id="javax.xml.stream" version="0.0.0"/>
    <bundle id="com.google.gson" version="0.0.0"/>
    <bundle id="org.freemarker" version="0.0.0"/>
    <bundle id="org.yaml.snakeyaml" version="0.0.0"/>


### PR DESCRIPTION
The error handling in Tycho 4 identifies when bundles are listed in category.xml but not available. The removed bundles were not in the output, and with this change the error is resolved in the build.

Updated setting for maven enforcer to match Tycho requirements.