### PR TITLE
Allow multiple parserPage XML elements

### DIFF
--- a/core/org.eclipse.cdt.ui/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.ui; singleton:=true
-Bundle-Version: 8.1.500.qualifier
+Bundle-Version: 8.1.600.qualifier
 Bundle-Activator: org.eclipse.cdt.ui.CUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.ui/schema/BinaryParserPage.exsd
+++ b/core/org.eclipse.cdt.ui/schema/BinaryParserPage.exsd
@@ -18,7 +18,7 @@
       </annotation>
       <complexType>
          <sequence>
-            <element ref="parserPage"/>
+            <element ref="parserPage" minOccurs="1" maxOccurs="unbounded"/>
          </sequence>
          <attribute name="point" type="string" use="required">
             <annotation>


### PR DESCRIPTION
Eliminates warning on `org.eclipse.cdt.ui/plugin.xml`