### PR TITLE
Sets the CMake CMAKE_BUILD_TYPE define Fixes #807

### DIFF
--- a/cmake/org.eclipse.cdt.cmake.core/META-INF/MANIFEST.MF
+++ b/cmake/org.eclipse.cdt.cmake.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.cmake.core;singleton:=true
-Bundle-Version: 1.5.500.qualifier
+Bundle-Version: 1.5.600.qualifier
 Bundle-Activator: org.eclipse.cdt.cmake.core.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeBuildConfiguration.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeBuildConfiguration.java
@@ -68,6 +68,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.debug.core.ILaunchManager;
 import org.osgi.service.prefs.Preferences;
 
 public class CMakeBuildConfiguration extends CBuildConfiguration {
@@ -160,6 +161,13 @@ public class CMakeBuildConfiguration extends CBuildConfiguration {
 
 			ICMakeProperties cmakeProperties = getPropertiesController().load();
 			runCMake |= !Files.exists(buildDir.resolve("CMakeCache.txt")); //$NON-NLS-1$
+
+			// Causes CMAKE_BUILD_TYPE to be set according to the launch mode
+			if (ILaunchManager.DEBUG_MODE.equals(getLaunchMode())) {
+				cmakeProperties.setBuildType("Debug"); //$NON-NLS-1$
+			} else {
+				cmakeProperties.setBuildType("Release"); //$NON-NLS-1$
+			}
 
 			final SimpleOsOverridesSelector overridesSelector = new SimpleOsOverridesSelector();
 			if (!runCMake) {


### PR DESCRIPTION
The CMAKE_BUILD_TYPE is added to CMake configuration build, based on the active launch mode; DEBUG_MODE sets a buildType of "Debug", everything else sets a buildType of "Release".
Note, the CMake CMAKE_BUILD_TYPE definition is not directly equivalent to the Launch Bar Launch Mode; there might be a scenario where the user wants to launch a debug session using the CMake Release build and not run it. However, for most cases this is probably sufficient.

For Issue CMake projects are ignoring the Launch mode Run/Debug #807.