### PR TITLE
Add support for String Terminator to be ESC \

### DIFF
--- a/terminal/plugins/org.eclipse.tm.terminal.control/META-INF/MANIFEST.MF
+++ b/terminal/plugins/org.eclipse.tm.terminal.control/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.tm.terminal.control; singleton:=true
-Bundle-Version: 5.5.300.qualifier
+Bundle-Version: 5.5.400.qualifier
 Bundle-Activator: org.eclipse.tm.internal.terminal.control.impl.TerminalPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
This fixes support to properly identify the end of OSC control sequences which can be terminated
with a BEL or ESC \.

Fixes https://github.com/eclipse-cdt/cdt/issues/831