### PR TITLE
Fix missing mylyn.wikitext dependency

### DIFF
--- a/releng/org.eclipse.cdt.target/cdt.target
+++ b/releng/org.eclipse.cdt.target/cdt.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="cdt" sequenceNumber="157">
+<target name="cdt" sequenceNumber="158">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/" />
@@ -13,6 +13,9 @@
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.test.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.unittest.ui" version="0.0.0" />
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/mylyn/updates/release/latest/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/egit/updates" />


### PR DESCRIPTION
lsp4e depends on mylyn.wikitext but it could not be found. For example: https://github.com/eclipse-cdt/cdt/actions/runs/9026888723/job/24804874235?pr=778