### PR TITLE
Update org.apache.aries.spifly.dynamic.bundle to 1.3.7

### DIFF
--- a/releng/org.eclipse.cdt.target/cdt.target
+++ b/releng/org.eclipse.cdt.target/cdt.target
@@ -70,7 +70,8 @@
 				<dependency>
 					<groupId>org.apache.aries.spifly</groupId>
 					<artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
-					<version>1.3.6</version>
+					<version>1.3.7</version>
+					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
The Orbit updater missed this update because of `<type>jar</type>` was missing. I've fixed that problem, but for consistency with all the other dependencies in the target, I've added here as well.