### PR TITLE
Use final p2 repos for all CDT 11.6 dependencies

### DIFF
--- a/build/org.eclipse.cdt.autotools-feature/feature.xml
+++ b/build/org.eclipse.cdt.autotools-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.autotools"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%provider"
       plugin="org.eclipse.cdt.autotools.ui"
       license-feature="org.eclipse.license"

--- a/build/org.eclipse.cdt.autotools.docs/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.autotools.docs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.cdt.autotools.docs;singleton:=true
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: %provider
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help,

--- a/build/org.eclipse.cdt.autotools.docs/pom.xml
+++ b/build/org.eclipse.cdt.autotools.docs/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.eclipse.cdt</groupId>
     <artifactId>cdt-parent</artifactId>
-    <version>11.6.0-SNAPSHOT</version>
+    <version>11.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <version>11.6.0-SNAPSHOT</version>
+  <version>11.6.1-SNAPSHOT</version>
   <artifactId>org.eclipse.cdt.autotools.docs</artifactId>
   <packaging>eclipse-plugin</packaging>
 

--- a/build/org.eclipse.cdt.core.autotools-feature/feature.xml
+++ b/build/org.eclipse.cdt.core.autotools-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.core.autotools"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.core.autotools.ui"
       license-feature="org.eclipse.license"

--- a/build/org.eclipse.cdt.gnu.build-feature/feature.xml
+++ b/build/org.eclipse.cdt.gnu.build-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.gnu.build"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.build.gcc.ui"
       license-feature="org.eclipse.license"

--- a/build/org.eclipse.cdt.meson-feature/feature.xml
+++ b/build/org.eclipse.cdt.meson-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.meson"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.meson.ui"
       license-feature="org.eclipse.license"

--- a/build/org.eclipse.cdt.meson.docs/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.meson.docs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.cdt.meson.docs;singleton:=true
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: %provider
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help,

--- a/build/org.eclipse.cdt.meson.docs/pom.xml
+++ b/build/org.eclipse.cdt.meson.docs/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.eclipse.cdt</groupId>
     <artifactId>cdt-parent</artifactId>
-    <version>11.6.0-SNAPSHOT</version>
+    <version>11.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <version>11.6.0-SNAPSHOT</version>
+  <version>11.6.1-SNAPSHOT</version>
   <artifactId>org.eclipse.cdt.meson.docs</artifactId>
   <packaging>eclipse-plugin</packaging>
 

--- a/build/org.eclipse.cdt.meson.ui.tests/pom.xml
+++ b/build/org.eclipse.cdt.meson.ui.tests/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.build-parent</artifactId>

--- a/cmake/aggregator/pom.xml
+++ b/cmake/aggregator/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cmake-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>cmake-aggregator</artifactId>

--- a/cmake/org.eclipse.cdt.cmake-feature/feature.xml
+++ b/cmake/org.eclipse.cdt.cmake-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.cmake"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.cmake.ui"
       license-feature="org.eclipse.license"

--- a/cmake/org.eclipse.cdt.cmake.ui.tests/pom.xml
+++ b/cmake/org.eclipse.cdt.cmake.ui.tests/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/cmake/pom.xml
+++ b/cmake/pom.xml
@@ -17,12 +17,12 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.cdt</groupId>
 	<artifactId>cmake-parent</artifactId>
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/codan/pom.xml
+++ b/codan/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.codan-parent</artifactId>

--- a/core/org.eclipse.cdt.core.linux.aarch64/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core.linux.aarch64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName.linux.aarch64
 Bundle-SymbolicName: org.eclipse.cdt.core.linux.aarch64;singleton:=true
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.cdt.core.native;bundle-version="[6.3.0,7.0.0)"
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core.linux.aarch64/pom.xml
+++ b/core/org.eclipse.cdt.core.linux.aarch64/pom.xml
@@ -17,11 +17,11 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
 	<artifactId>org.eclipse.cdt.core.linux.aarch64</artifactId>
 	<packaging>eclipse-plugin</packaging>
 

--- a/core/org.eclipse.cdt.core.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core.linux.ppc64le/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-SymbolicName: org.eclipse.cdt.core.linux.ppc64le;singleton:=true
 Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 Bundle-Name: %fragmentName.linux.ppc64le
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Fragment-Host: org.eclipse.cdt.core.native;bundle-version="[6.3.0,7.0.0)"
 Bundle-Vendor: %providerName
 Eclipse-PlatformFilter: (&(osgi.os=linux)(osgi.arch=ppc64le))

--- a/core/org.eclipse.cdt.core.linux.ppc64le/pom.xml
+++ b/core/org.eclipse.cdt.core.linux.ppc64le/pom.xml
@@ -17,11 +17,11 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
 	<artifactId>org.eclipse.cdt.core.linux.ppc64le</artifactId>
 	<packaging>eclipse-plugin</packaging>
 

--- a/core/org.eclipse.cdt.core.linux.x86_64/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core.linux.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName.linux.x86_64
 Bundle-SymbolicName: org.eclipse.cdt.core.linux.x86_64;singleton:=true
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.cdt.core.native;bundle-version="[6.3.0,7.0.0)"
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core.linux.x86_64/pom.xml
+++ b/core/org.eclipse.cdt.core.linux.x86_64/pom.xml
@@ -17,11 +17,11 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
 	<artifactId>org.eclipse.cdt.core.linux.x86_64</artifactId>
 	<packaging>eclipse-plugin</packaging>
 

--- a/core/org.eclipse.cdt.core.linux/pom.xml
+++ b/core/org.eclipse.cdt.core.linux/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.eclipse.cdt</groupId>
     <artifactId>cdt-parent</artifactId>
-    <version>11.6.0-SNAPSHOT</version>
+    <version>11.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/org.eclipse.cdt.core.macosx/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core.macosx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName.macosx
 Bundle-SymbolicName: org.eclipse.cdt.core.macosx; singleton:=true
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: %providerName
 Fragment-Host: org.eclipse.cdt.core.native;bundle-version="[6.3.0,7.0.0)"
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core.macosx/pom.xml
+++ b/core/org.eclipse.cdt.core.macosx/pom.xml
@@ -17,11 +17,11 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
 	<artifactId>org.eclipse.cdt.core.macosx</artifactId>
 	<packaging>eclipse-plugin</packaging>
 

--- a/core/org.eclipse.cdt.core.native/pom.xml
+++ b/core/org.eclipse.cdt.core.native/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.eclipse.cdt</groupId>
     <artifactId>cdt-parent</artifactId>
-    <version>11.6.0-SNAPSHOT</version>
+    <version>11.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/core/org.eclipse.cdt.core.tests/pom.xml
+++ b/core/org.eclipse.cdt.core.tests/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/core/org.eclipse.cdt.core.win32.x86_64/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core.win32.x86_64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName.win32.x86_64
 Bundle-SymbolicName: org.eclipse.cdt.core.win32.x86_64;singleton:=true
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Fragment-Host: org.eclipse.cdt.core.native;bundle-version="[6.3.0,7.0.0)"
 Eclipse-PlatformFilter: (&(osgi.os=win32)(osgi.arch=x86_64))
 Bundle-Vendor: %providerName

--- a/core/org.eclipse.cdt.core.win32.x86_64/pom.xml
+++ b/core/org.eclipse.cdt.core.win32.x86_64/pom.xml
@@ -17,11 +17,11 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
 	<artifactId>org.eclipse.cdt.core.win32.x86_64</artifactId>
 	<packaging>eclipse-plugin</packaging>
 

--- a/core/org.eclipse.cdt.core.win32/pom.xml
+++ b/core/org.eclipse.cdt.core.win32/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/core/org.eclipse.cdt.ui.tests/pom.xml
+++ b/core/org.eclipse.cdt.ui.tests/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt-parent</artifactId>

--- a/cross/org.eclipse.cdt.build.crossgcc-feature/feature.xml
+++ b/cross/org.eclipse.cdt.build.crossgcc-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.build.crossgcc"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.build.crossgcc"
       license-feature="org.eclipse.license"

--- a/cross/org.eclipse.cdt.build.crossgcc-feature/pom.xml
+++ b/cross/org.eclipse.cdt.build.crossgcc-feature/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/cross/org.eclipse.cdt.launch.remote-feature/feature.xml
+++ b/cross/org.eclipse.cdt.launch.remote-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.launch.remote"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/cross/org.eclipse.cdt.launch.remote-feature/pom.xml
+++ b/cross/org.eclipse.cdt.launch.remote-feature/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/cross/org.eclipse.cdt.launch.serial-feature/feature.xml
+++ b/cross/org.eclipse.cdt.launch.serial-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.launch.serial.feature"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.launch.serial.ui"
       license-feature="org.eclipse.license"

--- a/cross/pom.xml
+++ b/cross/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.cross-parent</artifactId>

--- a/debug/org.eclipse.cdt.debug.application.product/debug.product
+++ b/debug/org.eclipse.cdt.debug.application.product/debug.product
@@ -11,7 +11,7 @@
 
    SPDX-License-Identifier: EPL-2.0
 -->
-<product name="Stand-alone C/C++ GDB Debugger" uid="org.eclipse.cdt.debug.application.product" id="org.eclipse.cdt.debug.application.product" application="org.eclipse.cdt.debug.application.app" version="11.6.0.qualifier" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Stand-alone C/C++ GDB Debugger" uid="org.eclipse.cdt.debug.application.product" id="org.eclipse.cdt.debug.application.product" application="org.eclipse.cdt.debug.application.app" version="11.6.1.qualifier" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.cdt.debug.application/icons/about.png"/>

--- a/debug/org.eclipse.cdt.debug.application.product/pom.xml
+++ b/debug/org.eclipse.cdt.debug.application.product/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/debug/org.eclipse.cdt.debug.application.tests/pom.xml
+++ b/debug/org.eclipse.cdt.debug.application.tests/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.cdt</groupId>
     <artifactId>cdt-parent</artifactId>
-    <version>11.6.0-SNAPSHOT</version>
+    <version>11.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/debug/org.eclipse.cdt.debug.application/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.cdt.debug.application/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.cdt.debug.application;singleton:=true
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Activator: org.eclipse.cdt.debug.application.Activator
 Bundle-Vendor: %provider
 Require-Bundle: org.eclipse.ui,

--- a/debug/org.eclipse.cdt.debug.application/plugin.properties
+++ b/debug/org.eclipse.cdt.debug.application/plugin.properties
@@ -41,6 +41,6 @@ DebugRemoteExecutableMenu.label=&Remote Executable...
 DebugCore.description=Debug a corefile
 DebugCore.name=Debug Core File
 DebugCoreMenu.label=Debug &Core File...
-aboutText=Eclipse Stand-alone C/C++ GDB Graphical Debugger\n\nRelease 11.6.0\n
+aboutText=Eclipse Stand-alone C/C++ GDB Graphical Debugger\n\nRelease 11.6.1\n
 ProductDesc=Eclipse Stand-alone C/C++ GDB Debugger
 ProductName=Stand-alone C/C++ GDB Debugger

--- a/debug/org.eclipse.cdt.debug.standalone-feature/feature.xml
+++ b/debug/org.eclipse.cdt.debug.standalone-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.debug.standalone"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.debug.application"
       license-feature="org.eclipse.license"

--- a/debug/org.eclipse.cdt.gdb-feature/feature.xml
+++ b/debug/org.eclipse.cdt.gdb-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.gdb"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.gdb"
       license-feature="org.eclipse.license"

--- a/debug/org.eclipse.cdt.gdb-feature/pom.xml
+++ b/debug/org.eclipse.cdt.gdb-feature/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/debug/org.eclipse.cdt.gnu.debug-feature/feature.xml
+++ b/debug/org.eclipse.cdt.gnu.debug-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.gnu.debug"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.launch"
       license-feature="org.eclipse.license"

--- a/debug/pom.xml
+++ b/debug/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.debug-parent</artifactId>

--- a/doc/org.eclipse.cdt.doc.isv/META-INF/MANIFEST.MF
+++ b/doc/org.eclipse.cdt.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.doc.isv; singleton:=true
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.help;bundle-version="[3.2.0,4.0.0)"
 Bundle-ActivationPolicy: lazy

--- a/doc/org.eclipse.cdt.doc.isv/pom.xml
+++ b/doc/org.eclipse.cdt.doc.isv/pom.xml
@@ -17,11 +17,11 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
 	<artifactId>org.eclipse.cdt.doc.isv</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
@@ -121,7 +121,7 @@
 											<additionalArgument>-linkoffline ../../org.eclipse.platform.doc.isv/reference/api
 											</additionalArgument>
 											<additionalArgument>-public</additionalArgument>
-											<additionalArgument>-header "Eclipse CDT 11.6.0"
+											<additionalArgument>-header "Eclipse CDT 11.6.1"
 											</additionalArgument>
 											<additionalArgument>-bottom "Copyright (c) IBM Corp. and others 2004, 2021. All Rights Reserved."</additionalArgument>
 											<additionalArgument>-tag 'noimplement:a:Restriction:'</additionalArgument>

--- a/doc/org.eclipse.cdt.doc.user/META-INF/MANIFEST.MF
+++ b/doc/org.eclipse.cdt.doc.user/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.doc.user; singleton:=true
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/doc/org.eclipse.cdt.doc.user/pom.xml
+++ b/doc/org.eclipse.cdt.doc.user/pom.xml
@@ -16,11 +16,11 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
 	<artifactId>org.eclipse.cdt.doc.user</artifactId>
 	<packaging>eclipse-plugin</packaging>
 

--- a/dsf-gdb/org.eclipse.cdt.gnu.dsf-feature/feature.xml
+++ b/dsf-gdb/org.eclipse.cdt.gnu.dsf-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.gnu.dsf"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.dsf.gdb.ui"
       license-feature="org.eclipse.license"

--- a/dsf-gdb/org.eclipse.cdt.gnu.multicorevisualizer-feature/feature.xml
+++ b/dsf-gdb/org.eclipse.cdt.gnu.multicorevisualizer-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.gnu.multicorevisualizer"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.dsf.gdb.multicorevisualizer.ui"
       license-feature="org.eclipse.license"

--- a/dsf-gdb/org.eclipse.cdt.tests.dsf.gdb/pom.xml
+++ b/dsf-gdb/org.eclipse.cdt.tests.dsf.gdb/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/dsf-gdb/pom.xml
+++ b/dsf-gdb/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.dsf-gdb-parent</artifactId>

--- a/dsf/org.eclipse.cdt.examples.dsf-feature/feature.xml
+++ b/dsf/org.eclipse.cdt.examples.dsf-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.examples.dsf"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.examples.dsf"
       license-feature="org.eclipse.license"

--- a/dsf/org.eclipse.cdt.examples.dsf-feature/pom.xml
+++ b/dsf/org.eclipse.cdt.examples.dsf-feature/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/dsf/pom.xml
+++ b/dsf/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.dsf-parent</artifactId>

--- a/jsoncdb/aggregator/pom.xml
+++ b/jsoncdb/aggregator/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>jsoncdb-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>jsoncdb-aggregator</artifactId>

--- a/jsoncdb/org.eclipse.cdt.jsoncdb.freescale/META-INF/MANIFEST.MF
+++ b/jsoncdb/org.eclipse.cdt.jsoncdb.freescale/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Copyright: %Bundle-Copyright
 Bundle-SymbolicName: org.eclipse.cdt.jsoncdb.freescale;singleton:=true
-Bundle-Version: 1.0.100.qualifier
+Bundle-Version: 1.0.101.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.cdt.jsoncdb.core;bundle-version="1.4.100",
  org.eclipse.help;bundle-version="3.10.100",

--- a/jsoncdb/pom.xml
+++ b/jsoncdb/pom.xml
@@ -17,12 +17,12 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.eclipse.cdt</groupId>
 	<artifactId>jsoncdb-parent</artifactId>
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>

--- a/jtag/org.eclipse.cdt.debug.gdbjtag-feature/feature.xml
+++ b/jtag/org.eclipse.cdt.debug.gdbjtag-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.debug.gdbjtag"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/jtag/org.eclipse.cdt.debug.gdbjtag-feature/pom.xml
+++ b/jtag/org.eclipse.cdt.debug.gdbjtag-feature/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/jtag/org.eclipse.cdt.debug.gdbjtag.core.tests/pom.xml
+++ b/jtag/org.eclipse.cdt.debug.gdbjtag.core.tests/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/jtag/org.eclipse.cdt.debug.gdbjtag/pom.xml
+++ b/jtag/org.eclipse.cdt.debug.gdbjtag/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/jtag/pom.xml
+++ b/jtag/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.eclipse.cdt</groupId>
     <artifactId>cdt-parent</artifactId>
-    <version>11.6.0-SNAPSHOT</version>
+    <version>11.6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.cdt.jtag-parent</artifactId>

--- a/launch/org.eclipse.cdt.docker.launcher-feature/feature.xml
+++ b/launch/org.eclipse.cdt.docker.launcher-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.docker.launcher"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%provider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/launch/org.eclipse.cdt.docker.launcher-feature/pom.xml
+++ b/launch/org.eclipse.cdt.docker.launcher-feature/pom.xml
@@ -17,7 +17,7 @@
         <parent>
                 <groupId>org.eclipse.cdt</groupId>
                 <artifactId>cdt-parent</artifactId>
-                <version>11.6.0-SNAPSHOT</version>
+                <version>11.6.1-SNAPSHOT</version>
                 <relativePath>../../pom.xml</relativePath>
         </parent>
 

--- a/launch/org.eclipse.cdt.flatpak.launcher-feature/feature.xml
+++ b/launch/org.eclipse.cdt.flatpak.launcher-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.flatpak.launcher"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%provider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/launch/org.eclipse.cdt.flatpak.launcher-feature/pom.xml
+++ b/launch/org.eclipse.cdt.flatpak.launcher-feature/pom.xml
@@ -17,7 +17,7 @@
         <parent>
                 <groupId>org.eclipse.cdt</groupId>
                 <artifactId>cdt-parent</artifactId>
-                <version>11.6.0-SNAPSHOT</version>
+                <version>11.6.1-SNAPSHOT</version>
                 <relativePath>../../pom.xml</relativePath>
         </parent>
 

--- a/launch/pom.xml
+++ b/launch/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.launch-parent</artifactId>

--- a/launchbar/org.eclipse.launchbar.remote/feature.xml
+++ b/launchbar/org.eclipse.launchbar.remote/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.launchbar.remote"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.launchbar.remote.ui"
       license-feature="org.eclipse.license"

--- a/launchbar/org.eclipse.launchbar.ui.tests/pom.xml
+++ b/launchbar/org.eclipse.launchbar.ui.tests/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/launchbar/org.eclipse.launchbar/feature.xml
+++ b/launchbar/org.eclipse.launchbar/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.launchbar"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.launchbar.ui"
       license-feature="org.eclipse.license"

--- a/launchbar/pom.xml
+++ b/launchbar/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.launchbar-parent</artifactId>

--- a/llvm/org.eclipse.cdt.llvm.dsf.lldb-feature/feature.xml
+++ b/llvm/org.eclipse.cdt.llvm.dsf.lldb-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.llvm.dsf.lldb"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.llvm.dsf.lldb.ui"
       license-feature="org.eclipse.license"

--- a/llvm/org.eclipse.cdt.managedbuilder.llvm-feature/feature.xml
+++ b/llvm/org.eclipse.cdt.managedbuilder.llvm-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.managedbuilder.llvm"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.managedbuilder.llvm.ui"
       license-feature="org.eclipse.license"

--- a/llvm/pom.xml
+++ b/llvm/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.llvm-parent</artifactId>

--- a/memory/org.eclipse.cdt.debug.ui.memory-feature/feature.xml
+++ b/memory/org.eclipse.cdt.debug.ui.memory-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.debug.ui.memory"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.debug.ui.memory.memorybrowser"
       license-feature="org.eclipse.license"

--- a/memory/pom.xml
+++ b/memory/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.memory-parent</artifactId>

--- a/native/org.eclipse.cdt.native.serial/META-INF/MANIFEST.MF
+++ b/native/org.eclipse.cdt.native.serial/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.native.serial
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.cdt.serial

--- a/native/org.eclipse.cdt.native.serial/pom.xml
+++ b/native/org.eclipse.cdt.native.serial/pom.xml
@@ -19,11 +19,11 @@
   <parent>
     <groupId>org.eclipse.cdt</groupId>
     <artifactId>cdt-parent</artifactId>
-    <version>11.6.0-SNAPSHOT</version>
+    <version>11.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <version>11.6.0-SNAPSHOT</version>
+  <version>11.6.1-SNAPSHOT</version>
   <artifactId>org.eclipse.cdt.native.serial</artifactId>
   <packaging>eclipse-plugin</packaging>
 

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.native-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
 		<tycho-version>4.0.6</tycho-version>
 		<cbi-plugins.version>1.4.3</cbi-plugins.version>
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
-		<cdt-site>https://ci.eclipse.org/cdt/job/cdt/job/main/lastSuccessfulBuild/artifact/releng/org.eclipse.cdt.repo/target/repository</cdt-site>
-		<simrel-site>https://download.eclipse.org/staging/2024-06/</simrel-site>
+		<cdt-site>https://ci.eclipse.org/cdt/job/cdt/job/cdt_11_6/lastSuccessfulBuild/artifact/releng/org.eclipse.cdt.repo/target/repository</cdt-site>
+		<simrel-site>https://download.eclipse.org/releases/2024-06//</simrel-site>
 		<repo-path>tools/cdt/builds/master/nightly</repo-path>
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 		<sonar.jacoco.reportPath>${project.basedir}/../../target/jacoco.exec</sonar.jacoco.reportPath>
@@ -40,9 +40,9 @@
 		<tycho.scmUrl>scm:git:https://github.com/eclipse-cdt/cdt</tycho.scmUrl>
 		<!-- Some old tests, like CDescriptorOldTests, fail due to reflection access. Therefore we add-opens to make that pass -->
 		<base.test.vmargs>-Xms256m -Xmx512m -ea --add-opens=java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED</base.test.vmargs>
-		<comparator.repo>https://download.eclipse.org/tools/cdt/builds/11.5/cdt-11.5.0-rc2/</comparator.repo>
-		<api-baseline.repo>https://download.eclipse.org/tools/cdt/builds/11.5/cdt-11.5.0-rc2/</api-baseline.repo>
-		<api-baseline.repo.simrel>https://download.eclipse.org/releases/2024-03/</api-baseline.repo.simrel>
+		<comparator.repo>https://download.eclipse.org/tools/cdt/releases/11.6/</comparator.repo>
+		<api-baseline.repo>https://download.eclipse.org/tools/cdt/releases/11.6/</api-baseline.repo>
+		<api-baseline.repo.simrel>https://download.eclipse.org/releases/2024-06/</api-baseline.repo.simrel>
 		<!-- these parameters are to control baseline replace and compare. On a local build you want
 		     to avoid baseline replace and compare, especially if you have different versions of Java than
 			 the baseline was built with. This is the default.

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>org.eclipse.cdt</groupId>
 	<artifactId>cdt-parent</artifactId>
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>CDT Parent</name>
 

--- a/releng/org.eclipse.cdt-feature/feature.xml
+++ b/releng/org.eclipse.cdt-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/org.eclipse.cdt-feature/pom.xml
+++ b/releng/org.eclipse.cdt-feature/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.cdt.native-feature/feature.xml
+++ b/releng/org.eclipse.cdt.native-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.native"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.core.native"
       license-feature="org.eclipse.license"

--- a/releng/org.eclipse.cdt.platform-feature/feature.xml
+++ b/releng/org.eclipse.cdt.platform-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.platform"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.platform.branding"
       license-feature="org.eclipse.license"

--- a/releng/org.eclipse.cdt.platform.branding/META-INF/MANIFEST.MF
+++ b/releng/org.eclipse.cdt.platform.branding/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.platform.branding;singleton:=true
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/releng/org.eclipse.cdt.repo/pom.xml
+++ b/releng/org.eclipse.cdt.repo/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.cdt.sdk-feature/feature.xml
+++ b/releng/org.eclipse.cdt.sdk-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.sdk"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/org.eclipse.cdt.sdk-feature/pom.xml
+++ b/releng/org.eclipse.cdt.sdk-feature/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.cdt.sdk/META-INF/MANIFEST.MF
+++ b/releng/org.eclipse.cdt.sdk/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.sdk;singleton:=true
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/releng/org.eclipse.cdt.target/cdt-baseline.target
+++ b/releng/org.eclipse.cdt.target/cdt-baseline.target
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="cdt-baseline" sequenceNumber="37">
+<target name="cdt-baseline" sequenceNumber="38">
   <locations>
     <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
-      <repository location="https://download.eclipse.org/tools/cdt/builds/11.5/cdt-11.5.0-rc2/"/>
+      <repository location="https://download.eclipse.org/tools/cdt/releases/11.6/"/>
       <unit id="org.eclipse.cdt.autotools.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.cdt.build.crossgcc.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.cdt.cmake.feature.group" version="0.0.0"/>

--- a/releng/org.eclipse.cdt.target/cdt.target
+++ b/releng/org.eclipse.cdt.target/cdt.target
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="cdt" sequenceNumber="159">
+<target name="cdt" sequenceNumber="160">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/cbi/updates/license/" />
 			<unit id="org.eclipse.license.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.32-I-builds/" />
+			<repository location="https://download.eclipse.org/eclipse/updates/4.32/" />
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.jdt.annotation" version="0.0.0" />
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0" />
@@ -15,23 +15,23 @@
 			<unit id="org.eclipse.unittest.ui" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/mylyn/updates/release/latest/" />
+			<repository location="https://download.eclipse.org/mylyn/updates/release/4.3.0/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/egit/updates" />
+			<repository location="https://download.eclipse.org/egit/updates-6.9/" />
 			<unit id="org.eclipse.egit.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/linuxtools/updates-docker-nightly" />
+			<repository location="https://download.eclipse.org/linuxtools/update-docker-5.15.0/" />
 			<unit id="org.eclipse.linuxtools.docker.feature.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/lsp4e/snapshots/" />
+			<repository location="https://download.eclipse.org/lsp4e/releases/0.26.2/" />
 			<unit id="org.eclipse.lsp4e" version="0.0.0" />
 			<unit id="org.eclipse.lsp4e.debug" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/latest/" />
+			<repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.38.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/technology/swtbot/releases/latest" />
@@ -40,17 +40,17 @@
 			<unit id="org.eclipse.swtbot.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tm4e/snapshots/" />
+			<repository location="https://download.eclipse.org/tm4e/releases/0.12.0/" />
 			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.tm4e.language_pack.feature.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<!-- We explicitly have CDT in target platform so that developers can develop org.eclipse.cdt.core/ui without requiring all the projects from CDT in their workspace. -->
-			<repository location="https://download.eclipse.org/tools/cdt/builds/11.5/cdt-11.5.0-rc2/" />
+			<repository location="https://download.eclipse.org/tools/cdt/releases/11.6/" />
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/latest/" />
+			<repository location="https://download.eclipse.org/wildwebdeveloper/releases/1.3.6/" />
 		</location>
 		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" label="DirectFromMaven" missingManifest="error" type="Maven">
 			<dependencies>

--- a/releng/org.eclipse.cdt.testing-feature/feature.xml
+++ b/releng/org.eclipse.cdt.testing-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.testing"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/releng/org.eclipse.cdt.testing-feature/pom.xml
+++ b/releng/org.eclipse.cdt.testing-feature/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.cdt.testing.repo/pom.xml
+++ b/releng/org.eclipse.cdt.testing.repo/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.cdt.testing/pom.xml
+++ b/releng/org.eclipse.cdt.testing/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/releng/org.eclipse.cdt/META-INF/MANIFEST.MF
+++ b/releng/org.eclipse.cdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt; singleton:=true
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui.intro;bundle-version="[3.2.0,4.0.0)",

--- a/releng/org.eclipse.cdt/pom.xml
+++ b/releng/org.eclipse.cdt/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.releng-parent</artifactId>

--- a/remote/org.eclipse.remote-feature/feature.xml
+++ b/remote/org.eclipse.remote-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.remote"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.remote.ui"
       license-feature="org.eclipse.license"

--- a/remote/org.eclipse.remote.console-feature/feature.xml
+++ b/remote/org.eclipse.remote.console-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.remote.console"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/remote/org.eclipse.remote.doc.isv/META-INF/MANIFEST.MF
+++ b/remote/org.eclipse.remote.doc.isv/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Remote Development documentation plug-in
 Bundle-SymbolicName: org.eclipse.remote.doc.isv;singleton:=true
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: Eclipse PTP
 Require-Bundle: org.eclipse.remote.console,
  org.eclipse.remote.core,

--- a/remote/org.eclipse.remote.doc.isv/pom.xml
+++ b/remote/org.eclipse.remote.doc.isv/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
   <artifactId>org.eclipse.remote.doc.isv</artifactId>
 	<packaging>eclipse-plugin</packaging>
 
@@ -75,7 +75,7 @@
 											<additionalArgument>-linkoffline ../../org.eclipse.platform.doc.isv/reference/api
 											</additionalArgument>
 											<additionalArgument>-public</additionalArgument>
-											<additionalArgument>-header "Eclipse CDT's org.eclipse.remote 11.6.0"
+											<additionalArgument>-header "Eclipse CDT's org.eclipse.remote 11.6.1"
 											</additionalArgument>
 											<additionalArgument>-bottom "Copyright (c) IBM Corp. and others 2004, 2021. All Rights Reserved."</additionalArgument>
 											<additionalArgument>-tag 'noimplement:a:Restriction:'</additionalArgument>

--- a/remote/org.eclipse.remote.proxy-feature/feature.xml
+++ b/remote/org.eclipse.remote.proxy-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.remote.proxy"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.remote.proxy.ui"
       license-feature="org.eclipse.license"

--- a/remote/org.eclipse.remote.proxy.server.linux.ppc64le/META-INF/MANIFEST.MF
+++ b/remote/org.eclipse.remote.proxy.server.linux.ppc64le/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.remote.proxy.server.linux.ppc64le
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: %pluginProvider
 Bundle-Localization: plugin

--- a/remote/org.eclipse.remote.proxy.server.linux.ppc64le/pom.xml
+++ b/remote/org.eclipse.remote.proxy.server.linux.ppc64le/pom.xml
@@ -17,11 +17,11 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
 	<artifactId>org.eclipse.remote.proxy.server.linux.ppc64le</artifactId>
 	<packaging>eclipse-plugin</packaging>
 

--- a/remote/org.eclipse.remote.proxy.server.linux.x86_64/META-INF/MANIFEST.MF
+++ b/remote/org.eclipse.remote.proxy.server.linux.x86_64/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.remote.proxy.server.linux.x86_64
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: %pluginProvider
 Bundle-Localization: plugin

--- a/remote/org.eclipse.remote.proxy.server.linux.x86_64/pom.xml
+++ b/remote/org.eclipse.remote.proxy.server.linux.x86_64/pom.xml
@@ -17,11 +17,11 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
 	<artifactId>org.eclipse.remote.proxy.server.linux.x86_64</artifactId>
 	<packaging>eclipse-plugin</packaging>
 

--- a/remote/org.eclipse.remote.proxy.server.macosx.x86_64/META-INF/MANIFEST.MF
+++ b/remote/org.eclipse.remote.proxy.server.macosx.x86_64/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.remote.proxy.server.macosx.x86_64
-Bundle-Version: 11.6.0.qualifier
+Bundle-Version: 11.6.1.qualifier
 Bundle-Vendor: %pluginProvider
 Bundle-Localization: plugin

--- a/remote/org.eclipse.remote.proxy.server.macosx.x86_64/pom.xml
+++ b/remote/org.eclipse.remote.proxy.server.macosx.x86_64/pom.xml
@@ -17,11 +17,11 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<version>11.6.0-SNAPSHOT</version>
+	<version>11.6.1-SNAPSHOT</version>
 	<artifactId>org.eclipse.remote.proxy.server.macosx.x86_64</artifactId>
 	<packaging>eclipse-plugin</packaging>
 

--- a/remote/org.eclipse.remote.proxy.server.product/pom.xml
+++ b/remote/org.eclipse.remote.proxy.server.product/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/remote/org.eclipse.remote.serial-feature/feature.xml
+++ b/remote/org.eclipse.remote.serial-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.remote.serial"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.remote.serial.ui"
       license-feature="org.eclipse.license"

--- a/remote/org.eclipse.remote.telnet-feature/feature.xml
+++ b/remote/org.eclipse.remote.telnet-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.remote.telnet"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.remote.telnet.ui"
       license-feature="org.eclipse.license"

--- a/remote/pom.xml
+++ b/remote/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.remote-parent</artifactId>

--- a/terminal/features/org.eclipse.tm.terminal.connector.cdtserial.feature/feature.xml
+++ b/terminal/features/org.eclipse.tm.terminal.connector.cdtserial.feature/feature.xml
@@ -15,7 +15,7 @@
 <feature
       id="org.eclipse.tm.terminal.connector.cdtserial.feature"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/terminal/features/org.eclipse.tm.terminal.connector.local.feature/feature.xml
+++ b/terminal/features/org.eclipse.tm.terminal.connector.local.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.tm.terminal.connector.local.feature"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/terminal/features/org.eclipse.tm.terminal.connector.remote.feature/feature.xml
+++ b/terminal/features/org.eclipse.tm.terminal.connector.remote.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.tm.terminal.connector.remote.feature"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/terminal/features/org.eclipse.tm.terminal.connector.ssh.feature/feature.xml
+++ b/terminal/features/org.eclipse.tm.terminal.connector.ssh.feature/feature.xml
@@ -15,7 +15,7 @@
 <feature
       id="org.eclipse.tm.terminal.connector.ssh.feature"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.tm.terminal.connector.ssh"
       license-feature="org.eclipse.license"

--- a/terminal/features/org.eclipse.tm.terminal.connector.telnet.feature/feature.xml
+++ b/terminal/features/org.eclipse.tm.terminal.connector.telnet.feature/feature.xml
@@ -15,7 +15,7 @@
 <feature
       id="org.eclipse.tm.terminal.connector.telnet.feature"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/terminal/features/org.eclipse.tm.terminal.control.feature/feature.xml
+++ b/terminal/features/org.eclipse.tm.terminal.control.feature/feature.xml
@@ -16,7 +16,7 @@
 <feature
       id="org.eclipse.tm.terminal.control.feature"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.tm.terminal.control"
       license-feature="org.eclipse.license"

--- a/terminal/features/org.eclipse.tm.terminal.feature/feature.xml
+++ b/terminal/features/org.eclipse.tm.terminal.feature/feature.xml
@@ -11,7 +11,7 @@
 <feature
       id="org.eclipse.tm.terminal.feature"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.tm.terminal.view.core"
       license-feature="org.eclipse.license"

--- a/terminal/features/org.eclipse.tm.terminal.view.feature/feature.xml
+++ b/terminal/features/org.eclipse.tm.terminal.view.feature/feature.xml
@@ -11,7 +11,7 @@
 <feature
       id="org.eclipse.tm.terminal.view.feature"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.tm.terminal.view.ui"
       license-feature="org.eclipse.license"

--- a/terminal/features/pom.xml
+++ b/terminal/features/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>terminal-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm.terminal.features</artifactId>

--- a/terminal/plugins/pom.xml
+++ b/terminal/plugins/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>terminal-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.tm.terminal.plugins</artifactId>

--- a/terminal/pom.xml
+++ b/terminal/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>terminal-parent</artifactId>

--- a/terminal/repo/pom.xml
+++ b/terminal/repo/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/testsrunner/org.eclipse.cdt.testsrunner.feature/feature.xml
+++ b/testsrunner/org.eclipse.cdt.testsrunner.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.testsrunner.feature"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.testsrunner"
       license-feature="org.eclipse.license"

--- a/testsrunner/pom.xml
+++ b/testsrunner/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.testsrunner-parent</artifactId>

--- a/tools.templates/pom.xml
+++ b/tools.templates/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.tools.template-parent</artifactId>

--- a/unittest/org.eclipse.cdt.unittest.feature/feature.xml
+++ b/unittest/org.eclipse.cdt.unittest.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.unittest.feature"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/unittest/pom.xml
+++ b/unittest/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.unittest-parent</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.util-parent</artifactId>

--- a/visualizer/org.eclipse.cdt.visualizer-feature/feature.xml
+++ b/visualizer/org.eclipse.cdt.visualizer-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.visualizer"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.visualizer.ui"
       license-feature="org.eclipse.license"

--- a/visualizer/pom.xml
+++ b/visualizer/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.visualizer-parent</artifactId>

--- a/windows/org.eclipse.cdt.msw-feature/feature.xml
+++ b/windows/org.eclipse.cdt.msw-feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.cdt.msw"
       label="%featureName"
-      version="11.6.0.qualifier"
+      version="11.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.cdt.msw.build"
       license-feature="org.eclipse.license"

--- a/windows/pom.xml
+++ b/windows/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.eclipse.cdt</groupId>
 		<artifactId>cdt-parent</artifactId>
-		<version>11.6.0-SNAPSHOT</version>
+		<version>11.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.cdt.windows-parent</artifactId>


### PR DESCRIPTION
It is important we don't point at "latest" URLs for dependencies as we want to ensure compatibility with 2024-06 and if some project does a newer release we want to explicitly opt-in to it on this CDT 11.6 branch

Part of #842 