### PR TITLE
[703] fix NPE when no build binaries on system PATH

### DIFF
--- a/core/org.eclipse.cdt.core.tests/misc/org/eclipse/cdt/core/build/TestICBuildConfiguration.java
+++ b/core/org.eclipse.cdt.core.tests/misc/org/eclipse/cdt/core/build/TestICBuildConfiguration.java
@@ -13,7 +13,6 @@ package org.eclipse.cdt.core.build;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 
@@ -62,10 +61,12 @@ public class TestICBuildConfiguration {
 		/*
 		 * It's difficult to create a functional BuildConfiguration without a toolchain, so just use
 		 * this Error Build Configuration. It is adequate for simply testing the API.
+		 *
+		 * Edit: getBinaryParserIds() must not return null to prevent possible NPE
 		 */
 		ErrorBuildConfiguration errorBuildConfiguration = new ErrorBuildConfiguration(buildConfig, "errorBuildConfig");
 		List<String> binaryParserIds = errorBuildConfiguration.getBinaryParserIds();
-		assertNull(binaryParserIds, "Must be null");
+		assertNotNull(binaryParserIds, "Must not be null");
 	}
 
 	private IProject getProject() throws Exception {

--- a/core/org.eclipse.cdt.core/model/org/eclipse/cdt/internal/core/model/CModelManager.java
+++ b/core/org.eclipse.cdt.core/model/org/eclipse/cdt/internal/core/model/CModelManager.java
@@ -617,7 +617,7 @@ public class CModelManager implements IResourceChangeListener, IContentTypeChang
 				Set<String> parserIds = new HashSet<>();
 				for (IBuildConfiguration config : project.getBuildConfigs()) {
 					ICBuildConfiguration cconfig = config.getAdapter(ICBuildConfiguration.class);
-					if (cconfig != null) {
+					if (cconfig != null && cconfig.getBinaryParserIds() != null) {
 						parserIds.addAll(cconfig.getBinaryParserIds());
 					}
 				}

--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/ErrorBuildConfiguration.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/ErrorBuildConfiguration.java
@@ -12,6 +12,7 @@ package org.eclipse.cdt.core.build;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -145,8 +146,8 @@ public class ErrorBuildConfiguration extends PlatformObject implements ICBuildCo
 
 	@Override
 	public List<String> getBinaryParserIds() throws CoreException {
-		// TODO Auto-generated method stub
-		return null;
+		// Return empty list to prevent possible NPE
+		return Collections.emptyList();
 	}
 
 }


### PR DESCRIPTION
- fixes NPE when new cmake project has been created while there are no C/C++ build binaries on the PATH environment variable. The NPE has been thrown when the children of the project should be fetched (e.g. in project explorer view)

fixes #703