### PR TITLE
Fix a case of variable template instance not resolved

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/VariableTemplateTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/VariableTemplateTests.java
@@ -374,4 +374,37 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("waldo", CommonCPPTypes.int_);
 	}
+
+	//	template<bool _Test>
+	//	struct enable_if {
+	//	};
+	//
+	//	template <>
+	//	struct enable_if<true> {
+	//	  using typwe = int;
+	//	};
+	//
+	//	template <class ... _Traits>
+	//	inline constexpr bool trait_v = true;
+	//
+	//	template<class _Tx>
+	//	struct function_impl {
+	//	  template<class ... _Traits>
+	//	  using typse = typename enable_if<trait_v<_Traits...>>::typwe;
+	//	};
+	//
+	//	template <class _Fty>
+	//	class function : public function_impl<_Fty> {
+	//	public:
+	//	  template<class _Fx, typename function_impl<_Fty>::template typse<> = 0>
+	//	  function(_Fx _func) {
+	//	  }
+	//	};
+	//
+	//	int main() {
+	//	  function<void> func(0);
+	//	}
+	public void testVariableInstanceInImplicitName() throws Exception {
+		parseAndCheckImplicitNameBindings();
+	}
 }


### PR DESCRIPTION
When the variable template was instantiated through an implicit name (constructor), the current look-up point was used to determine whether or not the variable instance was an explicit specialization but it's not enough. During resolution of implicit name, the look-up was on the constructor call, not on the variable instance. I'm not sure if the current look-up should be changed but we already had the information about the AST node being an explicit specialization down the stack, so we just pass that info now and it seems safer than changing the look-up point.