### PR TITLE
Ignore lines with "in function" and "In function"

### DIFF
--- a/core/org.eclipse.cdt.core.tests/misc/org/eclipse/cdt/core/internal/errorparsers/tests/GLDErrorParserTests.java
+++ b/core/org.eclipse.cdt.core.tests/misc/org/eclipse/cdt/core/internal/errorparsers/tests/GLDErrorParserTests.java
@@ -122,12 +122,46 @@ public class GLDErrorParserTests extends GenericErrorParserTests {
 					"make: *** [makefile:47: parser] Error 1",
 					"\"make all\" terminated with exit code 2. Build might be incomplete.", },
 				// @formatter:on
-				2, // errors
+				1, // errors
 				0, // warnings
 				0, // Infos
-				new String[] { "a.cpp", "project" },
-				new String[] { "./src/a.o: in function `TLS wrapper function for A::max_compatdb_time':",
-						"undefined reference to `A::max_compatdb_time'" },
+				new String[] { "a.cpp" }, new String[] { "undefined reference to `A::max_compatdb_time'" },
 				new String[] { GLD_ERROR_PARSER_ID });
+	}
+
+	@Test
+	public void testLinkerMessages_stubbed_function() throws IOException {
+		runParserTest(new String[] { "make all ",
+				// @formatter:off
+				"Building target: f4.elf",
+				"Invoking: Cross GCC Linker",
+				"arm-none-eabi-gcc -mthumb -mcpu=cortex-m4 --specs=nosys.specs -o \"f4.elf\"  ./Src/main.o",
+				"c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld.exe: c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m/nofp/libc.a(libc_a-closer.o): in function `_close_r':",
+				"/data/jenkins/workspace/GNU-toolchain/arm-11/src/newlib-cygwin/newlib/libc/reent/closer.c:47: warning: _close is not implemented and will always fail",
+				"c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld.exe: c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m/nofp/libc.a(libc_a-fstatr.o): in function `_fstat_r':",
+				"/data/jenkins/workspace/GNU-toolchain/arm-11/src/newlib-cygwin/newlib/libc/reent/fstatr.c:55: warning: _fstat is not implemented and will always fail",
+				"c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld.exe: c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m/nofp/libc.a(libc_a-signalr.o): in function `_getpid_r':",
+				"/data/jenkins/workspace/GNU-toolchain/arm-11/src/newlib-cygwin/newlib/libc/reent/signalr.c:83: warning: _getpid is not implemented and will always fail",
+				"c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld.exe: c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m/nofp/libc.a(libc_a-isattyr.o): in function `_isatty_r':",
+				"/data/jenkins/workspace/GNU-toolchain/arm-11/src/newlib-cygwin/newlib/libc/reent/isattyr.c:52: warning: _isatty is not implemented and will always fail",
+				"c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld.exe: c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m/nofp/libc.a(libc_a-signalr.o): in function `_kill_r':",
+				"/data/jenkins/workspace/GNU-toolchain/arm-11/src/newlib-cygwin/newlib/libc/reent/signalr.c:53: warning: _kill is not implemented and will always fail",
+				"c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld.exe: c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m/nofp/libc.a(libc_a-lseekr.o): in function `_lseek_r':",
+				"/data/jenkins/workspace/GNU-toolchain/arm-11/src/newlib-cygwin/newlib/libc/reent/lseekr.c:49: warning: _lseek is not implemented and will always fail",
+				"c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld.exe: c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m/nofp/libc.a(libc_a-readr.o): in function `_read_r':",
+				"/data/jenkins/workspace/GNU-toolchain/arm-11/src/newlib-cygwin/newlib/libc/reent/readr.c:49: warning: _read is not implemented and will always fail",
+				"c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/../../../../arm-none-eabi/bin/ld.exe: c:/arm-11.3.rel1/bin/../lib/gcc/arm-none-eabi/11.3.1/thumb/v7e-m/nofp/libc.a(libc_a-writer.o): in function `_write_r':",
+				"/data/jenkins/workspace/GNU-toolchain/arm-11/src/newlib-cygwin/newlib/libc/reent/writer.c:49: warning: _write is not implemented and will always fail",
+				"Finished building target: f4.elf",
+				" ",
+				"",
+				"14:37:57 Build Failed. 8 errors, 8 warnings. (took 1s.244ms)"},
+				// @formatter:on
+				0, // errors
+				8, // warnings
+				0, // Infos
+				null, new String[] { /* Don't really know what to add here */ },
+				new String[] { GLD_ERROR_PARSER_ID, GCC_ERROR_PARSER_ID });
+
 	}
 }

--- a/core/org.eclipse.cdt.core/plugin.properties
+++ b/core/org.eclipse.cdt.core/plugin.properties
@@ -72,7 +72,7 @@ CDTGNUCErrorParser.regex.GenericWarning=(.*?):(\\d+):(\\d+:)?\\s*(([Ww]arning)|(
 CDTGNUCErrorParser.regex.OtherError=(.*?):(\\d+):(\\d+:)? (.*)
 
 CDTGNULinkerErrorParser.name=GNU Linker Error Parser
-CDTGNULinkerErrorParser.regex.InFunction=(.*?):?(\\(\\.[^\\s+]+\\+.*\\))?:\\s*(In function [`'"](.*)['"]:)
+CDTGNULinkerErrorParser.regex.InFunction=(.*?):?(\\(\\.[^\\s+]+\\+.*\\))?:\\s*([Ii]n function [`'"](.*)['"]:)
 CDTGNULinkerErrorParser.regex.WarningDangerousFunction=(.*?):(\\d+):(\\d+:)? ([Ww]arning:)?\\s*(the use of [`'"](.*)['"] is dangerous, better use [`'"](.*)['"].*)
 CDTGNULinkerErrorParser.regex.TextWarning=(.*?):?\\(\\.[^\\s+]+\\+.*\\): [Ww]arning:? (.*)
 CDTGNULinkerErrorParser.regex.TextError=(.*?):?\\(\\.[^\\s+]+\\+.*\\): (.*)


### PR DESCRIPTION
In recent binutils version, the warning, for stubbed functions, is properly printed and due to this correction, linking a project with stubbed functions fails the build in headless build rather than just printing the warnings.

Example:
```
.../arm-none-eabi/bin/ld.exe: .../libc.a(libc_a-writer.o): in function `_write_r':
(.text._write_r+0x10): warning: _write is not implemented and will always fail ...
12:02:52 Build Failed. 8 errors, 8 warnings. (took 6s.284ms)
```

The first line matches the error pattern `(.*[/\\])?ld(\.exe)?: (.*)` that incorectly fails the build in headless mode (a single line matching a pattern with severity "error" fails the build) when there are really only warnings in the build log.

The problem can be obsered using the GCC 11 (and later) toolchain builds with newlib for the arm-none-eabi target provided by Arm.