### PR TITLE
Allocate much more ram to the Pod on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
       steps {
         container('cdt') {
           timeout(activity: true, time: 30) {
-            withEnv(['MAVEN_OPTS=-XX:MaxRAMPercentage=85.0 -XX:+PrintFlagsFinal']) {
+            withEnv(['MAVEN_OPTS=-XX:MaxRAMPercentage=50.0 -XX:+PrintFlagsFinal']) {
               sh 'MVN="/jipp/tools/apache-maven/latest/bin/mvn -Dmaven.repo.local=/home/jenkins/.m2/repository \
                         --settings /home/jenkins/.m2/settings.xml" ./releng/scripts/check_code_cleanliness_only.sh'
             }
@@ -34,7 +34,7 @@ pipeline {
       steps {
         container('cdt') {
           timeout(activity: true, time: 20) {
-            withEnv(['MAVEN_OPTS=-XX:MaxRAMPercentage=85.0 -XX:+PrintFlagsFinal']) {
+            withEnv(['MAVEN_OPTS=-XX:MaxRAMPercentage=50.0 -XX:+PrintFlagsFinal']) {
               withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
                 sh '''/jipp/tools/apache-maven/latest/bin/mvn \
                       clean verify -B -V \

--- a/jenkins/pod-templates/cdt-full-pod-plus-eclipse-install.yaml
+++ b/jenkins/pod-templates/cdt-full-pod-plus-eclipse-install.yaml
@@ -8,10 +8,10 @@ spec:
     args: ["/bin/sh", "-c", "/home/vnc/.vnc/xstartup.sh && cat"]
     resources:
       requests:
-        memory: "2662Mi"
+        memory: "10000Mi"
         cpu: "1"
       limits:
-        memory: "2662Mi"
+        memory: "10000Mi"
         cpu: "1"
     volumeMounts:
     - name: settings-xml


### PR DESCRIPTION
I think with some of the recent changes (Tycho 4, API baselines, maybe even new dependency on Platform M3) it may be that our memory requirements have gone up substantially for the build.

Also, with Sonar in the works that also requires more memory.

Therefore see if the EF's JIPP infra will allocate 10G of ram to our build.

This should fix all the "Killed" messages randomly in the CDT builds. https://wiki.eclipse.org/Jenkins#What_is_killing_my_build.3F_I.27m_using_custom_containers.21