### PR TITLE
[#407] fix CompilerBuiltinsDetector for msys2 on Windows

### DIFF
--- a/jsoncdb/org.eclipse.cdt.jsoncdb.core/META-INF/MANIFEST.MF
+++ b/jsoncdb/org.eclipse.cdt.jsoncdb.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %bundleName
 Bundle-Description: %bundleDescription
 Bundle-Copyright: %Bundle-Copyright
 Bundle-SymbolicName: org.eclipse.cdt.jsoncdb.core;singleton:=true
-Bundle-Version: 1.4.200.qualifier
+Bundle-Version: 1.4.300.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/jsoncdb/org.eclipse.cdt.jsoncdb.core/src/org/eclipse/cdt/jsoncdb/core/internal/builtins/CompilerBuiltinsDetector.java
+++ b/jsoncdb/org.eclipse.cdt.jsoncdb.core/src/org/eclipse/cdt/jsoncdb/core/internal/builtins/CompilerBuiltinsDetector.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 
@@ -183,19 +184,33 @@ public class CompilerBuiltinsDetector {
 	 *         return {@code null}.
 	 */
 	private String[] getEnvp() {
+		var map = new HashMap<String, String>();
+		// The cc.exe from mingw64 (part of Msys2) on Windows needs the bin folder to be on the PATH to be executed.
+		// e.g. 'C:\msys64\mingw64\bin' must be part of the PATH environment variable. That's why we need PATH here:
+		// Fixes CDT #407
+		map.put("PATH", System.getenv("PATH")); //$NON-NLS-1$//$NON-NLS-2$
+
 		// On POSIX (Linux, UNIX) systems reset language variables to default (English)
 		// with UTF-8 encoding since GNU compilers can handle only UTF-8 characters.
 		// Include paths with locale characters will be handled properly regardless
 		// of the language as long as the encoding is set to UTF-8.
 		// English language is set for parser because it relies on English messages
 		// in the output of the 'gcc -v'.
-		String[] strings = {
-				// override for GNU gettext
-				"LANGUAGE" + "=en", //$NON-NLS-1$//$NON-NLS-2$
-				// for other parts of the system libraries
-				"LC_ALL" + "=C.UTF-8" }; //$NON-NLS-1$ //$NON-NLS-2$
 
-		return strings;
+		// override for GNU gettext
+		map.put("LANGUAGE", "en"); //$NON-NLS-1$ //$NON-NLS-2$
+		// for other parts of the system libraries
+		map.put("LC_ALL", "C.UTF-8"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		var envArray = map.entrySet().stream().map(entry -> {
+			var result = entry.getKey() + '=';
+			if (entry.getValue() != null) {
+				result = result + entry.getValue();
+			}
+			return result;
+		}).toArray(String[]::new);
+
+		return envArray;
 	}
 
 	/**

--- a/jsoncdb/org.eclipse.cdt.jsoncdb.core/src/org/eclipse/cdt/jsoncdb/core/internal/builtins/Messages.java
+++ b/jsoncdb/org.eclipse.cdt.jsoncdb.core/src/org/eclipse/cdt/jsoncdb/core/internal/builtins/Messages.java
@@ -23,6 +23,7 @@ class Messages extends NLS {
 	public static String CompilerBuiltinsDetector_msg_detection_finished;
 	public static String CompilerBuiltinsDetector_msg_detection_start;
 	public static String CompilerBuiltinsDetector_msg_unexpectedly_still_running;
+	public static String CompilerBuiltinsDetector_errmsg_determine_PATH_failed;
 	public static String DetectorConsole_title;
 	static {
 		// initialize resource bundle

--- a/jsoncdb/org.eclipse.cdt.jsoncdb.core/src/org/eclipse/cdt/jsoncdb/core/internal/builtins/messages.properties
+++ b/jsoncdb/org.eclipse.cdt.jsoncdb.core/src/org/eclipse/cdt/jsoncdb/core/internal/builtins/messages.properties
@@ -15,4 +15,5 @@ CompilerBuiltinsDetector_errmsg_command_failed=%1$s exited with status %2$d.
 CompilerBuiltinsDetector_msg_detection_finished=Detecting compiler built-ins took %d ms.
 CompilerBuiltinsDetector_msg_detection_start=%1$s Detecting compiler built-ins for project '%2$s'
 CompilerBuiltinsDetector_msg_unexpectedly_still_running=%1$s is unexpectedly still running. Some built-ins might not have been captured by the compiler built-ins detector.
+CompilerBuiltinsDetector_errmsg_determine_PATH_failed=Cannot determine PATH variable for project '%1$s'
 DetectorConsole_title=Compiler Built-ins Detection Console


### PR DESCRIPTION
The cc.exe from mingw64 (part of Msys2) on Windows needs the bin folder to be on the PATH to be executed. e.g. 'C:\msys64\mingw64\bin' must be part of the PATH environment variable

fixes #407