### PR TITLE
Avoid unnecessarily storing document in actions

### DIFF
--- a/dsf/org.eclipse.cdt.dsf.ui/src/org/eclipse/cdt/dsf/debug/internal/ui/disassembly/DisassemblyPart.java
+++ b/dsf/org.eclipse.cdt.dsf.ui/src/org/eclipse/cdt/dsf/debug/internal/ui/disassembly/DisassemblyPart.java
@@ -109,6 +109,7 @@ import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.ResourceLocator;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.BadPositionCategoryException;
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextOperationTarget;
@@ -580,8 +581,9 @@ public abstract class DisassemblyPart extends WorkbenchPart
 			if (fColumnSupport == null)
 				fColumnSupport = createColumnSupport();
 			return (T) fColumnSupport;
+		} else if (IDocument.class.equals(required)) {
+			return (T) getDocument();
 		}
-
 		return super.getAdapter(required);
 	}
 

--- a/dsf/org.eclipse.cdt.dsf.ui/src/org/eclipse/cdt/dsf/debug/internal/ui/disassembly/actions/RulerToggleBreakpointActionDelegate.java
+++ b/dsf/org.eclipse.cdt.dsf.ui/src/org/eclipse/cdt/dsf/debug/internal/ui/disassembly/actions/RulerToggleBreakpointActionDelegate.java
@@ -37,8 +37,7 @@ public class RulerToggleBreakpointActionDelegate extends AbstractDisassemblyRule
 		if (fDelegate != null) {
 			fDelegate.dispose();
 		}
-		return fDelegate = new ToggleBreakpointAction(disassemblyPart, disassemblyPart.getTextViewer().getDocument(),
-				rulerInfo);
+		return fDelegate = new ToggleBreakpointAction(disassemblyPart, null, rulerInfo);
 	}
 
 	/*

--- a/dsf/org.eclipse.cdt.dsf.ui/src/org/eclipse/cdt/dsf/debug/internal/ui/disassembly/actions/RulerToggleBreakpointHandler.java
+++ b/dsf/org.eclipse.cdt.dsf.ui/src/org/eclipse/cdt/dsf/debug/internal/ui/disassembly/actions/RulerToggleBreakpointHandler.java
@@ -18,7 +18,6 @@ import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.debug.ui.actions.ToggleBreakpointAction;
-import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.IVerticalRulerInfo;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.ui.IWorkbenchPart;
@@ -36,11 +35,9 @@ public class RulerToggleBreakpointHandler extends AbstractHandler {
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		IWorkbenchPart part = HandlerUtil.getActivePartChecked(event);
 		if (part instanceof IDisassemblyPart) {
-			IDisassemblyPart disassemblyPart = (IDisassemblyPart) part;
-			IDocument document = disassemblyPart.getTextViewer().getDocument();
 			final IVerticalRulerInfo rulerInfo = part.getAdapter(IVerticalRulerInfo.class);
 			if (rulerInfo != null) {
-				final ToggleBreakpointAction toggleBpAction = new ToggleBreakpointAction(part, document, rulerInfo);
+				final ToggleBreakpointAction toggleBpAction = new ToggleBreakpointAction(part, null, rulerInfo);
 				try {
 					toggleBpAction.update();
 					if (toggleBpAction.isEnabled()) {


### PR DESCRIPTION
With the first part of the fix in #603 we recreate the document regularly (on each context change) therefore we need to let any consumers of the document fetch the current version of the document from the editor (by calling getAdapter(IDocument.class)) when it is needed, rather than caching it.

Fixes #603