### PR TITLE
Accommodate external binary object files

### DIFF
--- a/core/org.eclipse.cdt.core/model/org/eclipse/cdt/core/model/IBinary.java
+++ b/core/org.eclipse.cdt.core/model/org/eclipse/cdt/core/model/IBinary.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2009 QNX Software Systems and others.
+ * Copyright (c) 2000, 2024 QNX Software Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,8 +11,11 @@
  * Contributors:
  *     QNX Software Systems - Initial API and implementation
  *     Markus Schorn (Wind River Systems)
+ *     John Dallaway - Support external binary files (#630)
  *******************************************************************************/
 package org.eclipse.cdt.core.model;
+
+import org.eclipse.core.runtime.IPath;
 
 /**
  * Represents a Binary file, for example an ELF executable.
@@ -57,4 +60,11 @@ public interface IBinary extends ICElement, IParent, IOpenable {
 	public boolean showInBinaryContainer();
 	//public IAddressFactory getAddressFactory();
 
+	/**
+	 * Returns the absolute path of the location of this binary. May be {@code null},
+	 * in case the location does not exist.
+	 * @return an absolute path to the location, or {@code null}
+	 * @since 8.4
+	 */
+	public IPath getLocation();
 }

--- a/core/org.eclipse.cdt.core/model/org/eclipse/cdt/internal/core/model/Archive.java
+++ b/core/org.eclipse.cdt.core/model/org/eclipse/cdt/internal/core/model/Archive.java
@@ -28,6 +28,7 @@ import org.eclipse.cdt.core.model.IBinary;
 import org.eclipse.cdt.core.model.ICElement;
 import org.eclipse.cdt.core.model.ICProject;
 import org.eclipse.cdt.internal.core.util.MementoTokenizer;
+import org.eclipse.core.filesystem.URIUtil;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -94,12 +95,12 @@ public class Archive extends Openable implements IArchive {
 				}
 				IFile file = ResourcesPlugin.getWorkspace().getRoot().getFileForLocation(objPath);
 				if (file == null) { // if object path is external to the workspace
-					// fallback to legacy behaviour
-					// TODO: support external paths in Binary class as we do in TranslationUnit
-					objPath = ar.getPath().append(objPath.lastSegment());
+					Binary binary = new Binary(this, URIUtil.toURI(objPath), obj);
+					info.addChild(binary);
+				} else {
+					Binary binary = new Binary(this, objPath, obj);
+					info.addChild(binary);
 				}
-				Binary binary = new Binary(this, objPath, obj);
-				info.addChild(binary);
 			}
 			return true;
 		}

--- a/core/org.eclipse.cdt.ui/plugin.properties
+++ b/core/org.eclipse.cdt.ui/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2003, 2023 IBM Corporation, QNX Software Systems, and others.
+# Copyright (c) 2003, 2024 IBM Corporation, QNX Software Systems, and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -656,6 +656,8 @@ ShiftRightAction.label= &Shift Right
 ShiftLeftAction.label= S&hift Left
 
 # Decorators
+binaryFileDecorator.label = C/C++ Binary Files
+binaryFileDecorator.description = Decorates C/C++ executable, object, core and shared library files.
 indexedFilesDecorator.label = C/C++ Indexed Files
 indexedFilesDecorator.description = Decorates files indexed by C/C++ Indexer.
 translationUnitDecorator.label = C/C++ Translation Units

--- a/core/org.eclipse.cdt.ui/plugin.xml
+++ b/core/org.eclipse.cdt.ui/plugin.xml
@@ -4446,6 +4446,17 @@
          </enablement>
       </decorator>
       <decorator
+            class="org.eclipse.cdt.internal.ui.viewsupport.BinaryFileDecorator"
+            id="org.eclipse.cdt.ui.binaryFile"
+            label="%binaryFileDecorator.label"
+            lightweight="true"
+            state="true">
+         <description>%binaryFileDecorator.description</description>
+         <enablement>
+            <objectClass name="org.eclipse.cdt.core.model.IBinary"/>
+         </enablement>
+      </decorator>
+      <decorator
             adaptable="true"
             class="org.eclipse.cdt.internal.ui.viewsupport.ExcludedFileDecorator"
             id="org.eclipse.cdt.managedbuilder.ui.excludedFile"

--- a/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/CElementAdapterFactory.java
+++ b/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/CElementAdapterFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2011 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  *     QNX Software System
  *     Anton Leherbauer (Wind River Systems)
  *     Sergey Prigogin (Google)
+ *     John Dallaway - process external binaries as C elements (#630)
  *******************************************************************************/
 package org.eclipse.cdt.internal.ui;
 
@@ -76,11 +77,13 @@ public class CElementAdapterFactory implements IAdapterFactory {
 	}
 
 	private IPropertySource getPropertySource(ICElement celement) {
-		if (celement instanceof IBinary) {
-			return new BinaryPropertySource((IBinary) celement);
-		}
 		IResource res = celement.getResource();
 		if (res != null) {
+			if (celement instanceof IBinary) {
+				// IBinary objects must have an IResource at present
+				// TODO: support external binaries as for external translation units
+				return new BinaryPropertySource((IBinary) celement);
+			}
 			if (res instanceof IFile) {
 				return new FilePropertySource((IFile) res);
 			}

--- a/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/navigator/OpenCElementAction.java
+++ b/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/navigator/OpenCElementAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2023 Wind River Systems, Inc. and others.
+ * Copyright (c) 2006, 2024 Wind River Systems, Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     Anton Leherbauer (Wind River Systems) - initial API and implementation
  *     Ed Swartz (Nokia)
  *     John Dallaway - do not handle absent external translation units (#563)
+ *     John Dallaway - do not handle external binaries (#630)
  *******************************************************************************/
 package org.eclipse.cdt.internal.ui.navigator;
 
@@ -21,6 +22,7 @@ import org.eclipse.cdt.core.model.ISourceReference;
 import org.eclipse.cdt.core.model.ITranslationUnit;
 import org.eclipse.cdt.internal.ui.util.EditorUtility;
 import org.eclipse.cdt.ui.CUIPlugin;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -76,14 +78,27 @@ public class OpenCElementAction extends OpenFileAction {
 			if (!(element instanceof ICElement) && element instanceof IAdaptable) {
 				element = ((IAdaptable) element).getAdapter(ICElement.class);
 			}
-			if (element instanceof ICElement && (element instanceof ISourceReference || element instanceof IBinary)) {
-				// do not handle absent external translation units
-				if (!(element instanceof ITranslationUnit tu) || (null != tu.getResource()) || tu.exists()) {
-					fOpenElement = (ICElement) element;
-				}
+			if ((element instanceof ICElement cElement) && canOpenCElement(cElement)) {
+				fOpenElement = (ICElement) element;
 			}
 		}
 		return fOpenElement != null || super.updateSelection(selection);
+	}
+
+	private boolean canOpenCElement(ICElement element) {
+		if (element instanceof ISourceReference sourceReference) {
+			if (null == sourceReference.getTranslationUnit()) {
+				return false; // no associated translation unit
+			}
+			// do not handle absent external translation units
+			return !(element instanceof ITranslationUnit tu) || (null != tu.getResource()) || tu.exists();
+		}
+		if (element instanceof IBinary) {
+			// do not handle external binaries
+			IResource resource = element.getResource();
+			return (null != resource) && resource.exists();
+		}
+		return false;
 	}
 
 }

--- a/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/viewsupport/BinaryFileDecorator.java
+++ b/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/viewsupport/BinaryFileDecorator.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2024 John Dallaway and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     John Dallaway - initial implementation (#630)
+ *******************************************************************************/
+package org.eclipse.cdt.internal.ui.viewsupport;
+
+import org.eclipse.cdt.core.model.IBinary;
+import org.eclipse.jface.preference.JFacePreferences;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.viewers.BaseLabelProvider;
+import org.eclipse.jface.viewers.IDecoration;
+import org.eclipse.jface.viewers.ILightweightLabelDecorator;
+import org.eclipse.swt.graphics.Color;
+
+/**
+ * Decorates binary files including executable, object, core and library files
+ */
+public final class BinaryFileDecorator extends BaseLabelProvider implements ILightweightLabelDecorator {
+
+	@Override
+	public boolean isLabelProperty(Object element, String property) {
+		return false;
+	}
+
+	@Override
+	public void decorate(Object element, IDecoration decoration) {
+		// if a binary file that is not present locally
+		if (element instanceof IBinary binary && !binary.exists()) {
+			// decorate label to indicate file is absent
+			Color color = JFaceResources.getColorRegistry().get(JFacePreferences.QUALIFIER_COLOR);
+			decoration.setForegroundColor(color);
+		}
+	}
+
+}

--- a/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/viewsupport/CElementImageProvider.java
+++ b/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/viewsupport/CElementImageProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2023 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,7 @@
  *     QNX Software System
  *     Markus Schorn (Wind River Systems)
  *     Anton Leherbauer (Wind River Systems)
- *     John Dallaway - use external file adornment (#563)
+ *     John Dallaway - use external file adornment (#563, #630)
  *******************************************************************************/
 package org.eclipse.cdt.internal.ui.viewsupport;
 
@@ -601,6 +601,9 @@ public class CElementImageProvider {
 							flags |= CElementImageDescriptor.EXTERNAL_FILE;
 						}
 					}
+				}
+				if ((element instanceof IBinary) && (null == element.getResource())) {
+					flags |= CElementImageDescriptor.EXTERNAL_FILE;
 				}
 			} catch (CModelException e) {
 			}

--- a/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/viewsupport/CElementLabelComposer.java
+++ b/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/viewsupport/CElementLabelComposer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2014 IBM Corporation and others.
+ * Copyright (c) 2003, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  *     Markus Schorn (Wind River Systems)
  *     Gerhard Schaber (Wind River Systems)
  *     Patrick Hofer [bug 325799]
+ *     John Dallaway - handle external binary files (#630)
  *******************************************************************************/
 package org.eclipse.cdt.internal.ui.viewsupport;
 
@@ -267,6 +268,9 @@ public class CElementLabelComposer {
 			break;
 		case ICElement.C_UNIT:
 			appendTranslationUnitLabel((ITranslationUnit) element, flags);
+			break;
+		case ICElement.C_BINARY:
+			appendBinaryLabel((IBinary) element, flags);
 			break;
 		case ICElement.C_CCONTAINER:
 			ICContainer container = (ICContainer) element;
@@ -826,6 +830,22 @@ public class CElementLabelComposer {
 	 */
 	public void getSourceRootLabel(ISourceRoot root, long flags) {
 		appendFolderLabel(root, flags);
+	}
+
+	/**
+	 * Appends the label for a binary to a StringBuilder.
+	 * @param container a container
+	 * @param flags any of the ROOT_* flags, and PROJECT_POST_QUALIFIED
+	 */
+	public void appendBinaryLabel(IBinary binary, long flags) {
+		IResource r = binary.getResource();
+		IPath path;
+		if (r != null) {
+			path = r.getFullPath().makeRelative();
+		} else {
+			path = binary.getPath();
+		}
+		fBuffer.append(path.lastSegment());
 	}
 
 	/**

--- a/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/ui/CElementSorter.java
+++ b/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/ui/CElementSorter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2023 IBM Corporation and others.
+ * Copyright (c) 2005, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@
  *     Anton Leherbauer (Wind River Systems)
  *     Markus Schorn (Wind River Systems)
  *     John Dallaway - sort external translation units by name (#563)
+ *     John Dallaway - sort external binary files by name (#630)
  *******************************************************************************/
 package org.eclipse.cdt.ui;
 
@@ -22,6 +23,7 @@ import java.util.Comparator;
 import org.eclipse.cdt.core.model.CModelException;
 import org.eclipse.cdt.core.model.CoreModel;
 import org.eclipse.cdt.core.model.IArchiveContainer;
+import org.eclipse.cdt.core.model.IBinary;
 import org.eclipse.cdt.core.model.IBinaryContainer;
 import org.eclipse.cdt.core.model.ICElement;
 import org.eclipse.cdt.core.model.IIncludeReference;
@@ -322,6 +324,10 @@ public class CElementSorter extends ViewerSorter {
 			// an external translation unit - sort by filename only (not path)
 			IPath location = tu.getLocation();
 			name1 = (null == location) ? tu.getElementName() : location.lastSegment();
+		} else if ((e1 instanceof IBinary binary) && (null == binary.getResource())) {
+			// an external binary - sort by filename only (not path)
+			IPath location = binary.getLocation();
+			name1 = (null == location) ? binary.getElementName() : location.lastSegment();
 		} else if (e1 instanceof ICElement) {
 			name1 = ((ICElement) e1).getElementName();
 			int idx = name1.lastIndexOf("::"); //$NON-NLS-1$
@@ -341,6 +347,10 @@ public class CElementSorter extends ViewerSorter {
 			// an external translation unit - sort by filename only (not path)
 			IPath location = tu.getLocation();
 			name2 = (null == location) ? tu.getElementName() : location.lastSegment();
+		} else if ((e2 instanceof IBinary binary) && (null == binary.getResource())) {
+			// an external binary - sort by filename only (not path)
+			IPath location = binary.getLocation();
+			name2 = (null == location) ? binary.getElementName() : location.lastSegment();
 		} else if (e2 instanceof ICElement) {
 			name2 = ((ICElement) e2).getElementName();
 			int idx = name2.lastIndexOf("::"); //$NON-NLS-1$


### PR DESCRIPTION
Accommodate external binary object files

- Adorn external binary object icons
- Present symbols under external binary object resources
- Label external binary objects with filename only
- Present absent external binary objects with grey label
- Sort external binary objects by filename only

Part of #630