### PR TITLE
[#669] Switch from "Require-Bundle:" to "Import-Package:" directive

### DIFF
--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -131,6 +131,7 @@ Export-Package: org.eclipse.cdt.core,
  org.eclipse.cdt.utils.som.parser,
  org.eclipse.cdt.utils.xcoff,
  org.eclipse.cdt.utils.xcoff.parser
+Import-Package: org.osgi.service.component.annotations;version="1.3.0"
 Require-Bundle: org.eclipse.cdt.core.native;bundle-version="[6.3.0,7.0.0)";visibility:=reexport,
  org.eclipse.core.contenttype;bundle-version="[3.8.200,4.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.8.200,4.0.0)",
@@ -140,7 +141,6 @@ Require-Bundle: org.eclipse.cdt.core.native;bundle-version="[6.3.0,7.0.0)";visib
  org.eclipse.core.runtime;bundle-version="[3.26.100,4.0.0)",
  org.eclipse.core.variables;bundle-version="[3.5.100,4.0.0)",
  org.eclipse.ltk.core.refactoring;bundle-version="[3.13.0,4.0.0)",
- org.eclipse.osgi.services;bundle-version="[3.11.100,4.0.0)",
  org.eclipse.text;bundle-version="[3.12.300,4.0.0)",
  com.google.gson;bundle-version="[2.8.6,3.0.0)",
  org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)";resolution:=optional

--- a/launchbar/org.eclipse.launchbar.ui.controls/META-INF/MANIFEST.MF
+++ b/launchbar/org.eclipse.launchbar.ui.controls/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-SymbolicName: org.eclipse.launchbar.ui.controls;singleton:=true
 Bundle-Version: 1.2.400.qualifier
 Bundle-Activator: org.eclipse.launchbar.ui.controls.internal.Activator
 Bundle-Vendor: %providerName
-Require-Bundle: org.eclipse.osgi.services;bundle-version="3.5.0",
- org.eclipse.core.runtime,
+Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.e4.core.di.annotations;bundle-version="1.5.0",
  org.eclipse.e4.core.contexts;bundle-version="1.5.0",
@@ -17,7 +16,8 @@ Require-Bundle: org.eclipse.osgi.services;bundle-version="3.5.0",
  org.eclipse.launchbar.core;bundle-version="2.0.0",
  org.eclipse.launchbar.ui;bundle-version="2.0.0"
 Import-Package: javax.annotation,
- javax.inject
+ javax.inject,
+ org.osgi.service.event;version="1.4.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin


### PR DESCRIPTION
* Fix MANIFEST.MF for org.eclipse.cdt.core
* Fix MANIFEST.MF for org.eclipse.launchbar.ui.controls

Fixes #669 