### PR TITLE
Explicitly activate shell for launchbar selector

### DIFF
--- a/launchbar/org.eclipse.launchbar.ui.controls/src/org/eclipse/launchbar/ui/controls/internal/CSelector.java
+++ b/launchbar/org.eclipse.launchbar.ui.controls/src/org/eclipse/launchbar/ui/controls/internal/CSelector.java
@@ -313,6 +313,7 @@ public abstract class CSelector extends Composite {
 		popup.setLocation(popupLocation.x, popupLocation.y + 5);
 		restoreShellSize();
 		popup.setVisible(true);
+		popup.setActive();
 		popup.setFocus();
 		getDisplay().addFilter(SWT.FocusIn, focusOutListener);
 		getDisplay().addFilter(SWT.FocusOut, focusOutListener);


### PR DESCRIPTION
In https://github.com/eclipse-platform/eclipse.platform.swt/issues/450 the behaviour was changed so that setFocus no longer activates the shell by default. Therefore when creating the popup shell and setting the focus the overall focus was still on a control in the main eclipse shell.

This affected Eclipse SWT/Platform 4.29 M1 and has been changed for M3. However there is intention to (possibly) change the default back to not activating in setFocus. If that happens this patch will be ready for it, and in the meantime (until CDT changes to M3) it resolves this test failure:

`createNewLaunchConfig (org.eclipse.launchbar.ui.tests.internal.CreateLaunchConfigTests) with error`

full trace:

```java
org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException: Could not find shell matching: with text 'Create Launch Configuration'
	at org.eclipse.launchbar.ui.tests.internal.CreateLaunchConfigTests.createNewLaunchConfig(CreateLaunchConfigTests.java:77)
Caused by: org.eclipse.swtbot.swt.finder.widgets.TimeoutException: Timeout after: 10000 ms.: Could not find shell matching: with text 'Create Launch Configuration'
	at org.eclipse.launchbar.ui.tests.internal.CreateLaunchConfigTests.createNewLaunchConfig(CreateLaunchConfigTests.java:77)
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```