### PR TITLE
LLVM optimization remarks.

### DIFF
--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core; singleton:=true
-Bundle-Version: 8.4.100.qualifier
+Bundle-Version: 8.4.200.qualifier
 Bundle-Activator: org.eclipse.cdt.core.CCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core/plugin.properties
+++ b/core/org.eclipse.cdt.core/plugin.properties
@@ -61,7 +61,8 @@ CDTGNUCErrorParser.regex.ReportedOnlyOncePerInputFile=(.*?):(\\d+):(\\d+:)? .*th
 CDTGNUCErrorParser.regex.InstantiatedFromHere=(.*?):(\\d+):(\\d+:)?\\s*(.*((instantiated)|(required)) from .*)
 CDTGNUCErrorParser.regex.SkippingInstantiationContexts=(.*?):(\\d+):(\\d+:)?\\s*(\\[\\s*skipping \\d+ instantiation context.*)
 CDTGNUCErrorParser.regex.InConstexprExpansion=(.*?):(\\d+):(\\d+:)?\\s*(in 'constexpr' expansion of.*)
-CDTGNUCErrorParser.regex.GenericInfo=(.*?):(\\d+):(\\d+:)?\\s*(([Nn]ote)|(NOTE)|([Ii]nfo)|(INFO)): (.*)
+# 'remark:' messages are LLVM optimization remarks.
+CDTGNUCErrorParser.regex.GenericInfo=(.*?):(\\d+):(\\d+:)?\\s*(([Nn]ote)|(NOTE)|([Ii]nfo)|(INFO)|(remark)): (.*)
 CDTGNUCErrorParser.regex.ParseErrorBefore=(.*?):(\\d+):(\\d+:)? (parse error before.*[`'"](.*)['"].*)
 CDTGNUCErrorParser.regex.ErrorUndeclared=(.*?):(\\d+):(\\d+:)? [Ee]rror: ([`'"](.*)['"] undeclared .*)
 CDTGNUCErrorParser.regex.ErrorConflictingTypesFor=(.*?):(\\d+):(\\d+:)? [Ee]rror: (conflicting types for .*[`'"](.*)['"].*)

--- a/core/org.eclipse.cdt.core/plugin.xml
+++ b/core/org.eclipse.cdt.core/plugin.xml
@@ -242,7 +242,7 @@
                severity="Error"
                variable-expr="$3"/>
          <pattern description-expr="$7" eat-processed-line="true" file-expr="$1" line-expr="$2" regex="%CDTGNUCErrorParser.regex.GenericWarning" severity="Warning"/>
-         <pattern description-expr="$9" eat-processed-line="true" file-expr="$1" line-expr="$2" regex="%CDTGNUCErrorParser.regex.GenericInfo" severity="Info"/>
+         <pattern description-expr="$10" eat-processed-line="true" file-expr="$1" line-expr="$2" regex="%CDTGNUCErrorParser.regex.GenericInfo" severity="Info"/>
          <pattern description-expr="$4" eat-processed-line="true" file-expr="$1" line-expr="$2" regex="%CDTGNUCErrorParser.regex.OtherError" severity="Error"/>
       </errorparser>
    </extension>


### PR DESCRIPTION
Added support for LLVM optimization remarks to the GCC c/c++ error parser. They were falsly treated as errors (OtherError). Now they are treated as generic infos. GCC has no diagnostic messages of 'remark' type. Since GCC and LLVM messages are very similar, no separate LLVM error parser was created.

Fixes #752