### PR TITLE
Adds capability to display warnings in LaunchBar Launch Config Dialog

### DIFF
--- a/launchbar/org.eclipse.launchbar.ui.tests/plugin.xml
+++ b/launchbar/org.eclipse.launchbar.ui.tests/plugin.xml
@@ -12,6 +12,15 @@
                after="org.eclipse.debug.ui.prototypeTab">
          </placement>
       </tab>
+      <!-- Test for Launch Bar Launch Configuration Warnings -->
+      <tab
+            class="org.eclipse.launchbar.ui.tests.internal.WarningLaunchConfigTab"
+            group="org.eclipse.pde.ui.launcher.WorkbenchLauncherTabGroup"
+            id="org.eclipse.launchbar.ui.tests.internal.WarningLaunchConfigTab"
+            name="Warning Tab">
+         <placement
+               after="my.custom.tab">
+         </placement>
+      </tab>
    </extension>
-
 </plugin>

--- a/launchbar/org.eclipse.launchbar.ui.tests/src/org/eclipse/launchbar/ui/tests/internal/CreateLaunchConfigTests.java
+++ b/launchbar/org.eclipse.launchbar.ui.tests/src/org/eclipse/launchbar/ui/tests/internal/CreateLaunchConfigTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 QNX Software Systems and others.
+ * Copyright (c) 2017, 2024 QNX Software Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,9 +11,11 @@
 package org.eclipse.launchbar.ui.tests.internal;
 
 import static org.eclipse.swtbot.eclipse.finder.matchers.WidgetMatcherFactory.withPartName;
+import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.widgetOfType;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.DebugPlugin;
@@ -24,6 +26,7 @@ import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.launchbar.ui.tests.SWTBotConfigSelector;
 import org.eclipse.launchbar.ui.tests.SWTBotConfigSelector.EditConfigDialog;
 import org.eclipse.launchbar.ui.tests.SWTBotConfigSelector.NewConfigDialog;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.SWTBot;
@@ -136,6 +139,104 @@ public class CreateLaunchConfigTests {
 			@Override
 			public String getFailureMessage() {
 				return "Unable to edit test config";
+			}
+		});
+	}
+
+	/**
+	 * Tests that when a new Launch Configuration is created, using the Launch Bar, it displays a
+	 * warning icon/message in the message area.
+	 * @see {@link WarningLaunchConfigTab}
+	 * @see {@code org.eclipse.launchbar.ui.tests/plugin.xml}
+	 */
+	@Test
+	@Timeout(value = 2, unit = TimeUnit.MINUTES)
+	public void createNewLaunchConfigWithWarning() throws Exception {
+		// Test message. Needs to be effectively final.
+		AtomicReference<String> warningMessage = new AtomicReference<>();
+
+		// Create config with launchbar
+		bot.waitUntil(new ICondition() {
+			@Override
+			public void init(SWTBot bot) {
+				/*
+				 * Use the Launch Bar new Launch Config and create an Eclipse Application Launch Config.
+				 * This will include a WarningLaunchConfigTab tab which has a warning set in it.
+				 */
+				NewConfigDialog dialog = new SWTBotConfigSelector(bot).newConfigDialog();
+				dialog.setMode("Debug").setType("Eclipse Application").next();
+
+				// Select the warning tab, which sets the Launch Config message area to contain a warning.
+				dialog.bot().cTabItem(WarningLaunchConfigTab.TAB_NAME).activate();
+
+				// Get the Launch Config message area and stash the warning message for testing later
+				int indexOfErrorLabel = dialog.bot().widgets(widgetOfType(Text.class)).size() - 1;
+				warningMessage.set(dialog.bot().text(indexOfErrorLabel).getText());
+
+				dialog.finish();
+			}
+
+			@Override
+			public boolean test() throws Exception {
+				// The expected value has a space prefixed to account for an added space for the warning icon.
+				return warningMessage.get() != null
+						&& warningMessage.get().equals(" " + WarningLaunchConfigTab.WARNING_MESSAGE);
+			}
+
+			@Override
+			public String getFailureMessage() {
+				return String.format("Incorrect warning message; expected=%s, actual=%s",
+						WarningLaunchConfigTab.WARNING_MESSAGE, warningMessage.get());
+			}
+		});
+	}
+
+	/**
+	 * Tests that when editing an existing Launch Configuration, using the Launch Bar, it displays a
+	 * warning icon/message in the message area.
+	 * @see {@link WarningLaunchConfigTab}
+	 * @see {@code org.eclipse.launchbar.ui.tests/plugin.xml}
+	 */
+	@Test
+	@Timeout(value = 2, unit = TimeUnit.MINUTES)
+	public void editExistingLaunchConfigWithWarning() throws Exception {
+		// Test message. Needs to be effectively final.
+		AtomicReference<String> warningMessage = new AtomicReference<>();
+
+		// Create a launch config to edit (well to view)
+		ILaunchConfigurationType type = DebugPlugin.getDefault().getLaunchManager()
+				.getLaunchConfigurationType("org.eclipse.pde.ui.RuntimeWorkbench");
+		ILaunchConfigurationWorkingCopy wc = type.newInstance(null, "Test Config 2");
+		wc.doSave();
+
+		// Edit config with launchbar
+		bot.waitUntil(new ICondition() {
+			@Override
+			public void init(SWTBot bot) {
+				// Open the launch config created above using the launch bar
+				EditConfigDialog dialog = new SWTBotConfigSelector(bot).editConfigDialog();
+
+				// Select the warning tab, which sets the Launch Config message area to contain a warning.
+				dialog.selectTab(WarningLaunchConfigTab.TAB_NAME);
+
+				// Get the Launch Config message area and stash the warning message for testing later
+				int indexOfErrorLabel = dialog.bot().widgets(widgetOfType(Text.class)).size() - 1;
+				warningMessage.set(dialog.bot().text(indexOfErrorLabel).getText());
+
+				dialog.ok();
+			}
+
+			@Override
+			public boolean test() throws Exception {
+				// The expected value has a space prefixed to account for an added space for the warning icon.
+				return warningMessage.get() != null
+						&& warningMessage.get().equals(" " + WarningLaunchConfigTab.WARNING_MESSAGE);
+			}
+
+			@Override
+			public String getFailureMessage() {
+				return String.format("Incorrect warning message; expected=%s, actual=%s",
+						WarningLaunchConfigTab.WARNING_MESSAGE, warningMessage.get());
 			}
 		});
 	}

--- a/launchbar/org.eclipse.launchbar.ui.tests/src/org/eclipse/launchbar/ui/tests/internal/WarningLaunchConfigTab.java
+++ b/launchbar/org.eclipse.launchbar.ui.tests/src/org/eclipse/launchbar/ui/tests/internal/WarningLaunchConfigTab.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Renesas Electronics Europe and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.launchbar.ui.tests.internal;
+
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.ui.AbstractLaunchConfigurationTab;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.RowLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+
+/**
+ * Creates a tab to test that the Launch Configuration, when opened via the Launch Bar,
+ * displays a warning in the message area.
+ * @see {@link CreateLaunchConfigTests}
+ */
+public class WarningLaunchConfigTab extends AbstractLaunchConfigurationTab {
+	public static final String WARNING_MESSAGE = "This is a warning";
+	public static final String TAB_NAME = "Warning Tab";
+
+	@Override
+	public void createControl(Composite parent) {
+		parent.setLayout(new RowLayout());
+		Label label = new Label(parent, SWT.NONE);
+		label.setText("The Launch Configuration message area should show a warning message!");
+		setControl(label);
+	}
+
+	@Override
+	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
+	}
+
+	@Override
+	public void initializeFrom(ILaunchConfiguration configuration) {
+	}
+
+	@Override
+	public void performApply(ILaunchConfigurationWorkingCopy configuration) {
+	}
+
+	@Override
+	public String getName() {
+		return TAB_NAME;
+	}
+
+	@Override
+	public String getId() {
+		return "org.eclipse.launchbar.ui.tests.internal.WarningLaunchConfigTab";
+	}
+
+	@Override
+	public boolean isValid(ILaunchConfiguration launchConfig) {
+		setWarningMessage(WARNING_MESSAGE);
+		return true;
+	}
+}

--- a/launchbar/org.eclipse.launchbar.ui/META-INF/MANIFEST.MF
+++ b/launchbar/org.eclipse.launchbar.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.launchbar.ui;singleton:=true
-Bundle-Version: 2.5.400.qualifier
+Bundle-Version: 2.5.500.qualifier
 Bundle-Activator: org.eclipse.launchbar.ui.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/launchbar/org.eclipse.launchbar.ui/src/org/eclipse/launchbar/ui/internal/LaunchBarLaunchConfigDialog.java
+++ b/launchbar/org.eclipse.launchbar.ui/src/org/eclipse/launchbar/ui/internal/LaunchBarLaunchConfigDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 QNX Software Systems and others.
+ * Copyright (c) 2016, 2024 QNX Software Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.ILaunchMode;
 import org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationPresentationManager;
 import org.eclipse.debug.ui.ILaunchConfigurationTab;
+import org.eclipse.debug.ui.ILaunchConfigurationTab2;
 import org.eclipse.debug.ui.ILaunchConfigurationTabGroup;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IMessageProvider;
@@ -163,6 +164,7 @@ public class LaunchBarLaunchConfigDialog extends TitleAreaDialog implements ILau
 				newTab.activated(workingCopy);
 
 				selItem.getControl().setFocus();
+				updateMessage();
 			}
 		});
 
@@ -386,6 +388,29 @@ public class LaunchBarLaunchConfigDialog extends TitleAreaDialog implements ILau
 		return null;
 	}
 
+	/**
+	 * Returns the current warning message or <code>null</code> if none.
+	 * @return Returns an appropriate warning message for display to user. The message returned will be:
+	 * The warning message defined by the visible tab or <code>null</code> if no message is defined.
+	 * Copied from LaunchConfigurationTabGroupViewer#getWarningMessage().
+	 */
+	private String getWarningMessage() {
+		if (initing) {
+			return null;
+		}
+		String message = null;
+
+		ILaunchConfigurationTab tab = getActiveTab();
+		if (tab instanceof ILaunchConfigurationTab2 confTab) {
+			String tabMessage = confTab.getWarningMessage();
+			if (tabMessage != null) {
+				message = tabMessage;
+			}
+		}
+
+		return message;
+	}
+
 	private String getTabsMessage() {
 		ILaunchConfigurationTab activeTab = getActiveTab();
 		if (activeTab != null) {
@@ -448,6 +473,12 @@ public class LaunchBarLaunchConfigDialog extends TitleAreaDialog implements ILau
 		if (message != null) {
 			setMessage(message, IMessageProvider.ERROR);
 			okButton.setEnabled(false);
+			return;
+		}
+
+		message = getWarningMessage();
+		if (message != null) {
+			setMessage(message, IMessageProvider.WARNING);
 			return;
 		}
 

--- a/launchbar/org.eclipse.launchbar.ui/src/org/eclipse/launchbar/ui/internal/dialogs/NewLaunchConfigEditPage.java
+++ b/launchbar/org.eclipse.launchbar.ui/src/org/eclipse/launchbar/ui/internal/dialogs/NewLaunchConfigEditPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 QNX Software Systems and others.
+ * Copyright (c) 2014, 2024 QNX Software Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -206,6 +206,12 @@ public class NewLaunchConfigEditPage extends WizardPage implements IPageChanging
 		@Override
 		public ILaunchConfigurationWorkingCopy getWorkingCopy() {
 			return super.getWorkingCopy();
+		}
+
+		@Override
+		protected void handleTabSelected() {
+			super.handleTabSelected();
+			setMessage(getWarningMessage(), WARNING);
 		}
 	}
 


### PR DESCRIPTION
Add SWTBot to test that the Launch Configuration, when opened via the Launch Bar, displays a warning in the message area.

The launch config warnings functionality offered by [1] is now available to users of the Launch Bar.

[1] https://github.com/eclipse-platform/eclipse.platform/commit/231ef131428719fb986eaa67511186dd9ec341fb 