### PR TITLE
Detection for VS 2022 toolchain

### DIFF
--- a/releng/scripts/check_features.sh
+++ b/releng/scripts/check_features.sh
@@ -59,7 +59,10 @@ git ls-files -- \*/feature.xml | while read feature_xml; do
         feature_start_year=$(git log --reverse --format='%ad' --date="format:%Y" -- $feature_xml $plugin_dir | head -1)
         ;;
     esac
-    feature_end_year=$(git log --format='%ad' --date="format:%Y" -- $feature_xml $plugin_dir | head -1)
+    # Choose latest of commit date and author date for the end of copyright
+    feature_end_year_author=$(git log --format='%ad' --date="format:%Y" -- $feature_xml $plugin_dir | head -1)
+    feature_end_year_commit=$(git log --format='%cd' --date="format:%Y" -- $feature_xml $plugin_dir | head -1)
+    feature_end_year=$((echo $feature_end_year_author ; echo $feature_end_year_commit) | sort -n | tail -1)
     feature_name=$(grep featureName= $feature_dir/feature.properties | sed '-es,featureName=,,')
     if [ "$feature_start_year" = "$feature_end_year" ]; then
         feature_years="${feature_start_year}"

--- a/windows/org.eclipse.cdt.msw.build/META-INF/MANIFEST.MF
+++ b/windows/org.eclipse.cdt.msw.build/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.msw.build;singleton:=true
-Bundle-Version: 2.0.200.qualifier
+Bundle-Version: 2.0.300.qualifier
 Bundle-Activator: org.eclipse.cdt.msw.build.Activator
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/windows/org.eclipse.cdt.msw.build/src/org/eclipse/cdt/internal/msw/build/IVSVersionConstants.java
+++ b/windows/org.eclipse.cdt.msw.build/src/org/eclipse/cdt/internal/msw/build/IVSVersionConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Marc-Andre Laperle.
+ * Copyright (c) 2020, 2021 Marc-Andre Laperle.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,4 +16,5 @@ package org.eclipse.cdt.internal.msw.build;
 interface IVSVersionConstants {
 	VSVersionNumber VS2017_BASE_VER = new VSVersionNumber(15);
 	VSVersionNumber VS2019_BASE_VER = new VSVersionNumber(16);
+	VSVersionNumber VS2022_BASE_VER = new VSVersionNumber(17);
 }

--- a/windows/org.eclipse.cdt.msw.build/src/org/eclipse/cdt/internal/msw/build/VSInstallationRegistry.java
+++ b/windows/org.eclipse.cdt.msw.build/src/org/eclipse/cdt/internal/msw/build/VSInstallationRegistry.java
@@ -35,11 +35,12 @@ public class VSInstallationRegistry {
 		fVsInstallations = new TreeMap<>();
 		// We are opting-in which versions to detect instead of trying to detect even unknown ones in order
 		// to allow proper testing for a new version before exposing it to users.
-		Arrays.asList(IVSVersionConstants.VS2017_BASE_VER, IVSVersionConstants.VS2019_BASE_VER).forEach(version -> {
-			VSInstallation insllation = detectVSInstallation(version);
-			if (insllation != null)
-				fVsInstallations.put(version, insllation);
-		});
+		Arrays.asList(IVSVersionConstants.VS2017_BASE_VER, IVSVersionConstants.VS2019_BASE_VER,
+				IVSVersionConstants.VS2022_BASE_VER).forEach(version -> {
+					VSInstallation insllation = detectVSInstallation(version);
+					if (insllation != null)
+						fVsInstallations.put(version, insllation);
+				});
 	}
 
 	private static VSInstallation detectVSInstallation(VSVersionNumber baseVersion) {


### PR DESCRIPTION
This adds basic support for VS 2022 by detecting the toolchain. I.e. include paths, lib paths, and PATH env var are properly detected.

The detection works the same as 2017 and 2019 since vswhere.exe works the same and the folder layout hasn't changed.

Revived from https://git.eclipse.org/r/c/cdt/org.eclipse.cdt/+/182202