### PR TITLE
Add a missing null check since terminal properties can be null

### DIFF
--- a/terminal/plugins/org.eclipse.tm.terminal.view.ui/src/org/eclipse/tm/terminal/view/ui/tabs/TabTerminalListener.java
+++ b/terminal/plugins/org.eclipse.tm.terminal.view.ui/src/org/eclipse/tm/terminal/view/ui/tabs/TabTerminalListener.java
@@ -127,13 +127,11 @@ public class TabTerminalListener implements ITerminalListener3 {
 			// Get the original terminal properties associated with the tab item
 			@SuppressWarnings({ "unchecked" })
 			final Map<String, Object> properties = (Map<String, Object>) item.getData("properties"); //$NON-NLS-1$
-			if (properties.containsKey(ITerminalsConnectorConstants.PROP_TITLE_DISABLE_ANSI_TITLE)) {
-				if (properties.get(
-						ITerminalsConnectorConstants.PROP_TITLE_DISABLE_ANSI_TITLE) instanceof Boolean disableAnsi) {
-					// Check if terminal title can be updated from ANSI escape sequence
-					if (disableAnsi && requestor == TerminalTitleRequestor.ANSI) {
-						return;
-					}
+			if (properties != null && properties
+					.get(ITerminalsConnectorConstants.PROP_TITLE_DISABLE_ANSI_TITLE) instanceof Boolean disableAnsi) {
+				// Check if terminal title can be updated from ANSI escape sequence
+				if (disableAnsi && requestor == TerminalTitleRequestor.ANSI) {
+					return;
 				}
 			}
 


### PR DESCRIPTION
Removes a redundant map lookup too.

Fixes #617