### PR TITLE
Clean up target platform

### DIFF
--- a/debug/org.eclipse.cdt.debug.application.product/debug.product
+++ b/debug/org.eclipse.cdt.debug.application.product/debug.product
@@ -189,9 +189,9 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="com.sun.jna.platform"/>
       <plugin id="com.sun.xml.bind"/>
       <plugin id="jakarta.activation-api"/>
+      <plugin id="jakarta.annotation-api"/>
       <plugin id="jakarta.servlet-api"/>
       <plugin id="jakarta.xml.bind-api"/>
-      <plugin id="javax.annotation"/>
       <plugin id="javax.el-api"/>
       <plugin id="javax.inject"/>
       <plugin id="javax.servlet.jsp-api"/>
@@ -201,6 +201,8 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.apache.batik.i18n"/>
       <plugin id="org.apache.batik.util"/>
       <plugin id="org.apache.commons.codec"/>
+      <plugin id="org.apache.commons.collections"/>
+      <plugin id="org.apache.commons.commons-beanutils"/>
       <plugin id="org.apache.commons.io"/>
       <plugin id="org.apache.commons.jxpath"/>
       <plugin id="org.apache.commons.logging"/>
@@ -405,6 +407,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.ui.workbench.texteditor"/>
       <plugin id="org.eclipse.urischeme"/>
       <plugin id="org.freemarker"/>
+      <plugin id="org.jdom"/>
       <plugin id="org.objectweb.asm"/>
       <plugin id="org.objectweb.asm.commons"/>
       <plugin id="org.objectweb.asm.tree"/>

--- a/releng/org.eclipse.cdt.target/cdt.target
+++ b/releng/org.eclipse.cdt.target/cdt.target
@@ -47,8 +47,7 @@
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/0.15.0/" />
-			<unit id="org.eclipse.wildwebdeveloper.embedder.node.feature.feature.group" version="0.0.0" />
+			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/latest/" />
 		</location>
 		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="DirectFromMaven" missingManifest="error" type="Maven">
 			<dependencies>
@@ -134,12 +133,6 @@
 					<groupId>com.google.guava</groupId>
 					<artifactId>guava</artifactId>
 					<version>32.1.1-jre</version>
-					<type>jar</type>
-				</dependency>
-				<dependency>
-					<groupId>org.hamcrest</groupId>
-					<artifactId>hamcrest</artifactId>
-					<version>2.2</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>


### PR DESCRIPTION
Until https://github.com/eclipse-cdt/cdt/pull/495 can be resolved fully, apply some of the required changes.

- wildwebdeveloper was out of date, however we don't really need wwd in CDT, but some of our dependencies have requirements that are fufilled (e.g. linuxtools)
- duplicate entry for hamcrest 2.2 removed (other entry was just above it!)