### PR TITLE
Update Main Tab for Core Build local launch configurations.

### DIFF
--- a/debug/org.eclipse.cdt.debug.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.cdt.debug.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.core; singleton:=true
-Bundle-Version: 8.8.600.qualifier
+Bundle-Version: 8.8.700.qualifier
 Bundle-Activator: org.eclipse.cdt.debug.core.CDebugCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/internal/core/launch/CoreBuildLocalLaunchConfigProvider.java
+++ b/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/internal/core/launch/CoreBuildLocalLaunchConfigProvider.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
@@ -66,6 +67,10 @@ public class CoreBuildLocalLaunchConfigProvider extends AbstractLaunchConfigProv
 
 		// Set the project and the connection
 		IProject project = descriptor.getAdapter(IProject.class);
+		// CMainTab2 expects these attributes when calling CLaunchConfigurationTab.getContext()
+		// Using empty string for default Core Build program.
+		workingCopy.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, project.getName());
+		workingCopy.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, ""); //$NON-NLS-1$
 		workingCopy.setMappedResources(new IResource[] { project });
 	}
 

--- a/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/internal/core/launch/CoreBuildLocalRunLaunchDelegate.java
+++ b/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/internal/core/launch/CoreBuildLocalRunLaunchDelegate.java
@@ -12,7 +12,6 @@ package org.eclipse.cdt.debug.internal.core.launch;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -55,7 +54,7 @@ public class CoreBuildLocalRunLaunchDelegate extends CoreBuildLaunchConfigDelega
 
 			String[] arguments = CommandLineUtil.argumentsToArray(args);
 			List<String> command = new ArrayList<>(1 + arguments.length);
-			command.add(Paths.get(exeFile.getLocationURI()).toString());
+			command.add(getProgramPath(configuration, exeFile));
 			command.addAll(Arrays.asList(arguments));
 
 			ProcessBuilder builder = new ProcessBuilder(command);

--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/META-INF/MANIFEST.MF
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.cdt.dsf.gdb;singleton:=true
-Bundle-Version: 7.1.300.qualifier
+Bundle-Version: 7.1.400.qualifier
 Bundle-Activator: org.eclipse.cdt.dsf.gdb.internal.GdbPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/internal/launching/CoreBuildLocalDebugLaunchDelegate.java
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/internal/launching/CoreBuildLocalDebugLaunchDelegate.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ExecutionException;
 
 import org.eclipse.cdt.core.build.ICBuildConfiguration;
 import org.eclipse.cdt.core.build.IToolChain;
+import org.eclipse.cdt.core.model.IBinary;
 import org.eclipse.cdt.debug.core.launch.CoreBuildLaunchConfigDelegate;
 import org.eclipse.cdt.dsf.concurrent.DataRequestMonitor;
 import org.eclipse.cdt.dsf.concurrent.ImmediateExecutor;
@@ -86,8 +87,8 @@ public class CoreBuildLocalDebugLaunchDelegate extends CoreBuildLaunchConfigDele
 		gdbLaunch.setGDBPath(gdbPath != null ? gdbPath.toString() : "gdb"); //$NON-NLS-1$
 		String gdbVersion = gdbLaunch.getGDBVersion();
 
-		Path exeFile = Paths.get(getBinary(buildConfig).getLocationURI());
-		gdbLaunch.setProgramPath(exeFile.toString());
+		IBinary exeFile = getBinary(buildConfig);
+		gdbLaunch.setProgramPath(getProgramPath(configuration, exeFile));
 
 		gdbLaunch.setServiceFactory(new GdbDebugServicesFactory(gdbVersion, configuration));
 

--- a/launch/org.eclipse.cdt.launch/META-INF/MANIFEST.MF
+++ b/launch/org.eclipse.cdt.launch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.launch; singleton:=true
-Bundle-Version: 10.4.600.qualifier
+Bundle-Version: 10.4.700.qualifier
 Bundle-Activator: org.eclipse.cdt.launch.internal.ui.LaunchUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/internal/corebuild/LocalLaunchConfigurationTabGroup.java
+++ b/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/internal/corebuild/LocalLaunchConfigurationTabGroup.java
@@ -11,7 +11,7 @@
 package org.eclipse.cdt.launch.internal.corebuild;
 
 import org.eclipse.cdt.launch.ui.CArgumentsTab;
-import org.eclipse.cdt.launch.ui.corebuild.CoreBuildMainTab;
+import org.eclipse.cdt.launch.ui.corebuild.CoreBuildMainTab2;
 import org.eclipse.cdt.launch.ui.corebuild.CoreBuildTab;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
 import org.eclipse.debug.ui.EnvironmentTab;
@@ -22,7 +22,7 @@ public class LocalLaunchConfigurationTabGroup extends AbstractLaunchConfiguratio
 
 	@Override
 	public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
-		ILaunchConfigurationTab mainTab = new CoreBuildMainTab();
+		ILaunchConfigurationTab mainTab = new CoreBuildMainTab2();
 		ILaunchConfigurationTab buildTab = new CoreBuildTab();
 		ILaunchConfigurationTab argumentsTab = new CArgumentsTab();
 		ILaunchConfigurationTab environmentTab = new EnvironmentTab();

--- a/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/internal/ui/LaunchMessages.java
+++ b/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/internal/ui/LaunchMessages.java
@@ -52,6 +52,7 @@ public class LaunchMessages extends NLS {
 	public static String CommonBuildTab_Default;
 	public static String CommonBuildTab_NotFound;
 	public static String CommonBuildTab_Toolchain;
+	public static String CoreBuildMainTab_Keep_empty_for_auto_selection;
 	public static String CoreBuildTab_Build;
 	public static String CoreBuildTab_NoOptions;
 	public static String CoreFileLaunchDelegate_Launching_postmortem_debugger;

--- a/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/internal/ui/LaunchMessages.properties
+++ b/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/internal/ui/LaunchMessages.properties
@@ -55,6 +55,7 @@ LocalAttachLaunchDelegate_CDT_Launch_Error=CDT Launch Error
 CommonBuildTab_Default=Default (%s)
 CommonBuildTab_NotFound=No suitable toolchains found
 CommonBuildTab_Toolchain=Toolchain
+CoreBuildMainTab_Keep_empty_for_auto_selection=keep empty for automatic selection
 CoreBuildTab_Build=Build Settings
 CoreBuildTab_NoOptions=No build options required.
 CoreFileLaunchDelegate_Launching_postmortem_debugger=Launching postmortem debugger

--- a/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/ui/CMainTab2.java
+++ b/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/ui/CMainTab2.java
@@ -93,7 +93,7 @@ public class CMainTab2 extends CAbstractMainTab {
 	 */
 	protected Combo fCoreTypeCombo;
 
-	private boolean fDontCheckProgram;
+	private boolean fDontCheckProgram = false;
 	private final boolean fSpecifyCoreFile;
 	private final boolean fIncludeBuildSettings;
 

--- a/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/ui/CMainTab2.java
+++ b/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/ui/CMainTab2.java
@@ -93,7 +93,7 @@ public class CMainTab2 extends CAbstractMainTab {
 	 */
 	protected Combo fCoreTypeCombo;
 
-	private final boolean fDontCheckProgram;
+	private boolean fDontCheckProgram;
 	private final boolean fSpecifyCoreFile;
 	private final boolean fIncludeBuildSettings;
 
@@ -109,6 +109,13 @@ public class CMainTab2 extends CAbstractMainTab {
 		fDontCheckProgram = (flags & DONT_CHECK_PROGRAM) != 0;
 		fSpecifyCoreFile = (flags & SPECIFY_CORE_FILE) != 0;
 		fIncludeBuildSettings = (flags & INCLUDE_BUILD_SETTINGS) != 0;
+	}
+
+	/**
+	 * @since 10.4
+	 */
+	protected void setDontCheckProgram(boolean dontCheck) {
+		fDontCheckProgram = dontCheck;
 	}
 
 	@Override

--- a/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/ui/corebuild/CoreBuildMainTab.java
+++ b/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/ui/corebuild/CoreBuildMainTab.java
@@ -10,73 +10,51 @@
  *******************************************************************************/
 package org.eclipse.cdt.launch.ui.corebuild;
 
-import org.eclipse.cdt.launch.internal.ui.LaunchUIPlugin;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.runtime.CoreException;
+import org.eclipse.cdt.launch.internal.ui.LaunchMessages;
+import org.eclipse.cdt.launch.ui.CMainTab2;
 import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
-import org.eclipse.debug.ui.AbstractLaunchConfigurationTab;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Text;
 
 /**
  * @since 9.1
  */
-public class CoreBuildMainTab extends AbstractLaunchConfigurationTab {
+public class CoreBuildMainTab extends CMainTab2 {
 
-	private Text projectName;
-
+	/*
+	 * A Core Build launch configuration is created immediately upon the Core Build project creation.
+	 * It cannot be created by hand and it is not duplicatable and can't be renamed.
+	 * The launch configuration is tied to the project. The project name may not be changed.
+	 */
 	@Override
-	public void createControl(Composite parent) {
-		Composite comp = new Composite(parent, SWT.NONE);
-		comp.setLayout(new GridLayout());
-
-		Label label = new Label(comp, SWT.NONE);
-		label.setText("This launch configuration was automatically created.");
-		label.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-
-		label = new Label(comp, SWT.NONE);
-		label.setText("Project:");
-
-		projectName = new Text(comp, SWT.READ_ONLY | SWT.BORDER);
-		projectName.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-
-		setControl(comp);
+	protected void createProjectGroup(Composite parent, int colSpan) {
+		super.createProjectGroup(parent, colSpan);
+		fProjText.setEnabled(false);
+		fProjButton.setVisible(false);
 	}
 
 	@Override
-	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
-		// none
+	protected void createExeFileGroup(Composite parent, int colSpan) {
+		super.createExeFileGroup(parent, colSpan);
+		fProgText.setMessage(LaunchMessages.CoreBuildMainTab_Keep_empty_for_auto_selection);
 	}
 
+	/*
+	 * For Core Build projects the build configuration is hidden and it is selected
+	 * via the LaunchBar Launch Mode. We remove the BuildConfigCombo.
+	 */
 	@Override
-	public void initializeFrom(ILaunchConfiguration configuration) {
-		try {
-			for (IResource resource : configuration.getMappedResources()) {
-				if (resource instanceof IProject) {
-					projectName.setText(resource.getName());
-					break;
-				}
-			}
-		} catch (CoreException e) {
-			LaunchUIPlugin.log(e.getStatus());
-		}
+	protected void createBuildConfigCombo(Composite parent, int colspan) {
+		fBuildConfigCombo = null;
 	}
 
+	/*
+	 * Don't check the program name if it is empty. When the program name is empty the default
+	 * CoreBuild binary is used.
+	 */
 	@Override
-	public void performApply(ILaunchConfigurationWorkingCopy configuration) {
-		// TODO Auto-generated method stub
-
+	public boolean isValid(ILaunchConfiguration config) {
+		String programName = fProgText.getText().trim();
+		setDontCheckProgram(programName.isEmpty());
+		return super.isValid(config);
 	}
-
-	@Override
-	public String getName() {
-		return "Main";
-	}
-
 }

--- a/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/ui/corebuild/CoreBuildMainTab.java
+++ b/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/ui/corebuild/CoreBuildMainTab.java
@@ -10,51 +10,73 @@
  *******************************************************************************/
 package org.eclipse.cdt.launch.ui.corebuild;
 
-import org.eclipse.cdt.launch.internal.ui.LaunchMessages;
-import org.eclipse.cdt.launch.ui.CMainTab2;
+import org.eclipse.cdt.launch.internal.ui.LaunchUIPlugin;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.ui.AbstractLaunchConfigurationTab;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
 
 /**
  * @since 9.1
  */
-public class CoreBuildMainTab extends CMainTab2 {
+public class CoreBuildMainTab extends AbstractLaunchConfigurationTab {
 
-	/*
-	 * A Core Build launch configuration is created immediately upon the Core Build project creation.
-	 * It cannot be created by hand and it is not duplicatable and can't be renamed.
-	 * The launch configuration is tied to the project. The project name may not be changed.
-	 */
+	private Text projectName;
+
 	@Override
-	protected void createProjectGroup(Composite parent, int colSpan) {
-		super.createProjectGroup(parent, colSpan);
-		fProjText.setEnabled(false);
-		fProjButton.setVisible(false);
+	public void createControl(Composite parent) {
+		Composite comp = new Composite(parent, SWT.NONE);
+		comp.setLayout(new GridLayout());
+
+		Label label = new Label(comp, SWT.NONE);
+		label.setText("This launch configuration was automatically created.");
+		label.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+
+		label = new Label(comp, SWT.NONE);
+		label.setText("Project:");
+
+		projectName = new Text(comp, SWT.READ_ONLY | SWT.BORDER);
+		projectName.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+
+		setControl(comp);
 	}
 
 	@Override
-	protected void createExeFileGroup(Composite parent, int colSpan) {
-		super.createExeFileGroup(parent, colSpan);
-		fProgText.setMessage(LaunchMessages.CoreBuildMainTab_Keep_empty_for_auto_selection);
+	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
+		// none
 	}
 
-	/*
-	 * For Core Build projects the build configuration is hidden and it is selected
-	 * via the LaunchBar Launch Mode. We remove the BuildConfigCombo.
-	 */
 	@Override
-	protected void createBuildConfigCombo(Composite parent, int colspan) {
-		fBuildConfigCombo = null;
+	public void initializeFrom(ILaunchConfiguration configuration) {
+		try {
+			for (IResource resource : configuration.getMappedResources()) {
+				if (resource instanceof IProject) {
+					projectName.setText(resource.getName());
+					break;
+				}
+			}
+		} catch (CoreException e) {
+			LaunchUIPlugin.log(e.getStatus());
+		}
 	}
 
-	/*
-	 * Don't check the program name if it is empty. When the program name is empty the default
-	 * CoreBuild binary is used.
-	 */
 	@Override
-	public boolean isValid(ILaunchConfiguration config) {
-		String programName = fProgText.getText().trim();
-		setDontCheckProgram(programName.isEmpty());
-		return super.isValid(config);
+	public void performApply(ILaunchConfigurationWorkingCopy configuration) {
+		// TODO Auto-generated method stub
+
 	}
+
+	@Override
+	public String getName() {
+		return "Main";
+	}
+
 }

--- a/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/ui/corebuild/CoreBuildMainTab2.java
+++ b/launch/org.eclipse.cdt.launch/src/org/eclipse/cdt/launch/ui/corebuild/CoreBuildMainTab2.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Intel corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.cdt.launch.ui.corebuild;
+
+import org.eclipse.cdt.launch.internal.ui.LaunchMessages;
+import org.eclipse.cdt.launch.ui.CMainTab2;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.swt.widgets.Composite;
+
+/**
+ * @since 10.4
+ */
+public class CoreBuildMainTab2 extends CMainTab2 {
+
+	/*
+	 * A Core Build launch configuration is created immediately upon the Core Build project creation.
+	 * It cannot be created by hand and it is not duplicatable and can't be renamed.
+	 * The launch configuration is tied to the project. The project name may not be changed.
+	 */
+	@Override
+	protected void createProjectGroup(Composite parent, int colSpan) {
+		super.createProjectGroup(parent, colSpan);
+		fProjText.setEnabled(false);
+		fProjButton.setVisible(false);
+	}
+
+	@Override
+	protected void createExeFileGroup(Composite parent, int colSpan) {
+		super.createExeFileGroup(parent, colSpan);
+		fProgText.setMessage(LaunchMessages.CoreBuildMainTab_Keep_empty_for_auto_selection);
+	}
+
+	/*
+	 * For Core Build projects the build configuration is hidden and it is selected
+	 * via the LaunchBar Launch Mode. We remove the BuildConfigCombo.
+	 */
+	@Override
+	protected void createBuildConfigCombo(Composite parent, int colspan) {
+		fBuildConfigCombo = null;
+	}
+
+	/*
+	 * Don't check the program name if it is empty. When the program name is empty the default
+	 * CoreBuild binary is used.
+	 */
+	@Override
+	public boolean isValid(ILaunchConfiguration config) {
+		String programName = fProgText.getText().trim();
+		setDontCheckProgram(programName.isEmpty());
+		return super.isValid(config);
+	}
+}


### PR DESCRIPTION
A new Main Tab was created for Core Build local projects based on the Main Tab used for the classic Managed Build projects. It adds these features:

* Option to select a different binary.
* Option to control launch pre-builds.

The default value for the binary is empty string. With empty string the behaviour for binary selection stays the same as it was.

The project name is fixed and cannot be changed. A Core Build launch configuration is created with the project and tied to it.

This change relates to #758. It affects all Core Build projects, including CMake projects.