### PR TITLE
Restore correct filterPattern expressions

### DIFF
--- a/build/org.eclipse.cdt.managedbuilder.gnu.ui/plugin.xml
+++ b/build/org.eclipse.cdt.managedbuilder.gnu.ui/plugin.xml
@@ -3922,7 +3922,7 @@ Contributors:
    <extension point="org.eclipse.cdt.core.templates">
       <template
             id="org.eclipse.cdt.build.core.templates.HelloWorldCCProject"
-            filterPattern=".*g++"
+            filterPattern=".*g\+\+"
             location="$nl$/templates/projecttemplates/HelloWorldCCProject/template.xml"
             projectType="org.eclipse.cdt.build.core.buildArtefactType.exe" />
       <template
@@ -3932,7 +3932,7 @@ Contributors:
             projectType="org.eclipse.cdt.build.core.buildArtefactType.exe" />
       <template
             id="org.eclipse.cdt.build.core.templates.MakefileHelloWorldCCProject"
-            filterPattern=".*g++"
+            filterPattern=".*g\+\+"
             location="$nl$/templates/projecttemplates/MakefileHelloWorldCCProject/template.xml"
             projectType="org.eclipse.cdt.build.makefile.projectType" />
    </extension>


### PR DESCRIPTION
Restore correct filterPattern expressions that were lost in the preceding clean up.

Relates to https://github.com/eclipse-cdt/cdt/issues/646