### PR TITLE
Split check code cleanliness into two build steps

### DIFF
--- a/.github/workflows/code-cleanliness.yml
+++ b/.github/workflows/code-cleanliness.yml
@@ -25,7 +25,11 @@ jobs:
       run: |
         curl -sL https://download.eclipse.org/eclipse/downloads/drops4/R-4.23-202203080310/eclipse-SDK-4.23-linux-gtk-x86_64.tar.gz | tar xz
     - name: Run Check Code Cleanliness
-      run: ECLIPSE=$PWD/eclipse/eclipse ./releng/scripts/check_code_cleanliness.sh
+      run: ECLIPSE=$PWD/eclipse/eclipse ./releng/scripts/check_code_cleanliness_only.sh
+    - name: Run Bundle Versions Bumped
+      run: ./releng/scripts/check_bundle_versions.sh
+    - name: Report on Bundle Versions Bumped
+      run: ./releng/scripts/check_bundle_versions_report.sh
     - name: Upload Logs
       uses: actions/upload-artifact@v3
       if: success() || failure()

--- a/releng/scripts/check_bundle_versions.sh
+++ b/releng/scripts/check_bundle_versions.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2018, 2023 Kichwa Coders Ltd and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+
+set -e
+set -o pipefail
+
+if test ! -z "$(git status -s -uno)"; then
+    echo "You have changes. Please stash them before continuing."
+    exit 1
+fi
+
+##
+# Make sure all versions have been bumped appropriately compared to the baseline
+##
+logfile=baseline-compare-and-replace.log
+echo "Running 'mvn verify -P baseline-compare-and-replace' to make sure all versions"
+echo "have been appropriately incremented."
+${MVN:-mvn} \
+        clean verify -B -V --fail-at-end \
+        -DskipDoc=true \
+        -DskipTests=true \
+        -P baseline-compare-and-replace \
+         2>&1 | tee ${logfile}
+
+if [ $? -eq 0 ]; then
+    echo "SUCCESS - Maven check all versions have been bumped appropriately appears to have completed successfully"
+    echo "SUCCESS - Maven check all versions have been bumped appropriately appears to have completed successfully" >> ${logfile}
+else
+    echo "FAILED - Maven check all versions have been bumped appropriately appears to have failed. See the report in the next build step."
+    echo "FAILED - Maven check all versions have been bumped appropriately appears to have failed. See the report in the next build step." >> ${logfile}
+fi

--- a/releng/scripts/check_bundle_versions_report.sh
+++ b/releng/scripts/check_bundle_versions_report.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2018, 2023 Kichwa Coders Ltd and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+
+set -e
+
+if test ! -z "$(git status -s -uno)"; then
+    echo "You have changes. Please stash them before continuing."
+    exit 1
+fi
+
+##
+# Make sure all versions have been bumped appropriately compared to the baseline
+##
+logfile=baseline-compare-and-replace.log
+bundles_only_qualifier_changed=$(grep "Only qualifier changed" ${logfile} | sed -e 's/^.*Only qualifier changed for .//' -e 's@/.*@@' | sort)
+if [ -n "$bundles_only_qualifier_changed" ]; then
+    echo "The following bundles are missing a service segment version bump:"
+    for bundle in $bundles_only_qualifier_changed; do
+        echo "  - $bundle"
+    done
+    echo "Please bump service segment by 100 if on main branch"
+    echo "The log of this build is above"
+    echo "See: https://wiki.eclipse.org/Version_Numbering#When_to_change_the_service_segment"
+    echo
+fi
+
+bundles_same_version_different_content=$(grep "baseline and build artifacts have same version but different contents" ${logfile} | sed -e 's/^.* on project //' -e 's@: baseline.*@@' | sort)
+if [ -n "$bundles_same_version_different_content" ]; then
+    echo "The following bundles have same version as baseline, but different contents:"
+    for bundle in $bundles_same_version_different_content; do
+        echo "  - $bundle"
+    done
+    echo "This can happen for a variety of reasons:"
+    echo "  - The comparison filters in the root pom.xml are not working"
+    echo "  - Different versions of Java are being used to compile compared to the baseline"
+    echo "  - A dependency has changed causing the generated classes to be different"
+    echo "The log of this build is above"
+    echo "Please bump service segment by 100 if on main branch"
+    echo "See: https://wiki.eclipse.org/Version_Numbering#When_to_change_the_service_segment"
+    echo
+fi
+
+success=$(grep "SUCCESS - Maven check all versions have been bumped appropriately appears to have completed successfully" ${logfile})
+if [ -n "$success" ]; then
+    echo "Maven check all versions have been bumped appropriately appears to have completed successfully"
+elif [ -z "$bundles_only_qualifier_changed" ] && [ -z "$bundles_same_version_different_content" ]; then
+    echo "Maven 'check all versions have been bumped appropriately' failed! Please see the"
+    echo "log of the failed maven run above"
+    exit 1
+fi

--- a/releng/scripts/check_code_cleanliness.sh
+++ b/releng/scripts/check_code_cleanliness.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###############################################################################
-# Copyright (c) 2018, 2020 Kichwa Coders Ltd and others.
+# Copyright (c) 2018, 2023 Kichwa Coders Ltd and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -17,93 +17,7 @@ if test ! -z "$(git status -s -uno)"; then
     exit 1
 fi
 
-##
-# Check the features are all branded and all content has proper licenses
-##
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-${DIR}/check_features.sh
-${DIR}/check_license.sh
-
-##
-# The next set of scripts automatically apply formatting and other rules
-# to CDT. At the end of this, git repo is checked for no diffs.
-##
-${DIR}/do_all_code_cleanups.sh
-
-##
-# Check that none of the above caused any changes
-##
-if test -z "$(git status -s -uno)"; then
-    echo "Tree looks clean!"
-else
-    echo "Tree is dirty - something needs to be cleaned up in your commit (more info below)"
-    echo "Result of git status"
-    git status
-    echo "Result of git diff"
-    git diff
-    echo "Tree is dirty - something needs to be cleaned up in your commit (see above for git status/diff). The 'something'"
-    echo "is likely a misformatted file, extra whitespace at end of line, or something similar. The diff above"
-    echo "shows what changes you need to apply to your patch to get it past the code cleanliness check."
-    exit 1
-fi
-
-##
-# Error out if there are dependencies that are not allowed in the dlls, exes, sos
-##
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-echo "Checking dependencies of all .dll, .exe and .so files in CDT to make"
-echo "sure no dependencies on unexpected or newer libraries are accidentally"
-echo "introduced."
-${DIR}/check_dll_dependencies.sh
-${DIR}/check_glibc_dependencies.sh
-
-
-##
-# Make sure all versions have been bumped appropriately compared to the baseline
-##
-logfile=baseline-compare-and-replace.log
-echo "Running 'mvn verify -P baseline-compare-and-replace' to make sure all versions"
-echo "have been appropriately incremented. The check output is very verbose, so it is"
-echo "redirected to ${logfile} which is archived as part of the build artifacts."
-if ${MVN:-mvn} \
-        clean verify -B -V --fail-at-end \
-        -DskipDoc=true \
-        -DskipTests=true \
-        -P baseline-compare-and-replace >${logfile} 2>&1; then
-    echo "Maven check all versions have been bumped appropriately appears to have completed successfully"
-else
-    bundles_only_qualifier_changed=$(grep "Only qualifier changed" ${logfile} | sed -e 's/^.*Only qualifier changed for .//' -e 's@/.*@@' | sort)
-    if [ -n "$bundles_only_qualifier_changed" ]; then
-        echo "The following bundles are missing a service segment version bump:"
-        for bundle in $bundles_only_qualifier_changed; do
-            echo "  - $bundle"
-        done
-        echo "Please bump service segment by 100 if on master branch"
-        echo "The log of this build is part of the artifacts"
-        echo "See: https://wiki.eclipse.org/Version_Numbering#When_to_change_the_service_segment"
-        echo
-    fi
-
-    bundles_same_version_different_content=$(grep "baseline and build artifacts have same version but different contents" ${logfile} | sed -e 's/^.* on project //' -e 's@: baseline.*@@' | sort)
-    if [ -n "$bundles_same_version_different_content" ]; then
-        echo "The following bundles have same version as baseline, but different contents:"
-        for bundle in $bundles_same_version_different_content; do
-            echo "  - $bundle"
-        done
-        echo "This can happen for a variety of reasons:"
-        echo "  - The comparison filters in the root pom.xml are not working"
-        echo "  - Different versions of Java are being used to compile compared to the baseline"
-        echo "  - A dependency has changed causing the generated classes to be different"
-        echo "The log of this build is part of the artifacts"
-        echo "Please bump service segment by 100 if on master branch"
-        echo "See: https://wiki.eclipse.org/Version_Numbering#When_to_change_the_service_segment"
-        echo
-    fi
-
-    if [ -z "$bundles_only_qualifier_changed" ] && [ -z "$bundles_same_version_different_content" ]; then
-        echo "Maven 'check all versions have been bumped appropriately' failed! Please see the"
-        echo "log of the failed maven run which is available as part of the artifacts in a"
-        echo "file called baseline-compare-and-replace.log"
-    fi
-    exit 1
-fi
+${DIR}/check_code_cleanliness_only.sh
+${DIR}/check_bundle_versions.sh
+${DIR}/check_bundle_versions_report.sh

--- a/releng/scripts/check_code_cleanliness_only.sh
+++ b/releng/scripts/check_code_cleanliness_only.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2018, 2023 Kichwa Coders Ltd and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+
+set -e
+
+if test ! -z "$(git status -s -uno)"; then
+    echo "You have changes. Please stash them before continuing."
+    exit 1
+fi
+
+##
+# Check the features are all branded and all content has proper licenses
+##
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+${DIR}/check_features.sh
+${DIR}/check_license.sh
+
+##
+# The next set of scripts automatically apply formatting and other rules
+# to CDT. At the end of this, git repo is checked for no diffs.
+##
+${DIR}/do_all_code_cleanups.sh
+
+##
+# Check that none of the above caused any changes
+##
+if test -z "$(git status -s -uno)"; then
+    echo "Tree looks clean!"
+else
+    echo "Tree is dirty - something needs to be cleaned up in your commit (more info below)"
+    echo "Result of git status"
+    git status
+    echo "Result of git diff"
+    git diff
+    echo "Tree is dirty - something needs to be cleaned up in your commit (see above for git status/diff). The 'something'"
+    echo "is likely a misformatted file, extra whitespace at end of line, or something similar. The diff above"
+    echo "shows what changes you need to apply to your patch to get it past the code cleanliness check."
+    exit 1
+fi
+
+##
+# Error out if there are dependencies that are not allowed in the dlls, exes, sos
+##
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+echo "Checking dependencies of all .dll, .exe and .so files in CDT to make"
+echo "sure no dependencies on unexpected or newer libraries are accidentally"
+echo "introduced."
+${DIR}/check_dll_dependencies.sh
+${DIR}/check_glibc_dependencies.sh


### PR DESCRIPTION
A while ago we made the "Make sure all versions have been bumped appropriately compared to the baseline" output to another file to make it clearer. This refactor splits it up into different build steps instead so that I don't have to open an additional log file.