### PR TITLE
Ensure DSF GDB preference pages and UI elements are available in Core Build

### DIFF
--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/internal/launching/CoreBuildLocalDebugLaunchDelegate.java
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/internal/launching/CoreBuildLocalDebugLaunchDelegate.java
@@ -68,6 +68,7 @@ public class CoreBuildLocalDebugLaunchDelegate extends CoreBuildLaunchConfigDele
 	@Override
 	public void launch(ILaunchConfiguration configuration, String mode, ILaunch launch, IProgressMonitor monitor)
 			throws CoreException {
+		org.eclipse.cdt.launch.LaunchUtils.enableActivity("org.eclipse.cdt.debug.dsfgdbActivity", true); //$NON-NLS-1$
 		GdbLaunch gdbLaunch = (GdbLaunch) launch;
 		ILaunchTarget target = ((ITargetedLaunch) launch).getLaunchTarget();
 		ICBuildConfiguration buildConfig = getBuildConfiguration(configuration, mode, target, monitor);


### PR DESCRIPTION
When using Core Build, the GdbLaunchDelegate is not used to create the launch. Therefore in the core launch we need to enable the activity to show all the DSF GDB specific UI in another place.

This PR adds one of those places, but it may very well be there are other places that this should be added.

Fixes https://github.com/eclipse-cdt/cdt/issues/972