### PR TITLE
Recognize simple declaration of function name with function type specifier

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
@@ -13894,4 +13894,22 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("true_value", 1);
 	}
+
+	//	typedef void (function_type_t)(char *, int, double);
+	//
+	//	void decl_function(char *, int, double) {
+	//	}
+	//
+	//	extern function_type_t decl_simple;
+	//
+	//	void decl_simple(char *, int, double) {
+	//	}
+	//
+	//	function_type_t* array[] = {
+	//			decl_function, // reference site marker
+	//			decl_simple, // reference site marker
+	//	};
+	public void testSimpleDeclarationOfFunction() throws Exception {
+		parseAndCheckImplicitNameBindings();
+	}
 }

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/CPPSemantics.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/CPPSemantics.java
@@ -4964,7 +4964,7 @@ public class CPPSemantics {
 		}
 
 		declarator = ASTQueries.findTypeRelevantDeclarator(declarator);
-		if (declarator instanceof ICPPASTFunctionDeclarator) {
+		if (declarator instanceof ICPPASTFunctionDeclarator || declarator instanceof ICPPASTDeclarator) {
 			// For declaration matching, compare the declared types (placeholders not resolved).
 			IType type = function.getDeclaredType();
 			return type.isSameType(CPPVisitor.createType(declarator, CPPVisitor.DO_NOT_RESOLVE_PLACEHOLDERS));


### PR DESCRIPTION
Simple declaration of function via function type decl specifier declares the same type as usual function declaration, fix this in the code.