### PR TITLE
Fix NPE if Launch Dialog not open yet

### DIFF
--- a/launchbar/org.eclipse.launchbar.ui/META-INF/MANIFEST.MF
+++ b/launchbar/org.eclipse.launchbar.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.launchbar.ui;singleton:=true
-Bundle-Version: 2.5.100.qualifier
+Bundle-Version: 2.5.200.qualifier
 Bundle-Activator: org.eclipse.launchbar.ui.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/launchbar/org.eclipse.launchbar.ui/src/org/eclipse/launchbar/ui/internal/LaunchBarLaunchConfigDialog.java
+++ b/launchbar/org.eclipse.launchbar.ui/src/org/eclipse/launchbar/ui/internal/LaunchBarLaunchConfigDialog.java
@@ -49,6 +49,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PlatformUI;
 
 public class LaunchBarLaunchConfigDialog extends TitleAreaDialog implements ILaunchBarLaunchConfigDialog {
 
@@ -325,6 +326,10 @@ public class LaunchBarLaunchConfigDialog extends TitleAreaDialog implements ILau
 	@Override
 	public void run(boolean fork, boolean cancelable, IRunnableWithProgress runnable)
 			throws InvocationTargetException, InterruptedException {
+		if (getShell() == null || !getShell().isVisible()) {
+			PlatformUI.getWorkbench().getProgressService().run(fork, cancelable, runnable);
+			return;
+		}
 		Control lastControl = getShell().getDisplay().getFocusControl();
 		if (lastControl != null && lastControl.getShell() != getShell()) {
 			lastControl = null;


### PR DESCRIPTION
Some flows (such as open JUnit test case) does a IRunnableContext.run before the UI is open. Therefore we need to fall back on the platform progress service to run it since the launch config UI is not ready yet

Fixes #555