### PR TITLE
Unify maven-compiler-plugin setting

### DIFF
--- a/core/org.eclipse.cdt.core.native/about.properties
+++ b/core/org.eclipse.cdt.core.native/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014, 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2014, 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=C/C++ Development Tooling Native Utilities\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2014, 2023 Contributors to the Eclipse Foundation
+Copyright (c) 2014, 2024 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/core/org.eclipse.cdt.core.native/pom.xml
+++ b/core/org.eclipse.cdt.core.native/pom.xml
@@ -110,7 +110,6 @@
 				<plugins>
 					<plugin>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.11.0</version>
 						<executions>
 							<execution>
 								<id>headers</id>

--- a/native/org.eclipse.cdt.native.serial/pom.xml
+++ b/native/org.eclipse.cdt.native.serial/pom.xml
@@ -204,7 +204,6 @@
 				<plugins>
 					<plugin>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.10.1</version>
 						<executions>
 							<execution>
 								<id>headers</id>

--- a/pom.xml
+++ b/pom.xml
@@ -937,6 +937,11 @@
 					<version>3.1.0</version>
 				</plugin>
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.12.1</version>
+				</plugin>
+				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>findbugs-maven-plugin</artifactId>
 					<version>3.0.5</version>


### PR DESCRIPTION
Define the common version in parent pom and don't override it. Move to latest version while at it.