### PR TITLE
Support environment variables in Core Build projects for Local

### DIFF
--- a/debug/org.eclipse.cdt.debug.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.cdt.debug.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.core; singleton:=true
-Bundle-Version: 8.8.500.qualifier
+Bundle-Version: 8.8.600.qualifier
 Bundle-Activator: org.eclipse.cdt.debug.core.CDebugCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/internal/core/launch/CoreBuildLocalRunLaunchDelegate.java
+++ b/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/internal/core/launch/CoreBuildLocalRunLaunchDelegate.java
@@ -15,7 +15,9 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.cdt.core.build.ICBuildConfiguration;
 import org.eclipse.cdt.core.model.IBinary;
@@ -32,6 +34,7 @@ import org.eclipse.core.variables.VariablesPlugin;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.core.target.launch.ITargetedLaunch;
 
@@ -65,7 +68,15 @@ public class CoreBuildLocalRunLaunchDelegate extends CoreBuildLaunchConfigDelega
 				builder.directory(new File(workingDirectory));
 			}
 
-			buildConfig.setBuildEnvironment(builder.environment());
+			Map<String, String> environment = builder.environment();
+			Map<String, String> launchEnvironment = configuration
+					.getAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, new HashMap<>());
+			if (!configuration.getAttribute(ILaunchManager.ATTR_APPEND_ENVIRONMENT_VARIABLES, true)) {
+				environment.clear();
+			}
+			environment.putAll(launchEnvironment);
+
+			buildConfig.setBuildEnvironment(environment);
 			Process process = builder.start();
 			DebugPlugin.newProcess(launch, process, exeFile.getPath().lastSegment());
 		} catch (IOException e) {

--- a/launch/org.eclipse.cdt.launch/META-INF/MANIFEST.MF
+++ b/launch/org.eclipse.cdt.launch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.launch; singleton:=true
-Bundle-Version: 10.4.500.qualifier
+Bundle-Version: 10.4.600.qualifier
 Bundle-Activator: org.eclipse.cdt.launch.internal.ui.LaunchUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/internal/corebuild/LocalLaunchConfigurationTabGroup.java
+++ b/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/internal/corebuild/LocalLaunchConfigurationTabGroup.java
@@ -14,6 +14,7 @@ import org.eclipse.cdt.launch.ui.CArgumentsTab;
 import org.eclipse.cdt.launch.ui.corebuild.CoreBuildMainTab;
 import org.eclipse.cdt.launch.ui.corebuild.CoreBuildTab;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
+import org.eclipse.debug.ui.EnvironmentTab;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.debug.ui.ILaunchConfigurationTab;
 
@@ -24,8 +25,9 @@ public class LocalLaunchConfigurationTabGroup extends AbstractLaunchConfiguratio
 		ILaunchConfigurationTab mainTab = new CoreBuildMainTab();
 		ILaunchConfigurationTab buildTab = new CoreBuildTab();
 		ILaunchConfigurationTab argumentsTab = new CArgumentsTab();
+		ILaunchConfigurationTab environmentTab = new EnvironmentTab();
 
-		setTabs(new ILaunchConfigurationTab[] { mainTab, buildTab, argumentsTab });
+		setTabs(new ILaunchConfigurationTab[] { mainTab, buildTab, argumentsTab, environmentTab });
 	}
 
 }


### PR DESCRIPTION
Added an Environment tab to the Core Build launch configurations for the Local target. Similar as the standard C/C++ Application launch configurations for Managed Build.