### PR TITLE
Add enabled to JSON Compilation Database Generator prop page (#847)

### DIFF
--- a/build/org.eclipse.cdt.managedbuilder.ui/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.managedbuilder.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.managedbuilder.ui; singleton:=true
-Bundle-Version: 9.4.200.qualifier
+Bundle-Version: 9.4.300.qualifier
 Bundle-Activator: org.eclipse.cdt.managedbuilder.ui.properties.ManagedBuilderUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/build/org.eclipse.cdt.managedbuilder.ui/plugin.xml
+++ b/build/org.eclipse.cdt.managedbuilder.ui/plugin.xml
@@ -820,6 +820,12 @@
             class="org.eclipse.cdt.managedbuilder.internal.ui.compilationdatabase.CompilationDatabaseGeneratorBlock"
             id="org.eclipse.cdt.managedbuilder.ui.properties.Page_JsonCompilationDatabaseGenerator"
             name="%JSONCompilatioDatabaseGeneratorPage.name">
+         <enabledWhen>
+            <adapt type="org.eclipse.core.resources.IProject">
+	           <test property="org.eclipse.core.resources.projectNature"
+	                  value="org.eclipse.cdt.managedbuilder.core.managedBuildNature"/>
+            </adapt>
+         </enabledWhen>
       </page>
 
   </extension>


### PR DESCRIPTION
Show the JSON Compilation Database Generator properties page only for managed build projects.

fixes #847