### PR TITLE
Save additional exception info

### DIFF
--- a/dsf/org.eclipse.cdt.dsf.ui/src/org/eclipse/cdt/dsf/debug/internal/ui/disassembly/provisional/DisassemblyViewer.java
+++ b/dsf/org.eclipse.cdt.dsf.ui/src/org/eclipse/cdt/dsf/debug/internal/ui/disassembly/provisional/DisassemblyViewer.java
@@ -344,7 +344,7 @@ public class DisassemblyViewer extends SourceViewer implements IPropertyChangeLi
 				}
 			}
 		} catch (BadLocationException ble) {
-			throw new IllegalArgumentException(ble.getLocalizedMessage());
+			throw new IllegalArgumentException(ble.getLocalizedMessage(), ble);
 		}
 	}
 


### PR DESCRIPTION
When a position exception was raised the info was
lost of the underlying exception.

See #603