### PR TITLE
Add a version of Dockerfiles with node included for cdt-gdb-adapter

### DIFF
--- a/docker/build-images.sh
+++ b/docker/build-images.sh
@@ -15,3 +15,4 @@ docker build --rm -f cdt-infra-all-gdbs/ubuntu-18.04/Dockerfile -t cdt-infra-all
 docker build --rm -f cdt-infra-eclipse-full/ubuntu-18.04/Dockerfile -t cdt-infra-eclipse-full:ubuntu-18.04 .
 docker build --rm -f cdt-infra-plus-eclipse-install/ubuntu-18.04/Dockerfile -t cdt-infra-plus-eclipse-install:ubuntu-18.04 .
 docker build --rm -f cdt-infra-plus-eclipse-install-github/ubuntu-18.04/Dockerfile -t cdt-infra-plus-eclipse-install-github:ubuntu-18.04 .
+docker build --rm -f cdt-infra-plus-node/ubuntu-18.04/Dockerfile -t cdt-infra-plus-node:ubuntu-18.04 .

--- a/docker/cdt-infra-plus-node/Readme.md
+++ b/docker/cdt-infra-plus-node/Readme.md
@@ -1,0 +1,2 @@
+This directory contains a convenience for the Eclipse CDT Cloud's cdt-gdb-adapter project that exists
+for historical reasons. See this reference https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/blob/main/src/integration-tests/README.md#running-the-tests-using-docker

--- a/docker/cdt-infra-plus-node/ubuntu-18.04/Dockerfile
+++ b/docker/cdt-infra-plus-node/ubuntu-18.04/Dockerfile
@@ -1,0 +1,21 @@
+FROM cdt-infra-eclipse-full:ubuntu-18.04
+USER root
+
+#Node
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*  \
+    && npm install -g yarn
+
+# socat needed for some cdt-gdb-adapter tests
+RUN apt-get update && apt-get install -y socat && rm -rf /var/lib/apt/lists/*
+
+#Fix permissions for OpenShift & standard k8s
+RUN chown -R 1000:0 ${HOME} \
+  && chmod -R g+rwX ${HOME}
+
+ENV USER_NAME vnc
+USER 1000
+WORKDIR ${HOME}
+
+CMD ["bash"]

--- a/docker/deploy-images.sh
+++ b/docker/deploy-images.sh
@@ -11,7 +11,7 @@ namespace=${1:-quay.io/eclipse-cdt}
 shorthash=$(git rev-parse --short HEAD)
 toplevel=$(git rev-parse --show-toplevel)
 
-images="cdt-infra-eclipse-full:ubuntu-18.04 cdt-infra-plus-eclipse-install:ubuntu-18.04 cdt-infra-plus-eclipse-install-github:ubuntu-18.04"
+images="cdt-infra-eclipse-full:ubuntu-18.04 cdt-infra-plus-eclipse-install:ubuntu-18.04 cdt-infra-plus-eclipse-install-github:ubuntu-18.04 cdt-infra-plus-node:ubuntu-18.04"
 
 $toplevel/docker/build-images.sh
 


### PR DESCRIPTION
This is a convenience for our sister project, eclipse-cdt-cloud, that are relying on CDT's infrastructure to do some testing.

See https://github.com/eclipse-cdt-cloud/cdt-gdb-adapter/blob/main/src/integration-tests/README.md#running-the-tests-using-docker