### PR TITLE
Resolve cast exception - fixup for inferring generic types

### DIFF
--- a/build/org.eclipse.cdt.managedbuilder.core/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.managedbuilder.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.managedbuilder.core; singleton:=true
-Bundle-Version: 9.6.0.qualifier
+Bundle-Version: 9.6.100.qualifier
 Bundle-Activator: org.eclipse.cdt.managedbuilder.core.ManagedBuilderCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/internal/tcmodification/ToolListModification.java
+++ b/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/internal/tcmodification/ToolListModification.java
@@ -411,7 +411,8 @@ public abstract class ToolListModification implements IToolListModification {
 
 	public ToolListModification(ResourceInfo rcInfo, ToolListModification base) {
 		fRcInfo = rcInfo;
-		Tool[] initialTools = (Tool[]) rcInfo.getTools();
+		ITool[] itools = rcInfo.getTools();
+		Tool[] initialTools = Arrays.copyOf(itools, itools.length, Tool[].class);
 		@SuppressWarnings("unchecked")
 		Map<Tool, Tool> initRealToToolMap = (Map<Tool, Tool>) TcModificationUtil.getRealToObjectsMap(initialTools,
 				null);


### PR DESCRIPTION
Long ago in 334702ee05048a95e131530ddb80fbf2654dfef5 generic types were added. However in at least one place a previous assumption that existed was broken. That assumption was the true type of ResourceInfo.getTools() would be Tool[] as opposed to ITool[]. That commit broke it for ResourceConfiguration.getTools()

Internally in CDT ITool is in practice always Tool, and as a result there are lots of downcast from ITool -> Tool. However ITool[] cannot be downcast to Tool[] unless the original type was Tool[].

Instead we use Arrays.copyOf to copy the array into the correct array type.

Steps to reproduce the problem now fixed:

1. Create a Managed Build executable project.
2. Open the properties window of the source file (as opposed to project)
3. At the Properties page, navigate to "C/C++ Build/Tool Chain Editor".
4. Click the "Apply" button.