### PR TITLE
Prepare repo for CDT 11.4.0 M3

### DIFF
--- a/debug/org.eclipse.cdt.debug.application.product/debug.product
+++ b/debug/org.eclipse.cdt.debug.application.product/debug.product
@@ -185,34 +185,29 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="bcprov"/>
       <plugin id="com.google.gson"/>
       <plugin id="com.ibm.icu"/>
+      <plugin id="com.jcraft.jsch"/>
+      <plugin id="com.sun.el.javax.el"/>
       <plugin id="com.sun.jna"/>
       <plugin id="com.sun.jna.platform"/>
       <plugin id="com.sun.xml.bind"/>
       <plugin id="jakarta.activation-api"/>
       <plugin id="jakarta.annotation-api"/>
       <plugin id="jakarta.inject.jakarta.inject-api"/>
-      <plugin id="jakarta.servlet-api"/>
       <plugin id="jakarta.xml.bind-api"/>
-      <plugin id="javax.el-api"/>
-      <plugin id="javax.servlet.jsp-api"/>
       <plugin id="org.apache.aries.spifly.dynamic.bundle"/>
       <plugin id="org.apache.batik.constants"/>
       <plugin id="org.apache.batik.css"/>
       <plugin id="org.apache.batik.i18n"/>
       <plugin id="org.apache.batik.util"/>
-      <plugin id="org.apache.commons.codec"/>
       <plugin id="org.apache.commons.collections"/>
       <plugin id="org.apache.commons.commons-beanutils"/>
       <plugin id="org.apache.commons.commons-io"/>
       <plugin id="org.apache.commons.jxpath"/>
       <plugin id="org.apache.commons.logging"/>
+      <plugin id="org.apache.felix.gogo.command"/>
+      <plugin id="org.apache.felix.gogo.runtime"/>
+      <plugin id="org.apache.felix.gogo.shell"/>
       <plugin id="org.apache.felix.scr"/>
-      <plugin id="org.apache.httpcomponents.client5.httpclient5"/>
-      <plugin id="org.apache.httpcomponents.core5.httpcore5"/>
-      <plugin id="org.apache.httpcomponents.core5.httpcore5-h2"/>
-      <plugin id="org.apache.httpcomponents.httpclient"/>
-      <plugin id="org.apache.httpcomponents.httpcore"/>
-      <plugin id="org.apache.jasper.glassfish"/>
       <plugin id="org.apache.lucene.analysis-common"/>
       <plugin id="org.apache.lucene.analysis-smartcn"/>
       <plugin id="org.apache.lucene.core"/>
@@ -252,6 +247,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.core.commands"/>
       <plugin id="org.eclipse.core.contenttype"/>
       <plugin id="org.eclipse.core.databinding"/>
+      <plugin id="org.eclipse.core.databinding.beans"/>
       <plugin id="org.eclipse.core.databinding.observable"/>
       <plugin id="org.eclipse.core.databinding.property"/>
       <plugin id="org.eclipse.core.expressions"/>
@@ -301,7 +297,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.ecf.filetransfer"/>
       <plugin id="org.eclipse.ecf.identity"/>
       <plugin id="org.eclipse.ecf.provider.filetransfer"/>
-      <plugin id="org.eclipse.ecf.provider.filetransfer.httpclient5"/>
+      <plugin id="org.eclipse.ecf.provider.filetransfer.httpclientjava"/>
       <plugin id="org.eclipse.ecf.provider.filetransfer.ssl" fragment="true"/>
       <plugin id="org.eclipse.ecf.ssl" fragment="true"/>
       <plugin id="org.eclipse.emf.common"/>
@@ -358,26 +354,33 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.help.webapp"/>
       <plugin id="org.eclipse.jdt.core"/>
       <plugin id="org.eclipse.jdt.core.compiler.batch"/>
+      <plugin id="org.eclipse.jetty.ee8.security"/>
+      <plugin id="org.eclipse.jetty.ee8.server"/>
+      <plugin id="org.eclipse.jetty.ee8.servlet"/>
       <plugin id="org.eclipse.jetty.http"/>
       <plugin id="org.eclipse.jetty.io"/>
       <plugin id="org.eclipse.jetty.security"/>
       <plugin id="org.eclipse.jetty.server"/>
-      <plugin id="org.eclipse.jetty.servlet"/>
+      <plugin id="org.eclipse.jetty.servlet-api"/>
+      <plugin id="org.eclipse.jetty.session"/>
       <plugin id="org.eclipse.jetty.util"/>
-      <plugin id="org.eclipse.jetty.util.ajax"/>
       <plugin id="org.eclipse.jface"/>
       <plugin id="org.eclipse.jface.databinding"/>
       <plugin id="org.eclipse.jface.notifications"/>
       <plugin id="org.eclipse.jface.text"/>
+      <plugin id="org.eclipse.jsch.core"/>
+      <plugin id="org.eclipse.jsch.ui"/>
       <plugin id="org.eclipse.launchbar.core"/>
       <plugin id="org.eclipse.launchbar.ui"/>
       <plugin id="org.eclipse.ltk.core.refactoring"/>
       <plugin id="org.eclipse.ltk.ui.refactoring"/>
+      <plugin id="org.eclipse.orbit.xml-apis-ext"/>
       <plugin id="org.eclipse.osgi"/>
       <plugin id="org.eclipse.osgi.compatibility.state" fragment="true"/>
       <plugin id="org.eclipse.osgi.services"/>
       <plugin id="org.eclipse.osgi.util"/>
       <plugin id="org.eclipse.search"/>
+      <plugin id="org.eclipse.search.core"/>
       <plugin id="org.eclipse.swt"/>
       <plugin id="org.eclipse.swt.cocoa.macosx.x86_64" fragment="true"/>
       <plugin id="org.eclipse.swt.gtk.linux.aarch64" fragment="true"/>
@@ -408,6 +411,7 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.eclipse.urischeme"/>
       <plugin id="org.freemarker.freemarker"/>
       <plugin id="org.jdom"/>
+      <plugin id="org.mortbay.jasper.apache-jsp"/>
       <plugin id="org.objectweb.asm"/>
       <plugin id="org.objectweb.asm.commons"/>
       <plugin id="org.objectweb.asm.tree"/>
@@ -430,23 +434,20 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="org.osgi.util.xml"/>
       <plugin id="org.sat4j.core"/>
       <plugin id="org.sat4j.pb"/>
-      <plugin id="org.slf4j.api"/>
       <plugin id="org.tukaani.xz"/>
-      <plugin id="org.w3c.css.sac"/>
-      <plugin id="org.w3c.dom.events"/>
-      <plugin id="org.w3c.dom.smil"/>
-      <plugin id="org.w3c.dom.svg"/>
       <plugin id="slf4j.api"/>
-      <plugin id="slf4j.nop"/>
+      <plugin id="slf4j.simple"/>
    </plugins>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
       <plugin id="org.eclipse.osgi" autoStart="true" startLevel="-1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
    </configurations>
 
    <repositories>

--- a/debug/org.eclipse.cdt.debug.application/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.cdt.debug.application/META-INF/MANIFEST.MF
@@ -20,7 +20,10 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.cdt.managedbuilder.core;bundle-version="8.2.1",
  org.eclipse.cdt.managedbuilder.gnu.ui;bundle-version="8.2.0",
  org.eclipse.cdt.debug.core,
- org.eclipse.ui.workbench
+ org.eclipse.ui.workbench,
+ org.eclipse.orbit.xml-apis-ext,
+ jakarta.activation-api,
+ jakarta.xml.bind-api
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<cbi-plugins.version>1.3.4</cbi-plugins.version>
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
 		<cdt-site>http://ci.eclipse.org/cdt/job/cdt-master/lastSuccessfulBuild/artifact/releng/org.eclipse.cdt.repo/target/repository</cdt-site>
-		<simrel-site>https://download.eclipse.org/staging/2023-09/</simrel-site>
+		<simrel-site>https://download.eclipse.org/staging/2023-12/</simrel-site>
 		<repo-path>tools/cdt/builds/master/nightly</repo-path>
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 		<sonar.jacoco.reportPath>${project.basedir}/../../target/jacoco.exec</sonar.jacoco.reportPath>

--- a/releng/CDT.setup
+++ b/releng/CDT.setup
@@ -74,7 +74,7 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="eclipse.target.platform"
-      value="${eclipse.target.platform.latest.released}"
+      value="${eclipse.target.platform.latest}"
       defaultValue=""
       storageURI="scope://Workspace"/>
   <setupTask

--- a/releng/org.eclipse.cdt.target/cdt.target
+++ b/releng/org.eclipse.cdt.target/cdt.target
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="cdt" sequenceNumber="150">
+<target name="cdt" sequenceNumber="151">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/" />
 			<unit id="org.eclipse.license.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.29/R-4.29-202309031000/" />
+			<repository location="https://download.eclipse.org/eclipse/updates/4.30-I-builds/I20231109-0710/" />
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.jdt.annotation" version="0.0.0" />
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0" />
@@ -57,10 +57,10 @@
 					<version>2.0.7</version>
 					<type>jar</type>
 				</dependency>
-				<!-- slf4j-api requires 1 impl, providing a dummy one... -->
+				<!-- slf4j-api requires 1 impl, provide the one that is generally used in the final product, such as standalone debugger -->
 				<dependency>
 					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-nop</artifactId>
+					<artifactId>slf4j-simple</artifactId>
 					<version>2.0.7</version>
 					<type>jar</type>
 				</dependency>
@@ -195,7 +195,7 @@
 			</dependencies>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release"/>
+			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202311141131"/>
 			<!-- failureaccess is needed because the Linuxtools depends on it but doesn't republish it - https://github.com/eclipse-linuxtools/org.eclipse.linuxtools/issues/232
 			This dep can't be added to maven section because of https://github.com/eclipse-pde/eclipse.pde/issues/675 -->
 			<unit id="com.google.guava.failureaccess" version="0.0.0" />
@@ -203,6 +203,7 @@
 			<unit id="org.hamcrest.core" version="1.3.0.v20230809-1000" />
 			<unit id="org.hamcrest.library" version="1.3.0.v20230809-1000" />
 			<unit id="org.junit" version="4.13.2.v20230809-1000" />
+			<unit id="org.eclipse.orbit.xml-apis-ext" version="1.0.0.v20230923-0644"/>
 		</location>
 	</locations>
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17" />


### PR DESCRIPTION
Includes updating to latest target platform. This should also fix #591 but it is hard to tell until after it is integrated into SimRel and the output checked in EPP.

Fixes https://github.com/eclipse-cdt/cdt/issues/591
Part of #548