### PR TITLE
Cursor not behaving correctly in memory view editor while chaging variable value on Hi-DPI

### DIFF
--- a/memory/org.eclipse.cdt.debug.ui.memory.floatingpoint/META-INF/MANIFEST.MF
+++ b/memory/org.eclipse.cdt.debug.ui.memory.floatingpoint/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.ui.memory.floatingpoint;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.100.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.debug.core;bundle-version="3.7.100",
  org.eclipse.debug.ui;bundle-version="3.8.1",

--- a/memory/org.eclipse.cdt.debug.ui.memory.floatingpoint/src/org/eclipse/cdt/debug/ui/memory/floatingpoint/FPAbstractPane.java
+++ b/memory/org.eclipse.cdt.debug.ui.memory.floatingpoint/src/org/eclipse/cdt/debug/ui/memory/floatingpoint/FPAbstractPane.java
@@ -774,7 +774,7 @@ public abstract class FPAbstractPane extends Canvas {
 		if (fCharacterWidth == -1) {
 			GC gc = new GC(this);
 			gc.setFont(fRendering.getFont());
-			fCharacterWidth = gc.getAdvanceWidth('F');
+			fCharacterWidth = gc.textExtent("F").x; //$NON-NLS-1$
 			gc.dispose();
 		}
 

--- a/memory/org.eclipse.cdt.debug.ui.memory.traditional/META-INF/MANIFEST.MF
+++ b/memory/org.eclipse.cdt.debug.ui.memory.traditional/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.ui.memory.traditional;singleton:=true
-Bundle-Version: 1.7.0.qualifier
+Bundle-Version: 1.7.100.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.debug.core,
  org.eclipse.debug.ui,

--- a/memory/org.eclipse.cdt.debug.ui.memory.traditional/src/org/eclipse/cdt/debug/ui/memory/traditional/AbstractPane.java
+++ b/memory/org.eclipse.cdt.debug.ui.memory.traditional/src/org/eclipse/cdt/debug/ui/memory/traditional/AbstractPane.java
@@ -742,7 +742,7 @@ public abstract class AbstractPane extends Canvas {
 		if (fCharacterWidth == -1) {
 			GC gc = new GC(this);
 			gc.setFont(fRendering.getFont());
-			fCharacterWidth = gc.getAdvanceWidth('F');
+			fCharacterWidth = gc.textExtent("F").x; //$NON-NLS-1$
 			gc.dispose();
 		}
 

--- a/memory/org.eclipse.cdt.debug.ui.memory.traditional/src/org/eclipse/cdt/debug/ui/memory/traditional/TextPane.java
+++ b/memory/org.eclipse.cdt.debug.ui.memory.traditional/src/org/eclipse/cdt/debug/ui/memory/traditional/TextPane.java
@@ -79,7 +79,7 @@ public class TextPane extends AbstractPane {
 	protected int getCellWidth() {
 		GC gc = new GC(this);
 		gc.setFont(fRendering.getFont());
-		int width = gc.getAdvanceWidth('F');
+		int width = gc.textExtent("F").x; //$NON-NLS-1$
 		gc.dispose();
 
 		return fRendering.getBytesPerColumn() / fRendering.getBytesPerCharacter() * width;


### PR DESCRIPTION
**Description**
Changing value of a hex digit in a cell in Memory View is not working correctly on higher resolution displays.

**Problem**
GC.getAdvanceWidth(...) method is being used to calculate character width which doesn't take zooming in consideration as it gets width using [native OS method](https://github.com/eclipse-platform/eclipse.platform.swt/blob/master/bundles/org.eclipse.swt/Eclipse%20SWT/win32/org/eclipse/swt/graphics/GC.java#L3167)

```java
public int getAdvanceWidth(char ch) {
	if (handle == 0) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
	checkGC(FONT);
	int[] width = new int[1];
	OS.GetCharWidth(handle, ch, ch, width);
	return width[0];
}
```

**Resolution**
Used GC.textExtent() method which automatically handles zooming using [DPIUtil.autoScaleDown(..)](https://github.com/eclipse-platform/eclipse.platform.swt/blob/master/bundles/org.eclipse.swt/Eclipse%20SWT/win32/org/eclipse/swt/graphics/GC.java#L4973) API

```java
public Point textExtent (String string) {
	return DPIUtil.autoScaleDown(drawable, textExtentInPixels(string, SWT.DRAW_DELIMITER | SWT.DRAW_TAB));
}
```

Fixes https://github.com/eclipse-cdt/cdt/issues/641
