### PR TITLE
Switch from javax to jakarta

### DIFF
--- a/launchbar/org.eclipse.launchbar.ui.controls/META-INF/MANIFEST.MF
+++ b/launchbar/org.eclipse.launchbar.ui.controls/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.launchbar.ui.controls;singleton:=true
-Bundle-Version: 1.2.400.qualifier
+Bundle-Version: 1.2.500.qualifier
 Bundle-Activator: org.eclipse.launchbar.ui.controls.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,
@@ -15,8 +15,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.debug.ui;bundle-version="3.11.200",
  org.eclipse.launchbar.core;bundle-version="2.0.0",
  org.eclipse.launchbar.ui;bundle-version="2.0.0"
-Import-Package: javax.annotation,
- javax.inject,
+Import-Package: jakarta.annotation,
+ jakarta.inject,
  org.osgi.service.event;version="1.4.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/launchbar/org.eclipse.launchbar.ui.controls/src/org/eclipse/launchbar/ui/controls/internal/LaunchBarControl.java
+++ b/launchbar/org.eclipse.launchbar.ui.controls/src/org/eclipse/launchbar/ui/controls/internal/LaunchBarControl.java
@@ -15,9 +15,6 @@
  *******************************************************************************/
 package org.eclipse.launchbar.ui.controls.internal;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.runtime.CoreException;
@@ -43,6 +40,9 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 
 public class LaunchBarControl implements ILaunchBarListener {
 	public static final String ID = "org.eclipse.launchbar"; //$NON-NLS-1$

--- a/launchbar/org.eclipse.launchbar.ui.controls/src/org/eclipse/launchbar/ui/controls/internal/LaunchBarInjector.java
+++ b/launchbar/org.eclipse.launchbar.ui.controls/src/org/eclipse/launchbar/ui/controls/internal/LaunchBarInjector.java
@@ -15,8 +15,6 @@
  *******************************************************************************/
 package org.eclipse.launchbar.ui.controls.internal;
 
-import javax.inject.Inject;
-
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.services.events.IEventBroker;
 import org.eclipse.e4.ui.model.application.MApplication;
@@ -30,6 +28,8 @@ import org.eclipse.e4.ui.model.application.ui.menu.MToolControl;
 import org.eclipse.e4.ui.workbench.UIEvents;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.widgets.Widget;
+
+import jakarta.inject.Inject;
 
 public class LaunchBarInjector {
 


### PR DESCRIPTION
This is to do CDT's part in resolving this warning at startup:

```
WARNING: Annotation classes from the 'javax.inject' or 'javax.annotation' package found.
It is recommended to migrate to the corresponding replacements in the jakarta namespace.
The Eclipse E4 Platform will remove support for those javax-annotations in a future release.
To suppress this warning, set the VM property: -Declipse.e4.inject.javax.warning=false
To disable processing of 'javax' annotations entirely, set the VM property: -Declipse.e4.inject.javax.disabled=true
```