### PR TITLE
Fix test cases that recently regressed

### DIFF
--- a/build/org.eclipse.cdt.managedbuilder.core.tests/resources/test30Projects/test30_2/Benchmarks/sources.mk
+++ b/build/org.eclipse.cdt.managedbuilder.core.tests/resources/test30Projects/test30_2/Benchmarks/sources.mk
@@ -3,9 +3,12 @@
 ################################################################################
 
 ASM_SRCS := 
+C++M_SRCS := 
 C++_SRCS := 
+CCM_SRCS := 
 CC_SRCS := 
 CPP_SRCS := 
+CXXM_SRCS := 
 CXX_SRCS := 
 C_UPPER_SRCS := 
 LOG_SRCS := 

--- a/build/org.eclipse.cdt.managedbuilder.core.tests/resources/test40Projects/test_40/Benchmarks/Test 4.0 ConfigName.Dbg/makefile
+++ b/build/org.eclipse.cdt.managedbuilder.core.tests/resources/test40Projects/test_40/Benchmarks/Test 4.0 ConfigName.Dbg/makefile
@@ -18,14 +18,23 @@ RM := rm -rf
 -include d1/subdir.mk
 
 ifneq ($(MAKECMDGOALS),clean)
+ifneq ($(strip $(C++M_DEPS)),)
+-include $(C++M_DEPS)
+endif
 ifneq ($(strip $(C++_DEPS)),)
 -include $(C++_DEPS)
+endif
+ifneq ($(strip $(CCM_DEPS)),)
+-include $(CCM_DEPS)
 endif
 ifneq ($(strip $(CC_DEPS)),)
 -include $(CC_DEPS)
 endif
 ifneq ($(strip $(CPP_DEPS)),)
 -include $(CPP_DEPS)
+endif
+ifneq ($(strip $(CXXM_DEPS)),)
+-include $(CXXM_DEPS)
 endif
 ifneq ($(strip $(CXX_DEPS)),)
 -include $(CXX_DEPS)

--- a/build/org.eclipse.cdt.managedbuilder.core.tests/resources/test40Projects/test_40/Benchmarks/Test 4.0 ConfigName.Dbg/sources.mk
+++ b/build/org.eclipse.cdt.managedbuilder.core.tests/resources/test40Projects/test_40/Benchmarks/Test 4.0 ConfigName.Dbg/sources.mk
@@ -3,18 +3,24 @@
 ################################################################################
 
 ASM_SRCS := 
+C++M_SRCS := 
 C++_SRCS := 
+CCM_SRCS := 
 CC_SRCS := 
 CPP_SRCS := 
+CXXM_SRCS := 
 CXX_SRCS := 
 C_SRCS := 
 C_UPPER_SRCS := 
 OBJ_SRCS := 
 O_SRCS := 
 S_UPPER_SRCS := 
+C++M_DEPS := 
 C++_DEPS := 
+CCM_DEPS := 
 CC_DEPS := 
 CPP_DEPS := 
+CXXM_DEPS := 
 CXX_DEPS := 
 C_DEPS := 
 C_UPPER_DEPS := 

--- a/build/org.eclipse.cdt.managedbuilder.core.tests/resources/test40Projects/test_40/Benchmarks/dbg 2/makefile
+++ b/build/org.eclipse.cdt.managedbuilder.core.tests/resources/test40Projects/test_40/Benchmarks/dbg 2/makefile
@@ -18,14 +18,23 @@ RM := rm -rf
 -include d1/subdir.mk
 
 ifneq ($(MAKECMDGOALS),clean)
+ifneq ($(strip $(C++M_DEPS)),)
+-include $(C++M_DEPS)
+endif
 ifneq ($(strip $(C++_DEPS)),)
 -include $(C++_DEPS)
+endif
+ifneq ($(strip $(CCM_DEPS)),)
+-include $(CCM_DEPS)
 endif
 ifneq ($(strip $(CC_DEPS)),)
 -include $(CC_DEPS)
 endif
 ifneq ($(strip $(CPP_DEPS)),)
 -include $(CPP_DEPS)
+endif
+ifneq ($(strip $(CXXM_DEPS)),)
+-include $(CXXM_DEPS)
 endif
 ifneq ($(strip $(CXX_DEPS)),)
 -include $(CXX_DEPS)

--- a/build/org.eclipse.cdt.managedbuilder.core.tests/resources/test40Projects/test_40/Benchmarks/dbg 2/sources.mk
+++ b/build/org.eclipse.cdt.managedbuilder.core.tests/resources/test40Projects/test_40/Benchmarks/dbg 2/sources.mk
@@ -3,18 +3,24 @@
 ################################################################################
 
 ASM_SRCS := 
+C++M_SRCS := 
 C++_SRCS := 
+CCM_SRCS := 
 CC_SRCS := 
 CPP_SRCS := 
+CXXM_SRCS := 
 CXX_SRCS := 
 C_SRCS := 
 C_UPPER_SRCS := 
 OBJ_SRCS := 
 O_SRCS := 
 S_UPPER_SRCS := 
+C++M_DEPS := 
 C++_DEPS := 
+CCM_DEPS := 
 CC_DEPS := 
 CPP_DEPS := 
+CXXM_DEPS := 
 CXX_DEPS := 
 C_DEPS := 
 C_UPPER_DEPS := 

--- a/build/org.eclipse.cdt.managedbuilder.core.tests/suite/org/eclipse/cdt/managedbuilder/tests/suite/ManagedBuilderPreconditionsTests.java
+++ b/build/org.eclipse.cdt.managedbuilder.core.tests/suite/org/eclipse/cdt/managedbuilder/tests/suite/ManagedBuilderPreconditionsTests.java
@@ -57,7 +57,8 @@ public class ManagedBuilderPreconditionsTests extends BaseTestCase {
 		IContentType contentTypeC = manager.getContentType(CCorePlugin.CONTENT_TYPE_CSOURCE);
 		fileExts.addAll(Arrays.asList(contentTypeC.getFileSpecs(IContentType.FILE_EXTENSION_SPEC)));
 
-		Set<String> expectedExts = new TreeSet<>(Arrays.asList(new String[] { "C", "c", "c++", "cc", "cpp", "cxx" }));
+		Set<String> expectedExts = new TreeSet<>(
+				Arrays.asList(new String[] { "C", "c", "c++", "cc", "cpp", "cxx", "ccm", "cxxm", "c++m" }));
 		assertEquals("Precodition FAILED - Content Types do not match expected defaults.", expectedExts.toString(),
 				fileExts.toString());
 	}


### PR DESCRIPTION
Recently new extensions were added to CDT for C++ modules in #422 At the time some test failures were not noticed. This change patches those failing tests.

Fixes #454