### PR TITLE
Implement deduction guide template

### DIFF
--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/CPPDeductionGuideTemplate.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/CPPDeductionGuideTemplate.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Igor V. Kovalenko.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Igor V. Kovalenko - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.cdt.internal.core.dom.parser.cpp;
+
+import org.eclipse.cdt.core.dom.ast.IASTDeclarator;
+import org.eclipse.cdt.core.dom.ast.IBinding;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPFunction;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPTemplateDefinition;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPTemplateParameter;
+
+/**
+ * Represents c++17 deduction guide template.
+ */
+public class CPPDeductionGuideTemplate extends CPPDeductionGuide
+		implements ICPPTemplateDefinition, ICPPTemplateParameterOwner {
+
+	public CPPDeductionGuideTemplate(IASTDeclarator fnDecl, ICPPFunction functionBinding) {
+		super(fnDecl, functionBinding);
+	}
+
+	@Override
+	public ICPPTemplateParameter[] getTemplateParameters() {
+		if (functionBinding instanceof ICPPTemplateDefinition template) {
+			return template.getTemplateParameters();
+		}
+		return null;
+	}
+
+	@Override
+	public IBinding resolveTemplateParameter(ICPPTemplateParameter param) {
+		if (functionBinding instanceof ICPPTemplateParameterOwner owner) {
+			return owner.resolveTemplateParameter(param);
+		}
+		return null;
+	}
+}

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/CPPVisitor.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/CPPVisitor.java
@@ -214,6 +214,7 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPClosureType;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPConstructor;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPConstructorTemplate;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPDeductionGuide;
+import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPDeductionGuideTemplate;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPEnumeration;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPEnumerator;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPField;
@@ -999,7 +1000,8 @@ public class CPPVisitor extends ASTQueries {
 			}
 
 			if (isDeductionGuide) {
-				binding = new CPPDeductionGuide(typeRelevantDtor, (ICPPFunction) binding);
+				binding = template ? new CPPDeductionGuideTemplate(typeRelevantDtor, (ICPPFunction) binding)
+						: new CPPDeductionGuide(typeRelevantDtor, (ICPPFunction) binding);
 			} else {
 				binding = CPPSemantics.checkDeclSpecifier(binding, name, parent);
 

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/pdom/dom/cpp/PDOMCPPLinkage.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/pdom/dom/cpp/PDOMCPPLinkage.java
@@ -853,7 +853,7 @@ class PDOMCPPLinkage extends PDOMLinkage implements IIndexCPPBindingConstants {
 				pdomBinding = new PDOMCPPMethod(this, parent, (ICPPMethod) binding);
 			}
 		} else if (binding instanceof ICPPDeductionGuide guide) {
-			if (guide.getFunctionBinding() instanceof ICPPFunctionTemplate) {
+			if (guide instanceof ICPPTemplateDefinition) {
 				pdomBinding = new PDOMCPPDeductionGuideTemplate(this, parent, guide);
 			} else {
 				pdomBinding = new PDOMCPPDeductionGuide(this, parent, guide);
@@ -1145,7 +1145,7 @@ class PDOMCPPLinkage extends PDOMLinkage implements IIndexCPPBindingConstants {
 			// this must be before functions
 			return CPPMETHOD;
 		} else if (binding instanceof ICPPDeductionGuide guide) {
-			if (guide.getFunctionBinding() instanceof ICPPFunctionTemplate) {
+			if (guide instanceof ICPPTemplateDefinition) {
 				return CPP_DEDUCTION_GUIDE_TEMPLATE;
 			} else {
 				return CPP_DEDUCTION_GUIDE;


### PR DESCRIPTION
Add missing implementation for deduction guide template.

Add test and new indexer test strategy which more closely mirror what happens in real life (i.e. index is rebuilt after files are already in the project) which helps reproducing issue #438

Closes #438