### PR TITLE
Allows launch config to override launch target connection type

### DIFF
--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/META-INF/MANIFEST.MF
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.cdt.dsf.gdb;singleton:=true
-Bundle-Version: 7.1.200.qualifier
+Bundle-Version: 7.1.300.qualifier
 Bundle-Activator: org.eclipse.cdt.dsf.gdb.internal.GdbPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/service/command/GDBControl.java
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/service/command/GDBControl.java
@@ -439,16 +439,19 @@ public class GDBControl extends AbstractMIControl implements IGDBControl {
 		}
 
 		// And optionally the target
-		if (launch instanceof ITargetedLaunch) {
-			ILaunchTarget target = ((ITargetedLaunch) launch).getLaunchTarget();
+		if (launch instanceof ITargetedLaunch targettedLaunch) {
+			ILaunchTarget target = targettedLaunch.getLaunchTarget();
 			if (target != null) {
 				attributes.putAll(target.getAttributes());
 				String tcp = target.getAttribute(IGDBLaunchConfigurationConstants.ATTR_REMOTE_TCP, ""); //$NON-NLS-1$
 				if (!tcp.isEmpty()) {
 					attributes.put(IGDBLaunchConfigurationConstants.ATTR_REMOTE_TCP, Boolean.parseBoolean(tcp));
 				} else {
-					attributes.put(IGDBLaunchConfigurationConstants.ATTR_REMOTE_TCP,
-							target.getTypeId().equals(GDBRemoteTCPLaunchTargetProvider.TYPE_ID));
+					// If the launch config attrs don't contain a REMOTE_TCP value then check the launch target attrs
+					if (!attributes.containsKey(IGDBLaunchConfigurationConstants.ATTR_REMOTE_TCP)) {
+						attributes.put(IGDBLaunchConfigurationConstants.ATTR_REMOTE_TCP,
+								target.getTypeId().equals(GDBRemoteTCPLaunchTargetProvider.TYPE_ID));
+					}
 				}
 			}
 		}
@@ -689,7 +692,7 @@ public class GDBControl extends AbstractMIControl implements IGDBControl {
 		getSession().addServiceEventListener(GDBControl.this, null);
 		register(new String[] { ICommandControl.class.getName(), ICommandControlService.class.getName(),
 				IMICommandControl.class.getName(), AbstractMIControl.class.getName(), IGDBControl.class.getName() },
-				new Hashtable<String, String>());
+				new Hashtable<>());
 		getSession().dispatchEvent(new GDBControlInitializedDMEvent(getContext()), getProperties());
 		requestMonitor.done();
 	}


### PR DESCRIPTION
When launching a GDB debug session using the Launch Bar and a Launch Target, now the launch takes into account a REMOTE_TCP value in the launch configuration before considering the type of the Launch Target.

Improves the change submitted in:
Bug 547881 - Allow targets to set ATTR_REMOTE_TCP

Fixes issue #622