### PR TITLE
Remove old Orbit in Oomph p2 repo from setup

### DIFF
--- a/releng/CDT.setup
+++ b/releng/CDT.setup
@@ -246,8 +246,6 @@
         <repository
             url="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2023-09"/>
         <repository
-            url="https://download.eclipse.org/oomph/simrel-orbit/milestone/latest/"/>
-        <repository
             url="https://download.eclipse.org/technology/swtbot/releases/latest"/>
         <repository
             url="https://download.eclipse.org/wildwebdeveloper/releases/latest"/>


### PR DESCRIPTION
The https://download.eclipse.org/oomph/simrel-orbit/ was the temporary URL.