### PR TITLE
Use launch configuration environment attributes in Core Build local d…

### DIFF
--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/META-INF/MANIFEST.MF
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.cdt.dsf.gdb;singleton:=true
-Bundle-Version: 7.1.300.qualifier
+Bundle-Version: 7.1.400.qualifier
 Bundle-Activator: org.eclipse.cdt.dsf.gdb.internal.GdbPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/internal/launching/CoreBuildLocalDebugLaunchDelegate.java
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/internal/launching/CoreBuildLocalDebugLaunchDelegate.java
@@ -40,6 +40,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.core.target.launch.ITargetedLaunch;
 
@@ -80,6 +81,14 @@ public class CoreBuildLocalDebugLaunchDelegate extends CoreBuildLaunchConfigDele
 		Properties envProps = new Properties();
 		envProps.putAll(buildEnv);
 		gdbLaunch.setInitialEnvironment(envProps);
+
+		// Override initial environment by launch configuration attributes.
+		Map<String, String> launchEnvironment = configuration.getAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES,
+				new HashMap<>());
+		if (!configuration.getAttribute(ILaunchManager.ATTR_APPEND_ENVIRONMENT_VARIABLES, true)) {
+			envProps.clear();
+		}
+		envProps.putAll(launchEnvironment);
 
 		IToolChain toolChain = buildConfig.getToolChain();
 		Path gdbPath = toolChain.getCommandPath(Paths.get("gdb")); //$NON-NLS-1$


### PR DESCRIPTION
…ebug.

The Core Build local debug launch uses the environment attributes from the new environment tab that was added in #901.