### PR TITLE
CMake: Fixed the correct path for starting 'cmake-gui' 

### DIFF
--- a/cmake/org.eclipse.cdt.cmake.ui/META-INF/MANIFEST.MF
+++ b/cmake/org.eclipse.cdt.cmake.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.cmake.ui;singleton:=true
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Activator: org.eclipse.cdt.cmake.ui.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/internal/ui/properties/CMakePropertyPage.java
+++ b/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/internal/ui/properties/CMakePropertyPage.java
@@ -134,7 +134,7 @@ public class CMakePropertyPage extends PropertyPage {
 						String sourceDir = project.getLocation().toOSString();
 						String buildDir = project.getLocation().append("build").append(configName).toOSString(); //$NON-NLS-1$
 
-						Runtime.getRuntime().exec(new String[] { "cmake-gui", "-H" + sourceDir, "-B" + buildDir }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+						Runtime.getRuntime().exec(new String[] { "cmake-gui", "-S" + sourceDir, "-B" + buildDir }); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 					} catch (CoreException | IOException e1) {
 						MessageDialog.openError(parent.getShell(),
 								Messages.CMakePropertyPage_FailedToStartCMakeGui_Title,


### PR DESCRIPTION
The follow-up PR for #532.

This PR fixed the wrong source flag which was set by spawning the `cmake-gui` command.

Closes #532
