### PR TITLE
Parse empty __attribute__(())

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPAttributeTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPAttributeTests.java
@@ -525,6 +525,12 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTDeclarator.class);
 	}
 
+	//	int a __attribute__ (());
+	public void testEmptyGCCAttribute() throws Exception {
+		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
+		checkAttributeRelations(getAttributeSpecifiers(tu), IASTDeclarator.class);
+	}
+
 	//	struct S {
 	//	  void foo() override __attribute__((attr));
 	//	};

--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core; singleton:=true
-Bundle-Version: 8.4.0.qualifier
+Bundle-Version: 8.4.100.qualifier
 Bundle-Activator: org.eclipse.cdt.core.CCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/AbstractGNUSourceCodeParser.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/AbstractGNUSourceCodeParser.java
@@ -2529,7 +2529,10 @@ public abstract class AbstractGNUSourceCodeParser implements ISourceCodeParser {
 			consume();
 			consume(IToken.tLPAREN);
 
-			addAttributesOrDeclspecs(result);
+			// Allow empty __attribute__(())
+			if (LT(1) != IToken.tRPAREN) {
+				addAttributesOrDeclspecs(result);
+			}
 
 			consumeOrEOC(IToken.tRPAREN);
 			endOffset = consumeOrEOC(IToken.tRPAREN).getEndOffset();


### PR DESCRIPTION
This is accepted by both GCC and Clang and encountered in real code. It looks a bit strange but basically a condtionally defined macro was used inside the (()) depending on a configurable feature macro of the project.