### PR TITLE
Launchbar build button always starts a build.

### DIFF
--- a/launchbar/org.eclipse.launchbar.ui/META-INF/MANIFEST.MF
+++ b/launchbar/org.eclipse.launchbar.ui/META-INF/MANIFEST.MF
@@ -2,14 +2,15 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.launchbar.ui;singleton:=true
-Bundle-Version: 2.5.400.qualifier
+Bundle-Version: 2.5.500.qualifier
 Bundle-Activator: org.eclipse.launchbar.ui.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.ui.ide,
  org.eclipse.debug.ui,
- org.eclipse.launchbar.core
+ org.eclipse.launchbar.core,
+ org.eclipse.cdt.debug.core;bundle-version="8.8.400"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin


### PR DESCRIPTION
Fixed the problem that the LaunchBar build button was not working when auto build was disabled in the launch configuration.

Fixes #765