### PR TITLE
Explicitly set application id for standalone debugger

### DIFF
--- a/debug/org.eclipse.cdt.debug.application/scripts/cdtdebug.sh
+++ b/debug/org.eclipse.cdt.debug.application/scripts/cdtdebug.sh
@@ -100,5 +100,6 @@ esac
 # Run eclipse with the Stand-alone Debugger product specified
 "$ECLIPSE_EXEC" -clean \
   -product org.eclipse.cdt.debug.application.product \
+  -application org.eclipse.cdt.debug.application.app \
   -data "$HOME/workspace-cdtdebug" \
   "${options[@]}"


### PR DESCRIPTION
Follow up for #782 to always explicitly set application

This wasn't needed in my development environment, but in the EPP version it was needed. I think it is because the normal config.ini specifies the application:

```sh
$ grep application eclipse/configuration/config.ini 
eclipse.application=org.eclipse.ui.ide.workbench
```

now that we don't define our own config.ini (see #782) we need to explicitly override the one set in the config.ini (if present)