### PR TITLE
Remove 'Experimental' label from Core Build Makefile projects.

### DIFF
--- a/build/org.eclipse.cdt.make.ui/plugin.xml
+++ b/build/org.eclipse.cdt.make.ui/plugin.xml
@@ -629,7 +629,7 @@
           label="Makefile Project"
           wizard="org.eclipse.cdt.make.internal.ui.wizards.NewMakefileProjectWizard">
        <description>
-          (Experimental) Create a new project that builds with the&apos;make&apos; build tool using CDT&apos;s new Core Build System.
+          Create a Makefile project using CDT&apos;s new Core Build System. Over existing content or a new project with optional Hello World example.
        </description>
        <tagReference
              id="org.eclipse.cdt.ui.cdtTag">

--- a/build/org.eclipse.cdt.make.ui/src/org/eclipse/cdt/make/internal/ui/wizards/NewMakefileProjectWizard.java
+++ b/build/org.eclipse.cdt.make.ui/src/org/eclipse/cdt/make/internal/ui/wizards/NewMakefileProjectWizard.java
@@ -50,7 +50,7 @@ public class NewMakefileProjectWizard extends TemplateWizard {
 
 				Button genSourceButton = new Button(buttonComp, SWT.CHECK);
 				genSourceButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-				genSourceButton.setText("Generate Source and Makefile");
+				genSourceButton.setText("Create Hello World Source and Makefile example"); //$NON-NLS-1$
 				genSourceButton.setSelection(generateSource);
 				genSourceButton.addSelectionListener(new SelectionAdapter() {
 					@Override


### PR DESCRIPTION
Removed the 'Experimental' label in project creation wizard for Core Build Makefile projects. Seven years after the inception it's time to remove it. Core Build Makefile is now in a usable state. The 'Experimental' label scares users away from it, making them fall back to the old Managed Build Makefile projects.