### PR TITLE
Remove and ignore object references from Yaml files

### DIFF
--- a/cmake/org.eclipse.cdt.cmake.core.tests/src/org/eclipse/cdt/cmake/core/internal/CMakePropertiesEvolutionTest.java
+++ b/cmake/org.eclipse.cdt.cmake.core.tests/src/org/eclipse/cdt/cmake/core/internal/CMakePropertiesEvolutionTest.java
@@ -22,9 +22,13 @@ import java.util.List;
 import org.eclipse.cdt.cmake.core.internal.properties.CMakePropertiesBean;
 import org.eclipse.cdt.cmake.core.properties.CMakeGenerator;
 import org.junit.Test;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
+import org.yaml.snakeyaml.inspector.TagInspector;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
 
 /**
  * @author Martin Weber
@@ -57,7 +61,14 @@ public class CMakePropertiesEvolutionTest {
 		extraArgs.add("arg2");
 		props.setExtraArguments(extraArgs);
 
-		Yaml yaml = new Yaml(new CustomClassLoaderConstructor(this.getClass().getClassLoader(), new LoaderOptions()));
+		var loaderoptions = new LoaderOptions();
+		TagInspector taginspector = tag -> tag.getClassName().equals(CMakePropertiesBean.class.getName());
+		loaderoptions.setTagInspector(taginspector);
+		Representer customRepresenter = new Representer(new DumperOptions());
+		customRepresenter.addClassTag(CMakePropertiesBean.class, Tag.MAP);
+
+		Yaml yaml = new Yaml(new CustomClassLoaderConstructor(this.getClass().getClassLoader(), loaderoptions),
+				customRepresenter);
 		String output = yaml.dump(props);
 
 		// try to load as evolved properties..

--- a/cmake/org.eclipse.cdt.cmake.core/META-INF/MANIFEST.MF
+++ b/cmake/org.eclipse.cdt.cmake.core/META-INF/MANIFEST.MF
@@ -22,4 +22,7 @@ Automatic-Module-Name: org.eclipse.cdt.cmake.core
 Bundle-Localization: plugin
 Import-Package: org.eclipse.core.variables,
  org.yaml.snakeyaml;version="[2.0.0,3.0.0)",
- org.yaml.snakeyaml.constructor;version="[2.0.0,3.0.0)"
+ org.yaml.snakeyaml.constructor;version="[2.0.0,3.0.0)",
+ org.yaml.snakeyaml.inspector;version="[2.0.0,3.0.0)",
+ org.yaml.snakeyaml.nodes;version="[2.0.0,3.0.0)",
+ org.yaml.snakeyaml.representer;version="[2.0.0,3.0.0)"


### PR DESCRIPTION
Yaml 2.0 fixes CVE-2022–1471 to error on object references. This commit adapts our use of Yaml to not output object references anymore and on loading explicitly allow object references to expected types.

Fixes #498