### PR TITLE
Fixed the loading failure issue of Control Flow Graph view

### DIFF
--- a/codan/org.eclipse.cdt.codan.ui.example.cfgview/src/org/eclipse/cdt/codan/ui/cfgview/ControlFlowGraphPlugin.java
+++ b/codan/org.eclipse.cdt.codan.ui.example.cfgview/src/org/eclipse/cdt/codan/ui/cfgview/ControlFlowGraphPlugin.java
@@ -25,7 +25,8 @@ import org.osgi.framework.BundleContext;
  */
 public class ControlFlowGraphPlugin extends AbstractUIPlugin {
 	// The plug-in ID
-	public static final String PLUGIN_ID = "org.eclipse.cdt.codan.ui.cfgview"; //$NON-NLS-1$
+	//Fixed the loading failure issue of Control Flow Graph view (Window ->Show View ->Other... ->C/C++->Control Flow Graph).
+	public static final String PLUGIN_ID = "org.eclipse.cdt.codan.ui.example.cfgview"; //$NON-NLS-1$
 	// The shared instance
 	private static ControlFlowGraphPlugin plugin;
 


### PR DESCRIPTION
### _**Dear committers:**_
### **Before fixing the issue：**
The source code was like this：public static final String PLUGIN_ID = "org.eclipse.cdt.codan.ui.cfgview"; 
As shown in the following figure, when the CDT project is running,  the Control Flow Graph view throws an exception.
![bad](https://github.com/user-attachments/assets/3f159a71-1d71-4666-8001-2c266c1d8e91)
### **After fixing the issue：**
The source code was like this：public static final String PLUGIN_ID = "org.eclipse.cdt.codan.ui.**example**.cfgview";
As shown in the following figure, when the CDT project is running,  the Control Flow Graph view runs normally.
![Well](https://github.com/user-attachments/assets/34e8eb78-0b14-4a19-9279-000a8a2d9cc8)
### **Conduct impact analysis on code changes:**
As shown in the following figure, the Plugin ID member variable is called by these three functions
![1](https://github.com/user-attachments/assets/1fc85dbd-7ad2-40a3-a535-ec302dc70072)
By analyzing these three calling functions, only the image resource loading function and logging function are affected, so this code change will not affect other functions.
![Image resource loading function](https://github.com/user-attachments/assets/4c061134-f5e5-4447-b70a-aa60065d0e14)
![logging function](https://github.com/user-attachments/assets/ec3c6837-275f-4f56-a813-2e6119a5fb41)
