### PR TITLE
Fix disassembly view when view is reset

### DIFF
--- a/dsf/org.eclipse.cdt.dsf.ui/META-INF/MANIFEST.MF
+++ b/dsf/org.eclipse.cdt.dsf.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.cdt.dsf.ui;singleton:=true
-Bundle-Version: 2.7.100.qualifier
+Bundle-Version: 2.7.200.qualifier
 Bundle-Activator: org.eclipse.cdt.dsf.internal.ui.DsfUIPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.5.0",

--- a/dsf/org.eclipse.cdt.dsf.ui/src/org/eclipse/cdt/dsf/debug/internal/ui/disassembly/DisassemblyPart.java
+++ b/dsf/org.eclipse.cdt.dsf.ui/src/org/eclipse/cdt/dsf/debug/internal/ui/disassembly/DisassemblyPart.java
@@ -2126,8 +2126,10 @@ public abstract class DisassemblyPart extends WorkbenchPart
 		fPCHistory.clear();
 		fPendingPCUpdates.clear();
 		fFile2Storage.clear();
-		fDocument.clear();
+		var oldDocument = fDocument;
+		fDocument = createDocument();
 		fViewer.setDocument(fDocument, new AnnotationModel());
+		oldDocument.dispose();
 		if (fDebugSessionId != null) {
 			attachBreakpointsAnnotationModel();
 			attachExtendedPCAnnotationModel();

--- a/dsf/org.eclipse.cdt.dsf.ui/src/org/eclipse/cdt/dsf/debug/internal/ui/disassembly/model/DisassemblyDocument.java
+++ b/dsf/org.eclipse.cdt.dsf.ui/src/org/eclipse/cdt/dsf/debug/internal/ui/disassembly/model/DisassemblyDocument.java
@@ -33,14 +33,12 @@ import org.eclipse.cdt.debug.internal.ui.disassembly.dsf.IDisassemblyDocument;
 import org.eclipse.cdt.debug.internal.ui.disassembly.dsf.LabelPosition;
 import org.eclipse.cdt.dsf.debug.internal.ui.disassembly.SourcePosition;
 import org.eclipse.cdt.dsf.debug.internal.ui.disassembly.text.REDDocument;
-import org.eclipse.cdt.dsf.debug.internal.ui.disassembly.text.REDTextStore;
 import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.sourcelookup.containers.LocalFileStorage;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.BadPositionCategoryException;
-import org.eclipse.jface.text.DefaultLineTracker;
 import org.eclipse.jface.text.DocumentRewriteSession;
 import org.eclipse.jface.text.DocumentRewriteSessionType;
 import org.eclipse.jface.text.IDocument;
@@ -127,16 +125,6 @@ public class DisassemblyDocument extends REDDocument implements IDisassemblyDocu
 		fFileInfoMap.clear();
 		fInvalidAddressRanges.clear();
 		fInvalidSource.clear();
-	}
-
-	/**
-	 * Clears all content and state.
-	 */
-	public void clear() {
-		dispose();
-		setTextStore(new REDTextStore());
-		setLineTracker(new DefaultLineTracker());
-		completeInitialization();
 	}
 
 	public AddressRangePosition[] getInvalidAddressRanges() {


### PR DESCRIPTION
The view can be reset in a couple of ways, by changing debug context or manually refreshing. With this change in Platform https://github.com/eclipse-platform/eclipse.platform.ui/pull/963 the CDT violation of the API aronud resetting state of the document was exposed.

Therefore the solution is to instead of trying to reset the state of the existing document, create a new one when the view is reset.

Fixes #603