### PR TITLE
Use the bundle providing javax.activation package in simrel

### DIFF
--- a/debug/org.eclipse.cdt.debug.application.product/debug.product
+++ b/debug/org.eclipse.cdt.debug.application.product/debug.product
@@ -190,10 +190,10 @@ Java and all Java-based trademarks are trademarks of Oracle Corporation in the U
       <plugin id="com.sun.jna"/>
       <plugin id="com.sun.jna.platform"/>
       <plugin id="com.sun.xml.bind"/>
-      <plugin id="jakarta.activation-api"/>
       <plugin id="jakarta.annotation-api"/>
       <plugin id="jakarta.inject.jakarta.inject-api"/>
       <plugin id="jakarta.xml.bind-api"/>
+      <plugin id="javax.activation"/>
       <plugin id="org.apache.aries.spifly.dynamic.bundle"/>
       <plugin id="org.apache.batik.constants"/>
       <plugin id="org.apache.batik.css"/>

--- a/debug/org.eclipse.cdt.debug.application/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.cdt.debug.application/META-INF/MANIFEST.MF
@@ -20,10 +20,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.cdt.managedbuilder.core;bundle-version="8.2.1",
  org.eclipse.cdt.managedbuilder.gnu.ui;bundle-version="8.2.0",
  org.eclipse.cdt.debug.core,
- org.eclipse.ui.workbench,
- org.eclipse.orbit.xml-apis-ext,
- jakarta.activation-api;bundle-version="[1.2.2,2.0.0)",
- jakarta.xml.bind-api;bundle-version="[2.3.3,3.0.0)"
+ org.eclipse.ui.workbench
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/releng/org.eclipse.cdt.repo/category.xml
+++ b/releng/org.eclipse.cdt.repo/category.xml
@@ -186,7 +186,7 @@
    <bundle id="org.eclipse.cdt.remote.core.source" version="0.0.0"/>
    <bundle id="com.sun.xml.bind" version="0.0.0"/>
    <bundle id="org.eclipse.orbit.xml-apis-ext" version="0.0.0"/>
-   <bundle id="jakarta.activation-api" version="1.2.2"/>
+   <bundle id="javax.activation" version="1.2.2.v20221203-1659"/>
    <bundle id="jakarta.xml.bind-api" version="2.3.3"/>
    <bundle id="com.google.gson" version="0.0.0"/>
    <bundle id="org.freemarker.freemarker" version="2.3.32.stable"/>

--- a/releng/org.eclipse.cdt.target/cdt.target
+++ b/releng/org.eclipse.cdt.target/cdt.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="cdt" sequenceNumber="152">
+<target name="cdt" sequenceNumber="153">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/" />
@@ -204,6 +204,13 @@
 			<unit id="org.hamcrest.library" version="1.3.0.v20230809-1000" />
 			<unit id="org.junit" version="4.13.2.v20230809-1000" />
 			<unit id="org.eclipse.orbit.xml-apis-ext" version="1.0.0.v20230923-0644"/>
+			<unit id="bcpg" version="0.0.0"/>
+			<unit id="bcprov" version="0.0.0"/>
+			<unit id="org.apache.commons.logging" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository/"/>
+			<unit id="javax.activation" version="1.2.2.v20221203-1659"/>
 		</location>
 	</locations>
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17" />


### PR DESCRIPTION
Because javax.activation 1.2.2.v20221203-1659 is in SimRel (for now) it gets picked by p2 over jakarta.activation-api 1.2.2 which provides the same packages.

As and when we update to Jave EE 9 (IIUC) we should be able to solve this in a cleaner way and not rely on the old orbit bundles. Also, if and when all projects contributing to simrel remove 1.2.2.v20221203-1659 then we can change too.

The other option is to try to force the jakarta.activation-api 1.2.2 into simrel and the EPP packages, but if we accidentally end up with both in a product then other things don't work, e.g. like this error:

<details>
<summary>frame work error details</summary>

```java
!ENTRY org.eclipse.cdt.debug.application 4 0 2023-11-20 15:06:47.456
!MESSAGE FrameworkEvent ERROR
!STACK 0
org.osgi.framework.BundleException: Could not resolve module: org.eclipse.cdt.debug.application [101]
  Unresolved requirement: Require-Bundle: org.eclipse.cdt.dsf; bundle-version="2.4.0"
    -> Bundle-SymbolicName: org.eclipse.cdt.dsf; bundle-version="2.12.0.202211062329"; singleton:="true"
       org.eclipse.cdt.dsf [116]
         No resolution report for the bundle.  Unresolved requirement: Require-Bundle: org.eclipse.cdt.dsf.ui; bundle-version="2.4.0"
    -> Bundle-SymbolicName: org.eclipse.cdt.dsf.ui; bundle-version="2.7.200.202311031553"; singleton:="true"
       org.eclipse.cdt.dsf.ui [119]
         Unresolved requirement: Require-Bundle: org.eclipse.cdt.dsf; bundle-version="2.0.0"
           -> Bundle-SymbolicName: org.eclipse.cdt.dsf; bundle-version="2.12.0.202211062329"; singleton:="true"
  Unresolved requirement: Require-Bundle: org.eclipse.cdt.gdb; bundle-version="7.0.0"
    -> Bundle-SymbolicName: org.eclipse.cdt.gdb; bundle-version="7.2.100.202303140100"; singleton:="true"
       org.eclipse.cdt.gdb [121]
         No resolution report for the bundle.  Unresolved requirement: Require-Bundle: org.eclipse.cdt.dsf.gdb.ui; bundle-version="2.4.0"
    -> Bundle-SymbolicName: org.eclipse.cdt.dsf.gdb.ui; bundle-version="2.8.300.202309151124"; singleton:="true"
       org.eclipse.cdt.dsf.gdb.ui [118]
         Unresolved requirement: Require-Bundle: org.eclipse.cdt.dsf.ui
           -> Bundle-SymbolicName: org.eclipse.cdt.dsf.ui; bundle-version="2.7.200.202311031553"; singleton:="true"
         Unresolved requirement: Require-Bundle: org.eclipse.cdt.dsf.gdb; bundle-version="[7.0.0,8.0.0)"
           -> Bundle-SymbolicName: org.eclipse.cdt.dsf.gdb; bundle-version="7.1.200.202309151124"; singleton:="true"
              org.eclipse.cdt.dsf.gdb [117]
                Unresolved requirement: Require-Bundle: org.eclipse.cdt.dsf
                  -> Bundle-SymbolicName: org.eclipse.cdt.dsf; bundle-version="2.12.0.202211062329"; singleton:="true"
                Unresolved requirement: Require-Bundle: org.eclipse.cdt.native.serial; bundle-version="1.1.100"
                  -> Bundle-SymbolicName: org.eclipse.cdt.native.serial; bundle-version="11.4.0.202311201859"
                     org.eclipse.cdt.native.serial [141]
                       No resolution report for the bundle.                Unresolved requirement: Require-Bundle: org.eclipse.cdt.gdb; bundle-version="7.0.0"
                  -> Bundle-SymbolicName: org.eclipse.cdt.gdb; bundle-version="7.2.100.202303140100"; singleton:="true"
         Unresolved requirement: Require-Bundle: org.eclipse.cdt.native.serial; bundle-version="1.1.100"
           -> Bundle-SymbolicName: org.eclipse.cdt.native.serial; bundle-version="11.4.0.202311201859"
         Unresolved requirement: Require-Bundle: org.eclipse.tm.terminal.control; bundle-version="4.0.0"
           -> Bundle-SymbolicName: org.eclipse.tm.terminal.control; bundle-version="5.5.100.202311142253"; singleton:="true"
              org.eclipse.tm.terminal.control [506]
                No resolution report for the bundle.         Unresolved requirement: Require-Bundle: org.eclipse.cdt.dsf
           -> Bundle-SymbolicName: org.eclipse.cdt.dsf; bundle-version="2.12.0.202211062329"; singleton:="true"
  Unresolved requirement: Require-Bundle: jakarta.activation-api; bundle-version="[1.2.2,2.0.0)"
    -> Bundle-SymbolicName: jakarta.activation-api; bundle-version="1.2.2"
       jakarta.activation-api [30]
         No resolution report for the bundle.  Unresolved requirement: Require-Bundle: org.eclipse.cdt.dsf.gdb; bundle-version="4.2.0"
    -> Bundle-SymbolicName: org.eclipse.cdt.dsf.gdb; bundle-version="7.1.200.202309151124"; singleton:="true"
  Unresolved requirement: Require-Bundle: org.eclipse.cdt.gdb.ui; bundle-version="7.0.0"
    -> Bundle-SymbolicName: org.eclipse.cdt.gdb.ui; bundle-version="7.2.0.202211062329"; singleton:="true"
       org.eclipse.cdt.gdb.ui [122]
         No resolution report for the bundle.  Bundle was not resolved because of a uses constraint violation.
  org.apache.felix.resolver.reason.ReasonException: Uses constraint violation. Unable to resolve resource org.eclipse.cdt.debug.application [osgi.identity; osgi.identity="org.eclipse.cdt.debug.application"; type="osgi.bundle"; version:Version="11.4.0.202311201855"; singleton:="true"] because it is exposed to package 'javax.activation' from resources jakarta.activation-api [osgi.identity; osgi.identity="jakarta.activation-api"; type="osgi.bundle"; version:Version="1.2.2"] and javax.activation [osgi.identity; osgi.identity="javax.activation"; type="osgi.bundle"; version:Version="1.2.2.v20221203-1659"] via two dependency chains.

Chain 1:
  org.eclipse.cdt.debug.application [osgi.identity; osgi.identity="org.eclipse.cdt.debug.application"; type="osgi.bundle"; version:Version="11.4.0.202311201855"; singleton:="true"]
    require: (&(osgi.wiring.bundle=jakarta.activation-api)(&(bundle-version>=1.2.2)(!(bundle-version>=2.0.0))))
     |
    provide: osgi.wiring.bundle: jakarta.activation-api
  jakarta.activation-api [osgi.identity; osgi.identity="jakarta.activation-api"; type="osgi.bundle"; version:Version="1.2.2"]

Chain 2:
  org.eclipse.cdt.debug.application [osgi.identity; osgi.identity="org.eclipse.cdt.debug.application"; type="osgi.bundle"; version:Version="11.4.0.202311201855"; singleton:="true"]
    require: (&(osgi.wiring.bundle=jakarta.xml.bind-api)(&(bundle-version>=2.3.3)(!(bundle-version>=3.0.0))))
     |
    provide: osgi.wiring.bundle; bundle-version:Version="2.3.3"; osgi.wiring.bundle="jakarta.xml.bind-api"
  jakarta.xml.bind-api [osgi.identity; osgi.identity="jakarta.xml.bind-api"; type="osgi.bundle"; version:Version="2.3.3"]
    import: (osgi.wiring.package=javax.activation)
     |
    export: osgi.wiring.package: javax.activation
  javax.activation [osgi.identity; osgi.identity="javax.activation"; type="osgi.bundle"; version:Version="1.2.2.v20221203-1659"]
	at org.eclipse.osgi.container.Module.start(Module.java:463)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel$2.run(ModuleContainer.java:1852)
	at org.eclipse.osgi.internal.framework.EquinoxContainerAdaptor$1$1.execute(EquinoxContainerAdaptor.java:136)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1845)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1786)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:1750)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1672)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1)
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:234)
	at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:345)
```

</details>

The underlying problem here is that the debug application's "product" that gets converted to a config.ini at CDT build time doesn't expose its dependencies fully to p2, so we end up with a built product in EPP that doesn't have everything listed in config.ini.

There is significant maintenance overhead and it is growing to keeping standalone as it is now working. Other options should probably be considered, such as using the config of the full product when launching.

Fixes #591