### PR TITLE
Make CodanRunner progress monitor work a bit better

### DIFF
--- a/codan/org.eclipse.cdt.codan.core/META-INF/MANIFEST.MF
+++ b/codan/org.eclipse.cdt.codan.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.codan.core;singleton:=true
-Bundle-Version: 4.2.100.qualifier
+Bundle-Version: 4.2.200.qualifier
 Bundle-Activator: org.eclipse.cdt.codan.core.CodanCorePlugin
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime,


### PR DESCRIPTION
The progress monitor didn't show which file was being analyzed properly.

Also, the work units didn't seem to be counted in a good way because the progress bar would stay stuck at like 1%. The fix in this commit for that is not perfect as it gives equal weight to all resources on a same level until further split into sub monitors. It still works quite a bit better without requiring more heavy changes.

Also fix usage of deprecated SubProgressMonitor.