### PR TITLE
Improve memory search results page

### DIFF
--- a/memory/org.eclipse.cdt.debug.ui.memory.search/META-INF/MANIFEST.MF
+++ b/memory/org.eclipse.cdt.debug.ui.memory.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.ui.memory.search;singleton:=true
-Bundle-Version: 1.5.0.qualifier
+Bundle-Version: 1.5.100.qualifier
 Bundle-Activator: org.eclipse.cdt.debug.ui.memory.search.MemorySearchPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/memory/org.eclipse.cdt.debug.ui.memory.search/src/org/eclipse/cdt/debug/ui/memory/search/MemorySearchResultsPage.java
+++ b/memory/org.eclipse.cdt.debug.ui.memory.search/src/org/eclipse/cdt/debug/ui/memory/search/MemorySearchResultsPage.java
@@ -22,6 +22,8 @@ import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.ui.memory.IMemoryRendering;
 import org.eclipse.debug.ui.memory.IMemoryRenderingContainer;
 import org.eclipse.debug.ui.memory.IRepositionableMemoryRendering;
+import org.eclipse.jface.viewers.DoubleClickEvent;
+import org.eclipse.jface.viewers.IDoubleClickListener;
 import org.eclipse.jface.viewers.ILabelProvider;
 import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -47,6 +49,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IMemento;
+import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.part.Page;
 
 public class MemorySearchResultsPage extends Page implements ISearchResultPage, IQueryListener {
@@ -205,6 +208,21 @@ public class MemorySearchResultsPage extends Page implements ISearchResultPage, 
 					}
 				}
 			}
+		});
+		fTreeViewer.addDoubleClickListener(new IDoubleClickListener() {
+
+			@Override
+			public void doubleClick(DoubleClickEvent event) {
+				// Open the memory view to emphasize the effect of the memory address selection in the search
+				if (event.getSelection() instanceof StructuredSelection
+						&& ((StructuredSelection) event.getSelection()).getFirstElement() instanceof MemoryMatch) {
+					IWorkbenchPart wb = ((IMemorySearchQuery) fQuery).getMemoryView().getSite().getPart();
+					if (wb == null)
+						return;
+					getSite().getPage().activate(wb);
+				}
+			}
+
 		});
 
 		fTreeViewer.setLabelProvider(new ILabelProvider() {


### PR DESCRIPTION
The Memory Browser and Memory views will jump to the memory address after a user selects a value from the Memory Search Result list. If the views belong to the same tab group as the Search view, then it might not be very intuitive for the user to switch back to one of the Memory views and see the effect of the selection. 
The current commit adds on the the double click listener(from MemorySearchResultsPage.java) the behavior to refocus on the Memory Browser/ Memory view.
Resolves: #515
