### PR TITLE
Workaround #684 by disabling dsf-gdb tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,8 +36,10 @@ pipeline {
           timeout(activity: true, time: 20) {
             withEnv(['MAVEN_OPTS=-XX:MaxRAMPercentage=50.0 -XX:+PrintFlagsFinal']) {
               withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
+                // XXX: Issue 684 means that dsf-gdb tests are skipped
                 sh '''/jipp/tools/apache-maven/latest/bin/mvn \
                       clean verify -B -V \
+                      -Ddsf-gdb.skip.tests=true \
                       -Dgpg.passphrase="${KEYRING_PASSPHRASE}"  \
                       -Dmaven.test.failure.ignore=true \
                       -DexcludedGroups=flakyTest,slowTest \


### PR DESCRIPTION
This only disables running the tests on Jenkins as the GitHub actions these tests work fine for now.

See https://github.com/eclipse-cdt/cdt/issues/684