### PR TITLE
[#693] Fix resource leak warnings for org.eclipse.cdt.core.utils

### DIFF
--- a/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/debug/dwarf/Dwarf.java
+++ b/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/debug/dwarf/Dwarf.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 QNX Software Systems and others.
+ * Copyright (c) 2000, 2024 QNX Software Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@
  *     Serge Beauchamp - Bug 409916
  *     John Dallaway - Support DW_FORM_line_strp (#198)
  *     John Dallaway - Support DW_FORM_implicit_const (#443)
+ *     Alexander Fedorov (ArSysOp) - fix resource leak (#693)
  *******************************************************************************/
 
 package org.eclipse.cdt.utils.debug.dwarf;
@@ -1065,12 +1066,10 @@ public class Dwarf implements AutoCloseable {
 	}
 
 	public static void main(String[] args) {
-		try {
-			DebugSymsRequestor symreq = new DebugSymsRequestor();
-			Dwarf dwarf = new Dwarf(args[0]);
+		DebugSymsRequestor symreq = new DebugSymsRequestor();
+		try (Dwarf dwarf = new Dwarf(args[0])) {
 			dwarf.parse(symreq);
-			DebugSym[] entries = symreq.getEntries();
-			for (DebugSym entry : entries) {
+			for (DebugSym entry : symreq.getEntries()) {
 				System.out.println(entry);
 			}
 		} catch (IOException e) {

--- a/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/debug/tools/DebugAddr2line.java
+++ b/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/debug/tools/DebugAddr2line.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2006 QNX Software Systems and others.
+ * Copyright (c) 2000, 2024 QNX Software Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     QNX Software Systems - Initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - fix resource leak (#693)
  *******************************************************************************/
 
 package org.eclipse.cdt.utils.debug.tools;
@@ -48,8 +49,9 @@ public class DebugAddr2line {
 			Stabs stabs = new Stabs(elf);
 			stabs.parse(symreq);
 		} else if (type == Elf.Attribute.DEBUG_TYPE_DWARF) {
-			Dwarf dwarf = new Dwarf(elf);
-			dwarf.parse(symreq);
+			try (Dwarf dwarf = new Dwarf(elf)) {
+				dwarf.parse(symreq);
+			}
 		} else {
 			throw new IOException(CCorePlugin.getResourceString("Util.unknownFormat")); //$NON-NLS-1$
 		}

--- a/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/debug/tools/DebugDump.java
+++ b/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/debug/tools/DebugDump.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 QNX Software Systems and others.
+ * Copyright (c) 2000, 2024 QNX Software Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     QNX Software Systems - Initial API and implementation
+ *     Alexander Fedorov (ArSysOp) - fix resource leak (#693)
  *******************************************************************************/
 
 package org.eclipse.cdt.utils.debug.tools;
@@ -58,8 +59,9 @@ public class DebugDump implements IDebugEntryRequestor {
 			Stabs stabs = new Stabs(elf);
 			stabs.parse(this);
 		} else if (type == Elf.Attribute.DEBUG_TYPE_DWARF) {
-			Dwarf dwarf = new Dwarf(elf);
-			dwarf.parse(this);
+			try (Dwarf dwarf = new Dwarf(elf)) {
+				dwarf.parse(this);
+			}
 		} else {
 			throw new IOException(CCorePlugin.getResourceString("Util.unknownFormat")); //$NON-NLS-1$
 		}

--- a/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/macho/MachO64.java
+++ b/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/utils/macho/MachO64.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 QNX Software Systems and others.
+ * Copyright (c) 2000, 2024 QNX Software Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     QNX Software Systems - Initial API and implementation
  *     Craig Watson.
  *     Apple Computer - work on performance optimizations
+ *     Alexander Fedorov (ArSysOp) - fix resource leak (#693)
  *******************************************************************************/
 package org.eclipse.cdt.utils.macho;
 
@@ -1157,20 +1158,17 @@ public class MachO64 implements AutoCloseable {
 	}
 
 	public static Attribute getAttributes(String file) throws IOException {
-		MachO64 macho = new MachO64(file);
-		Attribute attrib = macho.getAttributes();
-		macho.dispose();
-		return attrib;
+		try (MachO64 macho = new MachO64(file)) {
+			return macho.getAttributes();
+		}
 	}
 
 	public static Attribute getAttributes(byte[] array) throws IOException {
-		MachO64 emptyMachO = new MachO64();
-		emptyMachO.mhdr = emptyMachO.new MachOhdr(array);
-		//emptyMachO.sections = new MachO64.Section[0];
-		Attribute attrib = emptyMachO.getAttributes();
-		emptyMachO.dispose();
-
-		return attrib;
+		try (MachO64 emptyMachO = new MachO64()) {
+			emptyMachO.mhdr = emptyMachO.new MachOhdr(array);
+			//emptyMachO.sections = new MachO64.Section[0];
+			return emptyMachO.getAttributes();
+		}
 	}
 
 	public static boolean isMachOHeader(byte[] bytes) {


### PR DESCRIPTION
* use `try-with-resources` for `AutoCloseable`

Fixes #693 