### PR TITLE
Fix meson build under Docker Tooling

### DIFF
--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core; singleton:=true
-Bundle-Version: 8.3.0.qualifier
+Bundle-Version: 8.4.0.qualifier
 Bundle-Activator: org.eclipse.cdt.core.CCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/CBuildConfiguration.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/CBuildConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 QNX Software Systems and others.
+ * Copyright (c) 2015, 2023 QNX Software Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -80,7 +80,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.core.runtime.Status;
@@ -1050,6 +1049,14 @@ public abstract class CBuildConfiguration extends PlatformObject implements ICBu
 		} catch (CoreException e) {
 			// do nothing
 		}
+	}
+
+	/**
+	 * @since 8.4
+	 * @param launcher - launcher to set
+	 */
+	public void setLauncher(ICommandLauncher launcher) {
+		this.launcher = launcher;
 	}
 
 	/**

--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/IToolChainConstants.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/IToolChainConstants.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * 		Red Hat Inc. - initial contribution
+ *******************************************************************************/
+package org.eclipse.cdt.core.build;
+
+/**
+ * Tool chain constants
+ *
+ * @since 8.4
+ * @noimplement This interface is not intended to be implemented by clients.
+ * @noextend This interface is not intended to be extended by clients.
+ */
+public interface IToolChainConstants {
+
+	public final static String SECURITY_OPTS = "security_opts"; //$NON-NLS-1$
+
+}

--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/IToolChainConstants.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/IToolChainConstants.java
@@ -22,6 +22,6 @@ package org.eclipse.cdt.core.build;
  */
 public interface IToolChainConstants {
 
-	public final static String SECURITY_OPTS = "security_opts"; //$NON-NLS-1$
+	public final static String SECCOMP_UNDEFINED = "seccomp_undefined"; //$NON-NLS-1$
 
 }

--- a/launch/org.eclipse.cdt.docker.launcher/META-INF/MANIFEST.MF
+++ b/launch/org.eclipse.cdt.docker.launcher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.cdt.docker.launcher;singleton:=true
-Bundle-Version: 2.0.100.qualifier
+Bundle-Version: 2.0.200.qualifier
 Bundle-Activator: org.eclipse.cdt.docker.launcher.DockerLaunchUIPlugin
 Bundle-Vendor: %Plugin.vendor
 Bundle-Localization: plugin

--- a/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/docker/launcher/ContainerCommandLauncher.java
+++ b/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/docker/launcher/ContainerCommandLauncher.java
@@ -68,6 +68,8 @@ public class ContainerCommandLauncher implements ICommandLauncher, ICBuildComman
 
 	public final static String VOLUME_SEPARATOR_REGEX = "[|]"; //$NON-NLS-1$
 
+	public final static String SECCOMP_UNCONFINED_STR = "seccomp=unconfined"; //$NON-NLS-1$
+
 	private IProject fProject;
 	private Process fProcess;
 	private boolean fShowCommand;
@@ -260,14 +262,14 @@ public class ContainerCommandLauncher implements ICommandLauncher, ICBuildComman
 		final String connectionName;
 		final String imageName;
 		final String pathMapProperty;
-		final String seccomp;
+		final String seccompUndefinedStr;
 		if (buildCfg != null) {
 			IToolChain toolChain = buildCfg.getToolChain();
 			selectedVolumeString = toolChain.getProperty(SELECTED_VOLUMES_ID);
 			connectionName = toolChain.getProperty(IContainerLaunchTarget.ATTR_CONNECTION_URI);
 			imageName = toolChain.getProperty(IContainerLaunchTarget.ATTR_IMAGE_ID);
 			pathMapProperty = toolChain.getProperty(DOCKERD_PATH);
-			seccomp = toolChain.getProperty(IToolChainConstants.SECURITY_OPTS);
+			seccompUndefinedStr = toolChain.getProperty(IToolChainConstants.SECCOMP_UNDEFINED);
 		} else {
 			ICConfigurationDescription cfgd = CoreModel.getDefault().getProjectDescription(fProject)
 					.getActiveConfiguration();
@@ -280,7 +282,7 @@ public class ContainerCommandLauncher implements ICommandLauncher, ICBuildComman
 			connectionName = props.getProperty(ContainerCommandLauncher.CONNECTION_ID);
 			imageName = props.getProperty(ContainerCommandLauncher.IMAGE_ID);
 			pathMapProperty = props.getProperty(DOCKERD_PATH);
-			seccomp = props.getProperty(IToolChainConstants.SECURITY_OPTS);
+			seccompUndefinedStr = props.getProperty(IToolChainConstants.SECCOMP_UNDEFINED);
 		}
 
 		// Add any specified volumes to additional dir list
@@ -318,9 +320,10 @@ public class ContainerCommandLauncher implements ICommandLauncher, ICBuildComman
 			return null;
 		}
 
+		boolean seccompUndefined = Boolean.parseBoolean(seccompUndefinedStr);
 		fProcess = launcher.runCommand(connectionName, imageName, fProject, this, cmdList, workingDir, additionalDirs,
 				origEnv, fEnvironment, supportStdin, privilegedMode, labels, keepContainer,
-				seccomp == null ? null : List.of(seccomp));
+				seccompUndefined ? List.of(SECCOMP_UNCONFINED_STR) : null);
 
 		return fProcess;
 	}

--- a/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/docker/launcher/ContainerCommandLauncher.java
+++ b/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/docker/launcher/ContainerCommandLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Red Hat Inc. and others.
+ * Copyright (c) 2017, 2023 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -29,6 +29,7 @@ import org.eclipse.cdt.core.ICommandLauncher;
 import org.eclipse.cdt.core.build.ICBuildCommandLauncher;
 import org.eclipse.cdt.core.build.ICBuildConfiguration;
 import org.eclipse.cdt.core.build.IToolChain;
+import org.eclipse.cdt.core.build.IToolChainConstants;
 import org.eclipse.cdt.core.model.CoreModel;
 import org.eclipse.cdt.core.settings.model.ICConfigurationDescription;
 import org.eclipse.cdt.internal.core.ProcessClosure;
@@ -259,12 +260,14 @@ public class ContainerCommandLauncher implements ICommandLauncher, ICBuildComman
 		final String connectionName;
 		final String imageName;
 		final String pathMapProperty;
+		final String seccomp;
 		if (buildCfg != null) {
 			IToolChain toolChain = buildCfg.getToolChain();
 			selectedVolumeString = toolChain.getProperty(SELECTED_VOLUMES_ID);
 			connectionName = toolChain.getProperty(IContainerLaunchTarget.ATTR_CONNECTION_URI);
 			imageName = toolChain.getProperty(IContainerLaunchTarget.ATTR_IMAGE_ID);
 			pathMapProperty = toolChain.getProperty(DOCKERD_PATH);
+			seccomp = toolChain.getProperty(IToolChainConstants.SECURITY_OPTS);
 		} else {
 			ICConfigurationDescription cfgd = CoreModel.getDefault().getProjectDescription(fProject)
 					.getActiveConfiguration();
@@ -277,6 +280,7 @@ public class ContainerCommandLauncher implements ICommandLauncher, ICBuildComman
 			connectionName = props.getProperty(ContainerCommandLauncher.CONNECTION_ID);
 			imageName = props.getProperty(ContainerCommandLauncher.IMAGE_ID);
 			pathMapProperty = props.getProperty(DOCKERD_PATH);
+			seccomp = props.getProperty(IToolChainConstants.SECURITY_OPTS);
 		}
 
 		// Add any specified volumes to additional dir list
@@ -315,7 +319,8 @@ public class ContainerCommandLauncher implements ICommandLauncher, ICBuildComman
 		}
 
 		fProcess = launcher.runCommand(connectionName, imageName, fProject, this, cmdList, workingDir, additionalDirs,
-				origEnv, fEnvironment, supportStdin, privilegedMode, labels, keepContainer);
+				origEnv, fEnvironment, supportStdin, privilegedMode, labels, keepContainer,
+				seccomp == null ? null : List.of(seccomp));
 
 		return fProcess;
 	}

--- a/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/docker/launcher/ContainerCommandLauncherFactory.java
+++ b/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/docker/launcher/ContainerCommandLauncherFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Red Hat Inc. and others.
+ * Copyright (c) 2017, 2023 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -302,7 +302,7 @@ public class ContainerCommandLauncherFactory implements ICommandLauncherFactory,
 			return includePaths;
 		}
 
-		if (!getPaths(imgCnn, includePaths)) {
+		if (!getPaths(imgCnn, fetchPaths)) {
 			// There should be sufficient log messages by the root cause
 			return includePaths;
 		}
@@ -313,13 +313,20 @@ public class ContainerCommandLauncherFactory implements ICommandLauncherFactory,
 		Set<IPath> copiedVolumes = ContainerLauncher.getCopiedVolumes(tpath);
 		List<String> newEntries = new ArrayList<>();
 
-		for (String path : includePaths) {
-			if (copiedVolumes.contains(new Path(path))) {
-				IPath newPath = tpath.append(path);
-				String newEntry = newPath.toOSString();
-				newEntries.add(newEntry);
-			} else {
-				newEntries.add(path);
+		for (String includePath : includePaths) {
+			IPath path = new Path(includePath).makeAbsolute();
+			boolean found = false;
+			for (IPath copiedVolume : copiedVolumes) {
+				if (copiedVolume.isPrefixOf(path)) {
+					IPath newPath = tpath.append(path);
+					String newEntry = newPath.toOSString();
+					newEntries.add(newEntry);
+					found = true;
+					break;
+				}
+			}
+			if (!found) {
+				newEntries.add(path.toPortableString());
 			}
 		}
 		return newEntries;

--- a/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/ui/launchbar/ContainerGCCToolChain.java
+++ b/launch/org.eclipse.cdt.docker.launcher/src/org/eclipse/cdt/internal/docker/launcher/ui/launchbar/ContainerGCCToolChain.java
@@ -96,7 +96,7 @@ public class ContainerGCCToolChain extends PlatformObject implements IToolChain,
 		this.id = id;
 
 		this.properties.putAll(properties);
-		setProperty(IToolChainConstants.SECURITY_OPTS, "seccomp=unconfined"); //$NON-NLS-1$
+		setProperty(IToolChainConstants.SECCOMP_UNDEFINED, "true"); //$NON-NLS-1$
 		this.envVars = envVars;
 	}
 


### PR DESCRIPTION
- add new IToolChainConstants containing SECURITY_OPTS constant
- add new setLauncher() method to CBuildConfiguration so that watchProcess() can be used for container building
- enhance ContainerCommandLauncher to discover specification of security opts for execute() so "seccomp=undefined" can be specified
- fix ContainerCommandLauncherFactory.verifyIncludePaths() to only look at filtered includes that have been made absolute and to recognize matches when the prefix shows up in the loaded list
- add setting a property to ContainerGCCToolChain to set security opts and default to "seccomp=undefined"
- when generating scannerinfo, specify "seccomp=undefined"
- in ContainerGCCToolChain.startBuildProcess() remove extraneous banner statement and ensure that the build directory is created
- fixes #479