### PR TITLE
Support arguments and working directory in launching Core Build proje…

### DIFF
--- a/debug/org.eclipse.cdt.debug.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.cdt.debug.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.core; singleton:=true
-Bundle-Version: 8.8.400.qualifier
+Bundle-Version: 8.8.500.qualifier
 Bundle-Activator: org.eclipse.cdt.debug.core.CDebugCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/internal/core/launch/CoreBuildLocalRunLaunchDelegate.java
+++ b/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/internal/core/launch/CoreBuildLocalRunLaunchDelegate.java
@@ -60,6 +60,8 @@ public class CoreBuildLocalRunLaunchDelegate extends CoreBuildLaunchConfigDelega
 			String workingDirectory = configuration
 					.getAttribute(ICDTLaunchConfigurationConstants.ATTR_WORKING_DIRECTORY, ""); //$NON-NLS-1$
 			if (!workingDirectory.isBlank()) {
+				workingDirectory = VariablesPlugin.getDefault().getStringVariableManager()
+						.performStringSubstitution(workingDirectory);
 				builder.directory(new File(workingDirectory));
 			}
 

--- a/launch/org.eclipse.cdt.launch/META-INF/MANIFEST.MF
+++ b/launch/org.eclipse.cdt.launch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.launch; singleton:=true
-Bundle-Version: 10.4.400.qualifier
+Bundle-Version: 10.4.500.qualifier
 Bundle-Activator: org.eclipse.cdt.launch.internal.ui.LaunchUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/internal/corebuild/LocalLaunchConfigurationTabGroup.java
+++ b/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/internal/corebuild/LocalLaunchConfigurationTabGroup.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.cdt.launch.internal.corebuild;
 
+import org.eclipse.cdt.launch.ui.CArgumentsTab;
 import org.eclipse.cdt.launch.ui.corebuild.CoreBuildMainTab;
 import org.eclipse.cdt.launch.ui.corebuild.CoreBuildTab;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
@@ -22,8 +23,9 @@ public class LocalLaunchConfigurationTabGroup extends AbstractLaunchConfiguratio
 	public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
 		ILaunchConfigurationTab mainTab = new CoreBuildMainTab();
 		ILaunchConfigurationTab buildTab = new CoreBuildTab();
+		ILaunchConfigurationTab argumentsTab = new CArgumentsTab();
 
-		setTabs(new ILaunchConfigurationTab[] { mainTab, buildTab });
+		setTabs(new ILaunchConfigurationTab[] { mainTab, buildTab, argumentsTab });
 	}
 
 }


### PR DESCRIPTION
…cts for Local

Added the CArgumentsTab to the Core Build launch configuration for the Local target. This enables users to set command line arguments and specify a working directory.