### PR TITLE
[cdt_11_6] Use CDT's container to run all code cleanliness checks

### DIFF
--- a/.github/workflows/code-cleanliness.yml
+++ b/.github/workflows/code-cleanliness.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Run Check Code Cleanliness with Docker
         uses: addnab/docker-run-action@v3
         with:
-          image: quay.io/eclipse-cdt/cdt-infra-plus-eclipse-install-github@sha256:448dd492ab17c81b114c6adb5dc431a54b63991bf21265f7b7af93aea3704f87
+          image: quay.io/eclipse-cdt/cdt-infra-plus-eclipse-install-github@sha256:6949adee26f78e9968e16d52bc3accfd7b51d0f16c473ad4b6f1caee849ab519
           options: -v ${{ github.workspace }}:/work
           run: |
             set -x

--- a/.github/workflows/code-cleanliness.yml
+++ b/.github/workflows/code-cleanliness.yml
@@ -4,39 +4,26 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Set up JDK 21
-      uses: actions/setup-java@v3
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-        cache: maven
-    - name: Set up Maven
-      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
-      with:
-        maven-version: 3.9.2
-    - name: Install dependencies
-      run: |
-        sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-          libxml2-utils
-    - name: Install Eclipse SDK
-      run: |
-        curl -sL https://download.eclipse.org/eclipse/downloads/drops4/R-4.23-202203080310/eclipse-SDK-4.23-linux-gtk-x86_64.tar.gz | tar xz
-    - name: Run Check Code Cleanliness
-      run: ECLIPSE=$PWD/eclipse/eclipse ./releng/scripts/check_code_cleanliness_only.sh
-    - name: Run Bundle Versions Bumped
-      run: ./releng/scripts/check_bundle_versions.sh
-    - name: Report on Bundle Versions Bumped
-      run: ./releng/scripts/check_bundle_versions_report.sh
-    - name: Upload Logs
-      uses: actions/upload-artifact@v3
-      if: success() || failure()
-      with:
-        name: Code Cleanliness Detailed Logs
-        path: '*.log'
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Run Check Code Cleanliness with Docker
+        uses: addnab/docker-run-action@v3
+        with:
+          image: quay.io/eclipse-cdt/cdt-infra-plus-eclipse-install-github@sha256:448dd492ab17c81b114c6adb5dc431a54b63991bf21265f7b7af93aea3704f87
+          options: -v ${{ github.workspace }}:/work
+          run: |
+            set -x
+            cd /work
+            ./releng/scripts/check_code_cleanliness_only.sh
+            ./releng/scripts/check_bundle_versions.sh
+            ./releng/scripts/check_bundle_versions_report.sh
+      - name: Upload Logs
+        uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: Code Cleanliness Detailed Logs
+          path: "*.log"

--- a/docker/build-images.sh
+++ b/docker/build-images.sh
@@ -14,3 +14,4 @@ docker build --rm -f cdt-infra-base/ubuntu-18.04/Dockerfile -t cdt-infra-base:ub
 docker build --rm -f cdt-infra-all-gdbs/ubuntu-18.04/Dockerfile -t cdt-infra-all-gdbs:ubuntu-18.04 .
 docker build --rm -f cdt-infra-eclipse-full/ubuntu-18.04/Dockerfile -t cdt-infra-eclipse-full:ubuntu-18.04 .
 docker build --rm -f cdt-infra-plus-eclipse-install/ubuntu-18.04/Dockerfile -t cdt-infra-plus-eclipse-install:ubuntu-18.04 .
+docker build --rm -f cdt-infra-plus-eclipse-install-github/ubuntu-18.04/Dockerfile -t cdt-infra-plus-eclipse-install-github:ubuntu-18.04 .

--- a/docker/cdt-infra-eclipse-full/ubuntu-18.04/Dockerfile
+++ b/docker/cdt-infra-eclipse-full/ubuntu-18.04/Dockerfile
@@ -26,6 +26,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libxml2-utils \
       gettext-base \
       xserver-xephyr \
+      clang-format \
+      xvfb \
+      ssh-askpass \
     && apt-get install -y llvm \
     && apt-get install -y --no-install-recommends texinfo bison flex \
     && rm -rf /var/lib/apt/lists/* \

--- a/docker/cdt-infra-plus-eclipse-install-github/Readme.md
+++ b/docker/cdt-infra-plus-eclipse-install-github/Readme.md
@@ -1,0 +1,1 @@
+This directory contains dockerfiles for complete CDT Infra + Eclipse Installations for running on GitHub Actions

--- a/docker/cdt-infra-plus-eclipse-install-github/ubuntu-18.04/Dockerfile
+++ b/docker/cdt-infra-plus-eclipse-install-github/ubuntu-18.04/Dockerfile
@@ -1,13 +1,18 @@
 FROM ubuntu:18.04
 
+# The contents of this file are similar to cdt-infra-plus-eclipse-install/*/Dockerfile
+# because we don't want to share layers otherwise the change in permissions (1000 -> 1001)
+# causes an additional layer to be created in Docker, adding 300MB+ to download
+# size on each run
+
 ENV HOME=/home/vnc
 RUN apt-get update
 RUN apt-get install -y curl tar gzip
-#Eclipse SDK & Fix permissions for OpenShift & standard k8s
+#Eclipse SDK & Fix permissions for GitHub Actions
 RUN mkdir -p ${HOME}/buildtools && cd ${HOME}/buildtools \
   && curl -sL https://download.eclipse.org/eclipse/downloads/drops4/R-4.31-202402290520/eclipse-SDK-4.31-linux-gtk-x86_64.tar.gz | tar xvz \
   && mv eclipse eclipse-SDK-4.31 \
-  && chown -R 1000:0 ${HOME} \
+  && chown -R 1001:0 ${HOME} \
   && chmod -R g+rwX ${HOME}
 
 FROM cdt-infra-eclipse-full:ubuntu-18.04
@@ -15,6 +20,6 @@ USER root
 
 COPY --from=0 ${HOME}/buildtools ${HOME}/buildtools
 
-USER 1000
+USER 1001
 
-CMD ["/home/vnc/.vnc/xstartup.sh"]
+CMD ["/bin/bash"]

--- a/docker/deploy-images.sh
+++ b/docker/deploy-images.sh
@@ -11,7 +11,7 @@ namespace=${1:-quay.io/eclipse-cdt}
 shorthash=$(git rev-parse --short HEAD)
 toplevel=$(git rev-parse --show-toplevel)
 
-images="cdt-infra-eclipse-full:ubuntu-18.04 cdt-infra-plus-eclipse-install:ubuntu-18.04"
+images="cdt-infra-eclipse-full:ubuntu-18.04 cdt-infra-plus-eclipse-install:ubuntu-18.04 cdt-infra-plus-eclipse-install-github:ubuntu-18.04"
 
 $toplevel/docker/build-images.sh
 
@@ -28,7 +28,7 @@ for image in $images; do
     hashname=$(docker inspect --format='{{index .RepoDigests 0}}' $image)
     echo $image "-->" $hashname
     nameonly=$(echo $image | sed -es,:.*,,)
-    find $toplevel -name \*\.Jenkinsfile -or -name \*\.yaml | while read file; do
+    find $toplevel -name \*\.Jenkinsfile -or -name \*\.yaml -or -name \*\.yml | while read file; do
         sed -i "s#image: $namespace/$nameonly[:@].*#image: $hashname#" $file
         git add $file
     done

--- a/jenkins/pod-templates/cdt-full-pod-plus-eclipse-install.yaml
+++ b/jenkins/pod-templates/cdt-full-pod-plus-eclipse-install.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
   - name: cdt
-    image: quay.io/eclipse-cdt/cdt-infra-plus-eclipse-install@sha256:7146f40a39f75e364c473aa26044803582428f41f1f911e4b44a8ee8e72f89d1
+    image: quay.io/eclipse-cdt/cdt-infra-plus-eclipse-install@sha256:53be2931e1ce9694033e46784d9b1b841a4399b16f3b0c00bc5f07178d1cb125
     tty: true
     args: ["/bin/sh", "-c", "/home/vnc/.vnc/xstartup.sh && cat"]
     resources:

--- a/jenkins/pod-templates/cdt-full-pod-plus-eclipse-install.yaml
+++ b/jenkins/pod-templates/cdt-full-pod-plus-eclipse-install.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
   - name: cdt
-    image: quay.io/eclipse-cdt/cdt-infra-plus-eclipse-install@sha256:53be2931e1ce9694033e46784d9b1b841a4399b16f3b0c00bc5f07178d1cb125
+    image: quay.io/eclipse-cdt/cdt-infra-plus-eclipse-install@sha256:34d46fc15cdade4f103d3f1043c48441d41b532545e6b9083c17f5db0175bbab
     tty: true
     args: ["/bin/sh", "-c", "/home/vnc/.vnc/xstartup.sh && cat"]
     resources:

--- a/jenkins/pod-templates/cdt-full-pod-small.yaml
+++ b/jenkins/pod-templates/cdt-full-pod-small.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
   - name: cdt
-    image: quay.io/eclipse-cdt/cdt-infra-eclipse-full@sha256:4ec937663ffab34e0d91aadd0290cbf8af7adc068e11f135c1aa77cdf63d9056
+    image: quay.io/eclipse-cdt/cdt-infra-eclipse-full@sha256:ecde22ac03cfb4dc7c47b8f5e8f72f9e53ac325d3d568f1bd21fc7af76dc9ed0
     tty: true
     args: ["/bin/sh", "-c", "/home/vnc/.vnc/xstartup.sh && cat"]
     resources:

--- a/jenkins/pod-templates/cdt-full-pod-standard.yaml
+++ b/jenkins/pod-templates/cdt-full-pod-standard.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
   - name: cdt
-    image: quay.io/eclipse-cdt/cdt-infra-eclipse-full@sha256:4ec937663ffab34e0d91aadd0290cbf8af7adc068e11f135c1aa77cdf63d9056
+    image: quay.io/eclipse-cdt/cdt-infra-eclipse-full@sha256:ecde22ac03cfb4dc7c47b8f5e8f72f9e53ac325d3d568f1bd21fc7af76dc9ed0
     tty: true
     args: ["/bin/sh", "-c", "/home/vnc/.vnc/xstartup.sh && cat"]
     resources:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `cdt_11_6`:
 - [Use CDT&#x27;s container to run all code cleanliness checks](https://github.com/eclipse-cdt/cdt/pull/845)
 - [Update images to Dockerfiles from commit 46e37c6d22](https://github.com/eclipse-cdt/cdt/pull/845)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)