### PR TITLE
fix(908): fix for the cmake tool chain removal function.

### DIFF
--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeToolChainManager.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeToolChainManager.java
@@ -166,10 +166,8 @@ public class CMakeToolChainManager implements ICMakeToolChainManager {
 				tcNode.removeNode();
 				prefs.flush();
 			}
-		} catch (CoreException ce) {
-			Activator.log(ce);
-		} catch (BackingStoreException be) {
-			Activator.log(be);
+		} catch (CoreException | BackingStoreException e) {
+			Activator.log(e);
 		}
 	}
 

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeToolChainManager.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeToolChainManager.java
@@ -156,20 +156,18 @@ public class CMakeToolChainManager implements ICMakeToolChainManager {
 	public void removeToolChainFile(ICMakeToolChainFile file) {
 		init();
 		fireEvent(new CMakeToolChainEvent(CMakeToolChainEvent.REMOVED, file));
-		String tcId = makeToolChainId(file.getProperty(CMakeBuildConfiguration.TOOLCHAIN_TYPE),
-				file.getProperty(CMakeBuildConfiguration.TOOLCHAIN_ID));
-		filesByToolChain.remove(tcId);
-
-		String n = ((CMakeToolChainFile) file).n;
-		if (n != null) {
-			Preferences prefs = getPreferences();
-			Preferences tcNode = prefs.node(n);
-			try {
+		try {
+			String tcId = makeToolChainId(file.getToolChain());
+			filesByToolChain.remove(tcId);
+			String n = ((CMakeToolChainFile) file).n;
+			if (n != null) {
+				Preferences prefs = getPreferences();
+				Preferences tcNode = prefs.node(n);
 				tcNode.removeNode();
 				prefs.flush();
-			} catch (BackingStoreException e) {
-				Activator.log(e);
 			}
+		} catch (Exception e) {
+			Activator.log(e);
 		}
 	}
 

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeToolChainManager.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeToolChainManager.java
@@ -166,8 +166,10 @@ public class CMakeToolChainManager implements ICMakeToolChainManager {
 				tcNode.removeNode();
 				prefs.flush();
 			}
-		} catch (Exception e) {
-			Activator.log(e);
+		} catch (CoreException ce) {
+			Activator.log(ce);
+		} catch (BackingStoreException be) {
+			Activator.log(be);
 		}
 	}
 


### PR DESCRIPTION
The calculated ID in the removal function is different than the one in the add

[Original reported issue](https://github.com/eclipse-cdt/cdt/issues/908)