### PR TITLE
__DATE__ should have day prefixed with space

### DIFF
--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/parser/scanner/DateMacro.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/parser/scanner/DateMacro.java
@@ -16,6 +16,7 @@ package org.eclipse.cdt.internal.core.parser.scanner;
 
 import java.text.DateFormatSymbols;
 import java.util.Calendar;
+import java.util.Locale;
 
 import org.eclipse.cdt.core.parser.IToken;
 
@@ -33,7 +34,7 @@ public final class DateMacro extends DynamicMacro {
 		char[] charArray;
 		StringBuilder buffer = new StringBuilder("\""); //$NON-NLS-1$
 		Calendar cal = Calendar.getInstance();
-		DateFormatSymbols dfs = new DateFormatSymbols();
+		DateFormatSymbols dfs = new DateFormatSymbols(Locale.ENGLISH);
 		buffer.append(dfs.getShortMonths()[cal.get(Calendar.MONTH)]);
 		buffer.append(" "); //$NON-NLS-1$
 		int dom = cal.get(Calendar.DAY_OF_MONTH);

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/parser/scanner/DateMacro.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/parser/scanner/DateMacro.java
@@ -36,7 +36,11 @@ public final class DateMacro extends DynamicMacro {
 		DateFormatSymbols dfs = new DateFormatSymbols();
 		buffer.append(dfs.getShortMonths()[cal.get(Calendar.MONTH)]);
 		buffer.append(" "); //$NON-NLS-1$
-		append(buffer, cal.get(Calendar.DAY_OF_MONTH));
+		int dom = cal.get(Calendar.DAY_OF_MONTH);
+		if (dom < 10) {
+			buffer.append(" "); //$NON-NLS-1$
+		}
+		buffer.append(dom);
 		buffer.append(" "); //$NON-NLS-1$
 		buffer.append(cal.get(Calendar.YEAR));
 		buffer.append("\""); //$NON-NLS-1$


### PR DESCRIPTION
The documentation for GCC, and other compilers, stipulates that `__DATE__` with a day of month less than 10 should be prefixed by a space, not a zero.

Contributed by STMicroelectronics