### PR TITLE
Use org.eclipse.cdt.debug.ui.debugging context bindings for Visualizer and Executables Views.

### DIFF
--- a/debug/org.eclipse.cdt.debug.ui/plugin.xml
+++ b/debug/org.eclipse.cdt.debug.ui/plugin.xml
@@ -226,11 +226,6 @@
          <viewShortcut
                id="org.eclipse.ui.views.ProblemView">
          </viewShortcut>
-         <view
-               id="org.eclipse.cdt.debug.ui.executablesView"
-               relative="org.eclipse.ui.console.ConsoleView"
-               relationship="stack">
-         </view>
          <viewShortcut
                id="org.eclipse.cdt.debug.ui.executablesView">
          </viewShortcut>
@@ -963,8 +958,8 @@
          point="org.eclipse.debug.ui.contextViewBindings">
       <contextViewBinding
             viewId="org.eclipse.debug.ui.MemoryView"
-            contextId="org.eclipse.cdt.debug.ui.debugging">
-      </contextViewBinding>
+            contextId="org.eclipse.cdt.debug.ui.debugging"
+            autoClose="false"/>
       <contextViewBinding
             autoOpen="false"
             contextId="org.eclipse.cdt.debug.ui.debugging"
@@ -982,6 +977,10 @@
            contextId="org.eclipse.cdt.debug.ui.debugging"
            viewId="org.eclipse.cdt.debug.ui.debuggerConsoleView"
            autoClose="false"/>
+     <contextViewBinding
+           contextId="org.eclipse.cdt.debug.ui.debugging"
+           viewId="org.eclipse.cdt.debug.ui.executablesView"
+           autoClose="false"/>     
    </extension>
    <extension
          point="org.eclipse.ui.editors.annotationTypes">

--- a/visualizer/org.eclipse.cdt.visualizer.ui/META-INF/MANIFEST.MF
+++ b/visualizer/org.eclipse.cdt.visualizer.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.eclipse.cdt.visualizer.ui;singleton:=true
-Bundle-Version: 1.5.200.qualifier
+Bundle-Version: 1.5.300.qualifier
 Bundle-Activator: org.eclipse.cdt.visualizer.ui.plugin.CDTVisualizerUIPlugin
 Bundle-Vendor: %provider.name
 Require-Bundle: org.eclipse.ui,

--- a/visualizer/org.eclipse.cdt.visualizer.ui/plugin.xml
+++ b/visualizer/org.eclipse.cdt.visualizer.ui/plugin.xml
@@ -27,15 +27,16 @@
             targetID="org.eclipse.debug.ui.DebugPerspective">
             
          <!-- add Visualizer View in same "slot" as outline view -->
-         <view
-               relative="org.eclipse.ui.views.ContentOutline"
-               visible="true"
-               relationship="stack"
-               id="org.eclipse.cdt.visualizer.view">
-         </view>
          <viewShortcut
                id="org.eclipse.cdt.visualizer.view">
          </viewShortcut>
       </perspectiveExtension>
+   </extension>
+   <extension
+         point="org.eclipse.debug.ui.contextViewBindings">
+     <contextViewBinding
+           contextId="org.eclipse.cdt.debug.ui.debugging"
+           viewId="org.eclipse.cdt.visualizer.view"
+           autoClose="false"/>     
    </extension>
 </plugin>


### PR DESCRIPTION
Similar to Memory View and Debug Console View, We can use org.eclipse.cdt.debug.ui.debugging for Visualizer and Executables Views

see https://github.com/eclipse-cdt/cdt/issues/918