### PR TITLE
Update maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -631,7 +631,7 @@
 				<inherited>true</inherited>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.2.1</version>
+				<version>3.4.1</version>
 				<executions>
 				<execution>
 					<id>enforce-maven-version</id>
@@ -656,7 +656,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>sonar-maven-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.10.0.2594</version>
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
@@ -770,7 +770,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.8</version>
+				<version>0.8.11</version>
 				<executions>
 					<execution>
 						<id>pre-test</id>
@@ -926,7 +926,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.3.0</version>
+					<version>3.3.1</version>
 					<configuration>
 						<encoding>ISO-8859-1</encoding>
 					</configuration>
@@ -961,7 +961,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-pmd-plugin</artifactId>
-					<version>3.20.0</version>
+					<version>3.21.2</version>
 					<configuration>
 						<inputEncoding>utf-8</inputEncoding>
 						<minimumTokens>100</minimumTokens>
@@ -1064,7 +1064,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>build-helper-maven-plugin</artifactId>
-					<version>3.4.0</version>
+					<version>3.5.0</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
maven-enforcer-plugin 3.2.1 -> 3.4.1
maven-pmd-plugin 3.20.0 -> 3.21.2
maven-resources-plugin 3.3.0 -> 3.3.1
org.codehaus.mojo:build-helper-maven-plugin 3.4.0 -> 3.5.0 org.codehaus.mojo:sonar-maven-plugin 2.4 -> 3.10.0.2594 org.jacoco:jacoco-maven-plugin 0.8.8 -> 0.8.11