### PR TITLE
Missing synchronization lock on CBuildConfiguration.scannerInfoCache.

### DIFF
--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/CBuildConfiguration.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/CBuildConfiguration.java
@@ -678,7 +678,9 @@ public abstract class CBuildConfiguration extends PlatformObject implements ICBu
 	 * @since 6.1
 	 */
 	protected ScannerInfoCache getScannerInfoCache() {
-		return scannerInfoCache;
+		synchronized (scannerInfoLock) {
+			return scannerInfoCache;
+		}
 	}
 
 	private IExtendedScannerInfo getBaseScannerInfo(IResource resource) throws CoreException {


### PR DESCRIPTION
Added one missing synchronization lock for accessing CBuildConfiguration.scannerInfoCache. This could cause race conditions.

This was detected by static code analysis.