### PR TITLE
[#808] Support overriden default-editor-association in EditorUtility

### DIFF
--- a/core/org.eclipse.cdt.ui/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.ui; singleton:=true
-Bundle-Version: 8.1.400.qualifier
+Bundle-Version: 8.1.500.qualifier
 Bundle-Activator: org.eclipse.cdt.ui.CUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/util/EditorUtility.java
+++ b/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/util/EditorUtility.java
@@ -97,6 +97,7 @@ import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorRegistry;
 import org.eclipse.ui.IFileEditorInput;
+import org.eclipse.ui.IURIEditorInput;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -677,9 +678,9 @@ public class EditorUtility {
 			}
 		}
 		IEditorDescriptor desc = null;
-		if (input instanceof ExternalEditorInput externalInput) {
+		if (input instanceof IURIEditorInput uriEditorInput) {
 			try {
-				IFileStore fileStore = EFS.getFileSystem("file").getStore(externalInput.getPath()); //$NON-NLS-1$
+				IFileStore fileStore = EFS.getStore(uriEditorInput.getURI());
 				// get editor by considering overridden default editor association via IEditorAssociationOverride:
 				desc = IDE.getEditorDescriptorForFileStore(fileStore, false);
 			} catch (CoreException e) {

--- a/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/util/EditorUtility.java
+++ b/core/org.eclipse.cdt.ui/src/org/eclipse/cdt/internal/ui/util/EditorUtility.java
@@ -676,8 +676,20 @@ public class EditorUtility {
 				contentType = Platform.getContentTypeManager().getContentType(CCorePlugin.CONTENT_TYPE_BINARYFILE);
 			}
 		}
-		IEditorRegistry registry = PlatformUI.getWorkbench().getEditorRegistry();
-		IEditorDescriptor desc = registry.getDefaultEditor(input.getName(), contentType);
+		IEditorDescriptor desc = null;
+		if (input instanceof ExternalEditorInput externalInput) {
+			try {
+				IFileStore fileStore = EFS.getFileSystem("file").getStore(externalInput.getPath()); //$NON-NLS-1$
+				// get editor by considering overridden default editor association via IEditorAssociationOverride:
+				desc = IDE.getEditorDescriptorForFileStore(fileStore, false);
+			} catch (CoreException e) {
+				CUIPlugin.log(e);
+			}
+		}
+		if (desc == null) {
+			IEditorRegistry registry = PlatformUI.getWorkbench().getEditorRegistry();
+			desc = registry.getDefaultEditor(input.getName(), contentType);
+		}
 		if (desc != null) {
 			String editorID = desc.getId();
 			if (input instanceof IFileEditorInput) {


### PR DESCRIPTION
fixes #808 
fixes https://github.com/eclipse-cdt/cdt-lsp/issues/338