### PR TITLE
Convert \b to 0x7f to properly handle backspace in the terminal

### DIFF
--- a/NewAndNoteworthy/CDT-11.4.md
+++ b/NewAndNoteworthy/CDT-11.4.md
@@ -26,6 +26,14 @@ The managed build GNU linker tool description now provides an option for groupin
 
 The new option is available within managed build configurations using a _Cross GCC_, _Cygwin GCC_, _Linux GCC_ or _MinGW GCC_ toolchain.
 
+# Terminal
+
+## Backspace now sends `0x7f` instead of `0x08` (`\b`, `^H`)
+
+Introduced to [fix an incompatibility on Windows](https://github.com/eclipse-cdt/cdt/issues/392) the terminal converts `^H` to ascii `0x7f` to ensure a single character is deleted rather than a whole word.
+
+The java property `org.eclipse.tm.terminal.control.convertBackspace` can be set to `false` to disable this behavior in case it interferes with the expected behavior of the terminal.
+
 # API Changes, current and planned
 
 ## Changes to org.eclipse.tools.templates APIs

--- a/terminal/plugins/org.eclipse.tm.terminal.control/src/org/eclipse/tm/internal/terminal/emulator/VT100TerminalControl.java
+++ b/terminal/plugins/org.eclipse.tm.terminal.control/src/org/eclipse/tm/internal/terminal/emulator/VT100TerminalControl.java
@@ -185,6 +185,19 @@ public class VT100TerminalControl implements ITerminalControlForText, ITerminalC
 	private PollingTextCanvasModel fPollingTextCanvasModel;
 
 	/**
+	 * In some circumstances (e.g PowerShell on Windows) the backspace
+	 * character received from the keypress needs modifying. This
+	 * system property allows disabling this new feature in case there
+	 * are users who are negatively affected by this conversion.
+	 *
+	 * \b is ^H which is interpreted by the console as Ctrl + Backspace
+	 * which deletes a word. \b on its own should just delete a character
+	 * so we send 0x7f to do that.
+	 */
+	private boolean convertBackspace = Boolean
+			.parseBoolean(System.getProperty("org.eclipse.tm.terminal.control.convertBackspace", "true")); //$NON-NLS-1$ //$NON-NLS-2$
+
+	/**
 	 * Instantiate a Terminal widget.
 	 * @param target Callback for notifying the owner of Terminal state changes.
 	 * @param wndParent The Window parent to embed the Terminal in.
@@ -1173,6 +1186,11 @@ public class VT100TerminalControl implements ITerminalControlForText, ITerminalC
 					character = '\u001f';
 					break;
 				}
+			}
+
+			// see javadoc on convertBackspace for details
+			if (convertBackspace && !ctrlKeyPressed && character == '\b') {
+				character = 0x7f;
 			}
 
 			//TODO: At this point, Ctrl+M sends the same as Ctrl+Shift+M .


### PR DESCRIPTION
Includes a new system property `org.eclipse.tm.terminal.control.convertBackspace` to allow us to disable this new behaviour in the field if it turns out that some terminal/host combination does not like this conversion.

Fixes #392