### PR TITLE
Disable running tests on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
       steps {
         container('cdt') {
           timeout(activity: true, time: 30) {
-            withEnv(['MAVEN_OPTS=-XX:MaxRAMPercentage=60.0']) {
+            withEnv(['MAVEN_OPTS=-XX:MaxRAMPercentage=85.0 -XX:+PrintFlagsFinal']) {
               sh 'MVN="/jipp/tools/apache-maven/latest/bin/mvn -Dmaven.repo.local=/home/jenkins/.m2/repository \
                         --settings /home/jenkins/.m2/settings.xml" ./releng/scripts/check_code_cleanliness_only.sh'
             }
@@ -34,7 +34,7 @@ pipeline {
       steps {
         container('cdt') {
           timeout(activity: true, time: 20) {
-            withEnv(['MAVEN_OPTS=-XX:MaxRAMPercentage=60.0']) {
+            withEnv(['MAVEN_OPTS=-XX:MaxRAMPercentage=85.0 -XX:+PrintFlagsFinal']) {
               withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
                 sh '''/jipp/tools/apache-maven/latest/bin/mvn \
                       clean verify -B -V \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
           timeout(activity: true, time: 30) {
             withEnv(['MAVEN_OPTS=-XX:MaxRAMPercentage=60.0']) {
               sh 'MVN="/jipp/tools/apache-maven/latest/bin/mvn -Dmaven.repo.local=/home/jenkins/.m2/repository \
-                        --settings /home/jenkins/.m2/settings.xml" ./releng/scripts/check_code_cleanliness.sh'
+                        --settings /home/jenkins/.m2/settings.xml" ./releng/scripts/check_code_cleanliness_only.sh'
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
               withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
                 sh '''/jipp/tools/apache-maven/latest/bin/mvn \
                       clean verify -B -V \
+                      -DskipTests=true \
                       -Dgpg.passphrase="${KEYRING_PASSPHRASE}"  \
                       -Dmaven.test.failure.ignore=true \
                       -DexcludedGroups=flakyTest,slowTest \


### PR DESCRIPTION
The Jenkins CI at EF is running very slowly recently and all tests are timing out. The tests work fine locally and find on GitHub actions runners.

Therefore on the Jenkins CI build without running the tests.

This PR also includes a few other commits to try and speed up the overall build time on Jenkins.