### PR TITLE
Log errors when processing .cproject files

### DIFF
--- a/core/org.eclipse.cdt.core/model/org/eclipse/cdt/internal/core/settings/model/CProjectDescriptionStorageManager.java
+++ b/core/org.eclipse.cdt.core/model/org/eclipse/cdt/internal/core/settings/model/CProjectDescriptionStorageManager.java
@@ -252,7 +252,9 @@ public class CProjectDescriptionStorageManager {
 							.getAttribute(ICProjectDescriptionStorageType.STORAGE_TYPE_ATTRIBUTE);
 			}
 		} catch (Exception e) {
-			// Catch all, if not found, we use the old-style defaults...
+			CCorePlugin.log(
+					"Failed to load " + ICProjectDescriptionStorageType.STORAGE_FILE_NAME + " for project " + project, //$NON-NLS-1$//$NON-NLS-2$
+					e);
 		} finally {
 			if (stream != null) {
 				try {


### PR DESCRIPTION
This relates to #502 where we are getting rid of support for all pre-4.0 project structures. In the past if we failed to handle .cproject successfully we would default to old settings.

This change still has the fallback, but the error message is exposed to the Error Log instead of being suppressed.