### PR TITLE
[#746] Use inclusive language in codan

### DIFF
--- a/codan/org.eclipse.cdt.codan.checkers/META-INF/MANIFEST.MF
+++ b/codan/org.eclipse.cdt.codan.checkers/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.codan.checkers;singleton:=true
-Bundle-Version: 3.5.500.qualifier
+Bundle-Version: 3.5.600.qualifier
 Bundle-Activator: org.eclipse.cdt.codan.checkers.CodanCheckersActivator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/codan/org.eclipse.cdt.codan.checkers/OSGI-INF/l10n/bundle.properties
+++ b/codan/org.eclipse.cdt.codan.checkers/OSGI-INF/l10n/bundle.properties
@@ -186,10 +186,10 @@ problem.name.MissReferenceProblem = Missing reference return value in assignment
 problem.messagePattern.MissReferenceProblem = Assignment operators should return by reference
 problem.description.MissReferenceProblem = This rule will flag assignment operators not returning by reference
 
-checker.name.BlacklistChecker = Function or method in blacklist checker
-problem.name.BlacklistProblem = Function or method is blacklisted
-problem.messagePattern.BlacklistProblem = Function or method ''{0}'' is blacklisted
-problem.description.BlacklistProblem = This rule will flag the use of functions or methods in blacklist
+checker.name.BlacklistChecker = Function or method in denylist checker
+problem.name.BlacklistProblem = The use of function or method is denied
+problem.messagePattern.BlacklistProblem = The use of function or method ''{0}'' is denied
+problem.description.BlacklistProblem = This rule will flag the use of functions or methods in denylist
 
 checker.name.VariablesChecker = Variable checker
 problem.name.StaticVariableInHeaderProblem = Static variable in header file


### PR DESCRIPTION
Hello,

This PR is meant to be a replacement for the [PR 769](https://github.com/eclipse-cdt/cdt/pull/769) which would certainly have created backward compatibility problems and would have broken users already using the checker.

This PR therefore only contains minimal changes to litterals which can be seen in the frontend interface of Eclipse.

I also bumped the service segment by 100 in the file MANIFEST.MF (thank you a lot for the additional informations about this!)

All actions could be run without errors on the forked repository in my userspace, but unfortunately I could not find a .zip artifact with a runnable Eclipse to test if my changes work as expected (for example [this action run](https://github.com/thomas-z8/cdt/actions/runs/9145578852) produced a .zip artifact but it seems incomplete and I did not find a runnable Eclipse in it (maybe you can provide me with additional informations about this as well ?)

Thank you and regards
Thomas