### PR TITLE
Core Build project without binaries.

### DIFF
--- a/debug/org.eclipse.cdt.debug.core/META-INF/MANIFEST.MF
+++ b/debug/org.eclipse.cdt.debug.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.core; singleton:=true
-Bundle-Version: 8.8.800.qualifier
+Bundle-Version: 8.8.900.qualifier
 Bundle-Activator: org.eclipse.cdt.debug.core.CDebugCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/core/launch/CoreBuildLaunchConfigDelegate.java
+++ b/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/core/launch/CoreBuildLaunchConfigDelegate.java
@@ -127,12 +127,20 @@ public abstract class CoreBuildLaunchConfigDelegate extends LaunchConfigurationT
 	}
 
 	/**
+	 * Returns the full path to the binary.
+	 *
 	 * @since 8.8
+	 * @param configuration
+	 * @param buildConfig
+	 * @return
+	 * @throws CoreException
 	 */
-	protected String getProgramPath(ILaunchConfiguration configuration, IBinary exeFile) throws CoreException {
+	protected String getProgramPath(ILaunchConfiguration configuration, ICBuildConfiguration buildConfig)
+			throws CoreException {
 		String programName = configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, ""); //$NON-NLS-1$
 
 		if (programName.isBlank()) {
+			IBinary exeFile = getBinary(buildConfig);
 			return Paths.get(exeFile.getLocationURI()).toString();
 		} else {
 			IPath path = new Path(

--- a/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/core/launch/CoreBuildLaunchConfigDelegate.java
+++ b/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/core/launch/CoreBuildLaunchConfigDelegate.java
@@ -180,8 +180,9 @@ public abstract class CoreBuildLaunchConfigDelegate extends LaunchConfigurationT
 		// CDT launch configuration "Use workspace settings" is not selected.
 		// The workspace setting is already considered in org.eclipse.debug.internal.ui.DebugUIPlugin.buildAndLaunch(),
 		// before the settings in the CDT launch configuration.
-		int autoBuild = configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_BUILD_BEFORE_LAUNCH, 2);
-		if (autoBuild == 0) {
+		int autoBuild = configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_BUILD_BEFORE_LAUNCH,
+				ICDTLaunchConfigurationConstants.BUILD_BEFORE_LAUNCH_USE_WORKSPACE_SETTING);
+		if (autoBuild == ICDTLaunchConfigurationConstants.BUILD_BEFORE_LAUNCH_DISABLED) {
 			return false;
 		}
 

--- a/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/internal/core/launch/CoreBuildLocalRunLaunchDelegate.java
+++ b/debug/org.eclipse.cdt.debug.core/src/org/eclipse/cdt/debug/internal/core/launch/CoreBuildLocalRunLaunchDelegate.java
@@ -19,13 +19,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.cdt.core.build.ICBuildConfiguration;
-import org.eclipse.cdt.core.model.IBinary;
 import org.eclipse.cdt.debug.core.CDebugCorePlugin;
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.cdt.debug.core.launch.CoreBuildLaunchConfigDelegate;
 import org.eclipse.cdt.debug.internal.core.InternalDebugCoreMessages;
 import org.eclipse.cdt.utils.CommandLineUtil;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -44,7 +44,7 @@ public class CoreBuildLocalRunLaunchDelegate extends CoreBuildLaunchConfigDelega
 			throws CoreException {
 		ILaunchTarget target = ((ITargetedLaunch) launch).getLaunchTarget();
 		ICBuildConfiguration buildConfig = getBuildConfiguration(configuration, mode, target, monitor);
-		IBinary exeFile = getBinary(buildConfig);
+		String programPath = getProgramPath(configuration, buildConfig);
 
 		try {
 			String args = configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_ARGUMENTS, ""); //$NON-NLS-1$
@@ -54,7 +54,7 @@ public class CoreBuildLocalRunLaunchDelegate extends CoreBuildLaunchConfigDelega
 
 			String[] arguments = CommandLineUtil.argumentsToArray(args);
 			List<String> command = new ArrayList<>(1 + arguments.length);
-			command.add(getProgramPath(configuration, exeFile));
+			command.add(programPath);
 			command.addAll(Arrays.asList(arguments));
 
 			ProcessBuilder builder = new ProcessBuilder(command);
@@ -77,7 +77,7 @@ public class CoreBuildLocalRunLaunchDelegate extends CoreBuildLaunchConfigDelega
 
 			buildConfig.setBuildEnvironment(environment);
 			Process process = builder.start();
-			DebugPlugin.newProcess(launch, process, exeFile.getPath().lastSegment());
+			DebugPlugin.newProcess(launch, process, IPath.fromOSString(programPath).lastSegment());
 		} catch (IOException e) {
 			throw new CoreException(new Status(IStatus.ERROR, CDebugCorePlugin.PLUGIN_ID,
 					InternalDebugCoreMessages.CoreBuildLocalRunLaunchDelegate_ErrorLaunching, e));

--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/META-INF/MANIFEST.MF
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.cdt.dsf.gdb;singleton:=true
-Bundle-Version: 7.1.400.qualifier
+Bundle-Version: 7.1.500.qualifier
 Bundle-Activator: org.eclipse.cdt.dsf.gdb.internal.GdbPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/internal/launching/CoreBuildLocalDebugLaunchDelegate.java
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/internal/launching/CoreBuildLocalDebugLaunchDelegate.java
@@ -16,7 +16,6 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
 import org.eclipse.cdt.core.build.ICBuildConfiguration;
-import org.eclipse.cdt.core.model.IBinary;
 import org.eclipse.cdt.debug.core.launch.CoreBuildLaunchConfigDelegate;
 import org.eclipse.cdt.dsf.concurrent.DataRequestMonitor;
 import org.eclipse.cdt.dsf.concurrent.ImmediateExecutor;
@@ -81,8 +80,7 @@ public class CoreBuildLocalDebugLaunchDelegate extends CoreBuildLaunchConfigDele
 
 		String gdbVersion = gdbLaunch.getGDBVersion();
 
-		IBinary exeFile = getBinary(buildConfig);
-		gdbLaunch.setProgramPath(getProgramPath(configuration, exeFile));
+		gdbLaunch.setProgramPath(getProgramPath(configuration, buildConfig));
 
 		gdbLaunch.setServiceFactory(new GdbDebugServicesFactory(gdbVersion, configuration));
 


### PR DESCRIPTION
Do not check for binaries in the project directory if the user defined
a binary in the Main tab. This supports the case where the user
disables auto build and selects a binary outside the project directory.
Otherwise the binaries check would stop the launch with the message
that no binaries are found in the project.