### PR TITLE
Update to latest versions of build tools

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,10 +9,10 @@ jobs:
     timeout-minutes: 90
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         filters: |
@@ -22,15 +22,15 @@ jobs:
             - 'debug/**'
             - 'jtag/**'
     - name: Set up JDK 21
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Set up Maven
-      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+      uses: stCarolas/setup-maven@v5
       with:
-        maven-version: 3.9.2
+        maven-version: 3.9.6
     - name: Install GCC & GDB & other build essentials
       run: |
         sudo apt-get update
@@ -57,7 +57,7 @@ jobs:
         name: Code Cleanliness Detailed Logs
         path: '*.log'
     - name: Upload Test Results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: test-results

--- a/.github/workflows/code-cleanliness.yml
+++ b/.github/workflows/code-cleanliness.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Run Check Code Cleanliness with Docker
@@ -22,7 +22,7 @@ jobs:
             ./releng/scripts/check_bundle_versions.sh
             ./releng/scripts/check_bundle_versions_report.sh
       - name: Upload Logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: Code Cleanliness Detailed Logs

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Download Test Report
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v7
         with:
           name: test-results
           path: test-results

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho</groupId>
     <artifactId>tycho-build</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.10</version>
   </extension>
 </extensions>

--- a/build/org.eclipse.cdt.autotools.core/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.autotools.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.eclipse.cdt.autotools.core;singleton:=true
-Bundle-Version: 2.2.300.qualifier
+Bundle-Version: 2.2.400.qualifier
 Bundle-Activator: org.eclipse.cdt.autotools.core.AutotoolsPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.4.0",

--- a/build/org.eclipse.cdt.autotools.ui/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.autotools.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.eclipse.cdt.autotools.ui;singleton:=true
-Bundle-Version: 2.2.400.qualifier
+Bundle-Version: 2.2.500.qualifier
 Bundle-Activator: org.eclipse.cdt.autotools.ui.AutotoolsUIPlugin
 Bundle-Localization: plugin
 Bundle-Vendor: %provider

--- a/build/org.eclipse.cdt.autotools.ui/about.properties
+++ b/build/org.eclipse.cdt.autotools.ui/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2012, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2012, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=C/C++ Autotools support\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2012, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2012, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/build/org.eclipse.cdt.core.autotools.core/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.core.autotools.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core.autotools.core;singleton:=true
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-Activator: org.eclipse.cdt.core.autotools.core.internal.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.tools.templates.core;bundle-version="2.0.0",

--- a/build/org.eclipse.cdt.make.core/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.make.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.make.core; singleton:=true
-Bundle-Version: 7.6.500.qualifier
+Bundle-Version: 7.6.600.qualifier
 Bundle-Activator: org.eclipse.cdt.make.core.MakeCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/build/org.eclipse.cdt.make.ui/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.make.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.make.ui; singleton:=true
-Bundle-Version: 8.3.100.qualifier
+Bundle-Version: 8.3.200.qualifier
 Bundle-Activator: org.eclipse.cdt.make.internal.ui.MakeUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/build/org.eclipse.cdt.meson.core/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.meson.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.eclipse.cdt.meson.core;singleton:=true
-Bundle-Version: 1.2.200.qualifier
+Bundle-Version: 1.2.300.qualifier
 Bundle-Activator: org.eclipse.cdt.meson.core.Activator
 Bundle-Vendor: %provider
 Require-Bundle: org.eclipse.core.runtime,

--- a/build/org.eclipse.cdt.meson.ui/META-INF/MANIFEST.MF
+++ b/build/org.eclipse.cdt.meson.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.eclipse.cdt.meson.ui;singleton:=true
-Bundle-Version: 1.2.300.qualifier
+Bundle-Version: 1.2.400.qualifier
 Bundle-Vendor: %vendorName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Activator: org.eclipse.cdt.meson.ui.Activator

--- a/build/org.eclipse.cdt.meson.ui/about.properties
+++ b/build/org.eclipse.cdt.meson.ui/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2018, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=C/C++ Meson Build Support - Preview\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2018, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2018, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/cmake/org.eclipse.cdt.cmake.ui/META-INF/MANIFEST.MF
+++ b/cmake/org.eclipse.cdt.cmake.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.cmake.ui;singleton:=true
-Bundle-Version: 1.4.400.qualifier
+Bundle-Version: 1.4.500.qualifier
 Bundle-Activator: org.eclipse.cdt.cmake.ui.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/cmake/org.eclipse.cdt.cmake.ui/about.properties
+++ b/cmake/org.eclipse.cdt.cmake.ui/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2015, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=C/C++ CMake Build Support - Preview\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2015, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2015, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/codan/org.eclipse.cdt.codan.checkers.ui/META-INF/MANIFEST.MF
+++ b/codan/org.eclipse.cdt.codan.checkers.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.codan.checkers.ui;singleton:=true
-Bundle-Version: 3.4.100.qualifier
+Bundle-Version: 3.4.200.qualifier
 Bundle-Activator: org.eclipse.cdt.codan.internal.checkers.ui.CheckersUiActivator
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/codan/org.eclipse.cdt.codan.checkers/META-INF/MANIFEST.MF
+++ b/codan/org.eclipse.cdt.codan.checkers/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.codan.checkers;singleton:=true
-Bundle-Version: 3.5.600.qualifier
+Bundle-Version: 3.5.700.qualifier
 Bundle-Activator: org.eclipse.cdt.codan.checkers.CodanCheckersActivator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/codan/org.eclipse.cdt.codan.core.cxx/META-INF/MANIFEST.MF
+++ b/codan/org.eclipse.cdt.codan.core.cxx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.codan.core.cxx;singleton:=true
-Bundle-Version: 3.6.100.qualifier
+Bundle-Version: 3.6.200.qualifier
 Bundle-Activator: org.eclipse.cdt.codan.core.cxx.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.cdt.core,

--- a/codan/org.eclipse.cdt.codan.core/META-INF/MANIFEST.MF
+++ b/codan/org.eclipse.cdt.codan.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.codan.core;singleton:=true
-Bundle-Version: 4.2.200.qualifier
+Bundle-Version: 4.2.300.qualifier
 Bundle-Activator: org.eclipse.cdt.codan.core.CodanCorePlugin
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime,

--- a/codan/org.eclipse.cdt.codan.ui/META-INF/MANIFEST.MF
+++ b/codan/org.eclipse.cdt.codan.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.codan.ui; singleton:=true
-Bundle-Version: 3.5.100.qualifier
+Bundle-Version: 3.5.200.qualifier
 Bundle-Activator: org.eclipse.cdt.codan.internal.ui.CodanUIActivator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.cdt.codan.core,

--- a/cross/org.eclipse.cdt.build.crossgcc/META-INF/MANIFEST.MF
+++ b/cross/org.eclipse.cdt.build.crossgcc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.cdt.build.crossgcc;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.cdt.core;bundle-version="5.1.0",
  org.eclipse.cdt.managedbuilder.core;bundle-version="9.6.0",

--- a/cross/org.eclipse.cdt.build.crossgcc/about.properties
+++ b/cross/org.eclipse.cdt.build.crossgcc/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2009, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2009, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=C/C++ GCC Cross Compiler Support\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2009, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2009, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/cross/org.eclipse.cdt.launch.remote/META-INF/MANIFEST.MF
+++ b/cross/org.eclipse.cdt.launch.remote/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.launch.remote;singleton:=true
-Bundle-Version: 2.7.200.qualifier
+Bundle-Version: 2.7.300.qualifier
 Bundle-Activator: org.eclipse.cdt.internal.launch.remote.Activator
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.cdt.launch,

--- a/cross/org.eclipse.cdt.launch.remote/about.properties
+++ b/cross/org.eclipse.cdt.launch.remote/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2009, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2009, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=C/C++ Remote Launch\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2009, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2009, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/doc/org.eclipse.cdt.doc.user/pom.xml
+++ b/doc/org.eclipse.cdt.doc.user/pom.xml
@@ -43,7 +43,7 @@
 			<plugin>
 				<groupId>org.asciidoctor</groupId>
 				<artifactId>asciidoctor-maven-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.1</version>
 				<executions>
 					<execution>
 						<id>adoc-to-html</id>

--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb.multicorevisualizer.ui/META-INF/MANIFEST.MF
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb.multicorevisualizer.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.cdt.dsf.gdb.multicorevisualizer.ui;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Bundle-Activator: org.eclipse.cdt.dsf.gdb.multicorevisualizer.internal.ui.MulticoreVisualizerUIPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb.multicorevisualizer.ui/about.properties
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb.multicorevisualizer.ui/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2012, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2012, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=C/C++ Multicore Visualizer\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2012, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2012, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/dsf/org.eclipse.cdt.dsf/META-INF/MANIFEST.MF
+++ b/dsf/org.eclipse.cdt.dsf/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.cdt.dsf;singleton:=true
-Bundle-Version: 2.12.100.qualifier
+Bundle-Version: 2.12.200.qualifier
 Bundle-Activator: org.eclipse.cdt.dsf.internal.DsfPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/dsf/org.eclipse.cdt.examples.dsf.pda.ui/META-INF/MANIFEST.MF
+++ b/dsf/org.eclipse.cdt.examples.dsf.pda.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.examples.dsf.pda.ui;singleton:=true
-Bundle-Version: 2.3.100.qualifier
+Bundle-Version: 2.3.200.qualifier
 Bundle-Activator: org.eclipse.cdt.examples.dsf.pda.ui.PDAUIPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/dsf/org.eclipse.cdt.examples.dsf.pda/META-INF/MANIFEST.MF
+++ b/dsf/org.eclipse.cdt.examples.dsf.pda/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.examples.dsf.pda;singleton:=true
-Bundle-Version: 2.3.100.qualifier
+Bundle-Version: 2.3.200.qualifier
 Bundle-Activator: org.eclipse.cdt.examples.dsf.pda.PDAPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/dsf/org.eclipse.cdt.examples.dsf/META-INF/MANIFEST.MF
+++ b/dsf/org.eclipse.cdt.examples.dsf/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.cdt.examples.dsf;singleton:=true
-Bundle-Version: 2.4.300.qualifier
+Bundle-Version: 2.4.400.qualifier
 Bundle-Activator: org.eclipse.cdt.examples.dsf.DsfExamplesPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/dsf/org.eclipse.cdt.examples.dsf/about.properties
+++ b/dsf/org.eclipse.cdt.examples.dsf/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2009, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2009, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=C/C++ Debugger Services Framework (DSF) Examples\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2009, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2009, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/jsoncdb/org.eclipse.cdt.jsoncdb.core/META-INF/MANIFEST.MF
+++ b/jsoncdb/org.eclipse.cdt.jsoncdb.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %bundleName
 Bundle-Description: %bundleDescription
 Bundle-Copyright: %Bundle-Copyright
 Bundle-SymbolicName: org.eclipse.cdt.jsoncdb.core;singleton:=true
-Bundle-Version: 1.4.300.qualifier
+Bundle-Version: 1.4.400.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/jtag/org.eclipse.cdt.debug.gdbjtag.core/META-INF/MANIFEST.MF
+++ b/jtag/org.eclipse.cdt.debug.gdbjtag.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.gdbjtag.core;singleton:=true
-Bundle-Version: 10.8.200.qualifier
+Bundle-Version: 10.8.300.qualifier
 Bundle-Activator: org.eclipse.cdt.debug.gdbjtag.core.Activator
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/launch/org.eclipse.cdt.docker.launcher/META-INF/MANIFEST.MF
+++ b/launch/org.eclipse.cdt.docker.launcher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.cdt.docker.launcher;singleton:=true
-Bundle-Version: 2.1.300.qualifier
+Bundle-Version: 2.1.400.qualifier
 Bundle-Activator: org.eclipse.cdt.docker.launcher.DockerLaunchUIPlugin
 Bundle-Vendor: %Plugin.vendor
 Bundle-Localization: plugin

--- a/launch/org.eclipse.cdt.docker.launcher/about.properties
+++ b/launch/org.eclipse.cdt.docker.launcher/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2015, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=C/C++ Docker Container Launch Support\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2015, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2015, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/launchbar/org.eclipse.launchbar.core/META-INF/MANIFEST.MF
+++ b/launchbar/org.eclipse.launchbar.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.launchbar.core;singleton:=true
-Bundle-Version: 2.5.200.qualifier
+Bundle-Version: 2.5.300.qualifier
 Bundle-Activator: org.eclipse.launchbar.core.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/llvm/org.eclipse.cdt.llvm.dsf.lldb.core/META-INF/MANIFEST.MF
+++ b/llvm/org.eclipse.cdt.llvm.dsf.lldb.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.cdt.llvm.dsf.lldb.core;singleton:=true
-Bundle-Version: 1.102.100.qualifier
+Bundle-Version: 1.102.200.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.debug.core,

--- a/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/META-INF/MANIFEST.MF
+++ b/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.managedbuilder.llvm.ui;singleton:=true
-Bundle-Version: 1.4.200.qualifier
+Bundle-Version: 1.4.300.qualifier
 Bundle-Activator: org.eclipse.cdt.managedbuilder.llvm.ui.LlvmUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/about.properties
+++ b/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2013, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2013, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=C/C++ LLVM-Family Compiler Build Support\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2013, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2013, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/memory/org.eclipse.cdt.debug.ui.memory.floatingpoint/META-INF/MANIFEST.MF
+++ b/memory/org.eclipse.cdt.debug.ui.memory.floatingpoint/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.ui.memory.floatingpoint;singleton:=true
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.debug.core;bundle-version="3.7.100",
  org.eclipse.debug.ui;bundle-version="3.8.1",

--- a/memory/org.eclipse.cdt.debug.ui.memory.memorybrowser/META-INF/MANIFEST.MF
+++ b/memory/org.eclipse.cdt.debug.ui.memory.memorybrowser/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.ui.memory.memorybrowser;singleton:=true
-Bundle-Version: 1.5.200.qualifier
+Bundle-Version: 1.5.300.qualifier
 Bundle-Activator: org.eclipse.cdt.debug.ui.memory.memorybrowser.MemoryBrowserPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/memory/org.eclipse.cdt.debug.ui.memory.memorybrowser/about.properties
+++ b/memory/org.eclipse.cdt.debug.ui.memory.memorybrowser/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2009, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2009, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=C/C++ Memory View Enhancements\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2009, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2009, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/memory/org.eclipse.cdt.debug.ui.memory.search/META-INF/MANIFEST.MF
+++ b/memory/org.eclipse.cdt.debug.ui.memory.search/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.ui.memory.search;singleton:=true
-Bundle-Version: 1.5.300.qualifier
+Bundle-Version: 1.5.400.qualifier
 Bundle-Activator: org.eclipse.cdt.debug.ui.memory.search.MemorySearchPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/memory/org.eclipse.cdt.debug.ui.memory.traditional/META-INF/MANIFEST.MF
+++ b/memory/org.eclipse.cdt.debug.ui.memory.traditional/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.ui.memory.traditional;singleton:=true
-Bundle-Version: 1.7.100.qualifier
+Bundle-Version: 1.7.200.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.debug.core,
  org.eclipse.debug.ui,

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
 
 	<properties>
 		<required-maven-version>3.9.1</required-maven-version>
-		<tycho-version>4.0.6</tycho-version>
-		<cbi-plugins.version>1.4.3</cbi-plugins.version>
+		<tycho-version>4.0.10</tycho-version>
+		<cbi-plugins.version>1.5.2</cbi-plugins.version>
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
 		<cdt-site>https://ci.eclipse.org/cdt/job/cdt/job/main/lastSuccessfulBuild/artifact/releng/org.eclipse.cdt.repo/target/repository</cdt-site>
 		<simrel-site>https://download.eclipse.org/staging/2024-06/</simrel-site>
@@ -626,7 +626,7 @@
 				<inherited>true</inherited>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.4.1</version>
+				<version>3.5.0</version>
 				<executions>
 				<execution>
 					<id>enforce-maven-version</id>
@@ -770,7 +770,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.11</version>
+				<version>0.8.12</version>
 				<executions>
 					<execution>
 						<id>pre-test</id>
@@ -939,7 +939,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.12.1</version>
+					<version>3.13.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
@@ -961,7 +961,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-pmd-plugin</artifactId>
-					<version>3.21.2</version>
+					<version>3.26.0</version>
 					<configuration>
 						<inputEncoding>utf-8</inputEncoding>
 						<minimumTokens>100</minimumTokens>
@@ -1064,7 +1064,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>build-helper-maven-plugin</artifactId>
-					<version>3.5.0</version>
+					<version>3.6.0</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/releng/org.eclipse.cdt/about.properties
+++ b/releng/org.eclipse.cdt/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2002, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2002, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=C/C++ Development Tools\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2002, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2002, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/remote/org.eclipse.cdt.remote.core/META-INF/MANIFEST.MF
+++ b/remote/org.eclipse.cdt.remote.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.remote.core;singleton:=true
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Activator: org.eclipse.cdt.remote.internal.core.Activator
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/remote/org.eclipse.remote.console/META-INF/MANIFEST.MF
+++ b/remote/org.eclipse.remote.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.remote.console;singleton:=true
-Bundle-Version: 1.4.200.qualifier
+Bundle-Version: 1.4.300.qualifier
 Bundle-Activator: org.eclipse.remote.internal.console.Activator
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/remote/org.eclipse.remote.console/about.properties
+++ b/remote/org.eclipse.remote.console/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=Remote Command Shell Console\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/remote/org.eclipse.remote.core/META-INF/MANIFEST.MF
+++ b/remote/org.eclipse.remote.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.remote.core;singleton:=true
-Bundle-Version: 4.2.200.qualifier
+Bundle-Version: 4.2.300.qualifier
 Bundle-Activator: org.eclipse.remote.internal.core.RemoteCorePlugin
 Bundle-Vendor: %pluginProvider
 Bundle-ActivationPolicy: lazy

--- a/remote/org.eclipse.remote.jsch.core/META-INF/MANIFEST.MF
+++ b/remote/org.eclipse.remote.jsch.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.remote.jsch.core;singleton:=true
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Activator: org.eclipse.remote.internal.jsch.core.Activator
 Bundle-Vendor: %pluginProvider
 Bundle-ActivationPolicy: lazy

--- a/remote/org.eclipse.remote.proxy.core/META-INF/MANIFEST.MF
+++ b/remote/org.eclipse.remote.proxy.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.remote.proxy.core;singleton:=true
-Bundle-Version: 1.1.100.qualifier
+Bundle-Version: 1.1.200.qualifier
 Bundle-Activator: org.eclipse.remote.internal.proxy.core.Activator
 Bundle-Vendor: %pluginProvider
 Bundle-ActivationPolicy: lazy

--- a/remote/org.eclipse.remote.proxy.protocol.core/META-INF/MANIFEST.MF
+++ b/remote/org.eclipse.remote.proxy.protocol.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.remote.proxy.protocol.core;singleton:=true
-Bundle-Version: 2.1.100.qualifier
+Bundle-Version: 2.1.200.qualifier
 Bundle-Activator: org.eclipse.remote.internal.proxy.protocol.core.Activator
 Bundle-Vendor: %pluginProvider
 Bundle-ActivationPolicy: lazy

--- a/remote/org.eclipse.remote.proxy.server.core/META-INF/MANIFEST.MF
+++ b/remote/org.eclipse.remote.proxy.server.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.remote.proxy.server.core;singleton:=true
-Bundle-Version: 1.1.100.qualifier
+Bundle-Version: 1.1.200.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.eclipse.core.filesystem,
  org.eclipse.core.runtime,

--- a/remote/org.eclipse.remote.telnet.core/META-INF/MANIFEST.MF
+++ b/remote/org.eclipse.remote.telnet.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-SymbolicName: org.eclipse.remote.telnet.core;singleton:=true
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Activator: org.eclipse.remote.telnet.internal.core.Activator
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/remote/org.eclipse.remote.ui/META-INF/MANIFEST.MF
+++ b/remote/org.eclipse.remote.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.remote.ui;singleton:=true
-Bundle-Version: 2.3.200.qualifier
+Bundle-Version: 2.3.300.qualifier
 Bundle-Activator: org.eclipse.remote.internal.ui.RemoteUIPlugin
 Bundle-Vendor: %pluginProvider
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/remote/org.eclipse.remote.ui/about.properties
+++ b/remote/org.eclipse.remote.ui/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=Remote Services\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/terminal/plugins/org.eclipse.tm.terminal.connector.remote/META-INF/MANIFEST.MF
+++ b/terminal/plugins/org.eclipse.tm.terminal.connector.remote/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.tm.terminal.connector.remote;singleton:=true
-Bundle-Version: 4.8.300.qualifier
+Bundle-Version: 4.8.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/terminal/plugins/org.eclipse.tm.terminal.connector.ssh/META-INF/MANIFEST.MF
+++ b/terminal/plugins/org.eclipse.tm.terminal.connector.ssh/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.tm.terminal.connector.ssh;singleton:=true
-Bundle-Version: 4.8.300.qualifier
+Bundle-Version: 4.8.400.qualifier
 Bundle-Activator: org.eclipse.tm.terminal.connector.ssh.activator.UIPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.expressions;bundle-version="3.4.400",

--- a/terminal/plugins/org.eclipse.tm.terminal.connector.ssh/about.properties
+++ b/terminal/plugins/org.eclipse.tm.terminal.connector.ssh/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2018, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=TM Terminal SSH Connector Extensions\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2018, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2018, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/terminal/plugins/org.eclipse.tm.terminal.connector.telnet/META-INF/MANIFEST.MF
+++ b/terminal/plugins/org.eclipse.tm.terminal.connector.telnet/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.tm.terminal.connector.telnet;singleton:=true
-Bundle-Version: 4.8.100.qualifier
+Bundle-Version: 4.8.200.qualifier
 Bundle-Activator: org.eclipse.tm.terminal.connector.telnet.activator.UIPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.expressions;bundle-version="3.4.400",

--- a/terminal/plugins/org.eclipse.tm.terminal.view.core/META-INF/MANIFEST.MF
+++ b/terminal/plugins/org.eclipse.tm.terminal.view.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.tm.terminal.view.core;singleton:=true
-Bundle-Version: 4.10.300.qualifier
+Bundle-Version: 4.10.400.qualifier
 Bundle-Activator: org.eclipse.tm.terminal.view.core.activator.CoreBundleActivator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.expressions;bundle-version="3.4.400",

--- a/terminal/plugins/org.eclipse.tm.terminal.view.core/about.properties
+++ b/terminal/plugins/org.eclipse.tm.terminal.view.core/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2018, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=TM Terminal\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2018, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2018, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/terminal/plugins/org.eclipse.tm.terminal.view.ui/META-INF/MANIFEST.MF
+++ b/terminal/plugins/org.eclipse.tm.terminal.view.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.tm.terminal.view.ui;singleton:=true
-Bundle-Version: 4.11.500.qualifier
+Bundle-Version: 4.11.600.qualifier
 Bundle-Activator: org.eclipse.tm.terminal.view.ui.activator.UIPlugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.expressions;bundle-version="3.4.400",

--- a/terminal/plugins/org.eclipse.tm.terminal.view.ui/about.properties
+++ b/terminal/plugins/org.eclipse.tm.terminal.view.ui/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2018, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=Terminal (Console) View\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2018, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2018, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/testsrunner/org.eclipse.cdt.testsrunner.boost/META-INF/MANIFEST.MF
+++ b/testsrunner/org.eclipse.cdt.testsrunner.boost/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.testsrunner.boost;singleton:=true
-Bundle-Version: 7.2.300.qualifier
+Bundle-Version: 7.2.400.qualifier
 Bundle-Activator: org.eclipse.cdt.testsrunner.internal.boost.BoostTestsRunnerPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/testsrunner/org.eclipse.cdt.testsrunner.gtest/META-INF/MANIFEST.MF
+++ b/testsrunner/org.eclipse.cdt.testsrunner.gtest/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.testsrunner.gtest;singleton:=true
-Bundle-Version: 7.2.100.qualifier
+Bundle-Version: 7.2.200.qualifier
 Bundle-Activator: org.eclipse.cdt.testsrunner.internal.gtest.GoogleTestsRunnerPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/tools.templates/org.eclipse.tools.templates.ui/META-INF/MANIFEST.MF
+++ b/tools.templates/org.eclipse.tools.templates.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.tools.templates.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.tools.templates.ui;singleton:=true
-Bundle-Version: 2.0.100.qualifier
+Bundle-Version: 2.0.200.qualifier
 Bundle-Activator: org.eclipse.tools.templates.ui.internal.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/unittest/org.eclipse.cdt.unittest/META-INF/MANIFEST.MF
+++ b/unittest/org.eclipse.cdt.unittest/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.cdt.unittest
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.unittest;singleton:=true
-Bundle-Version: 1.1.100.qualifier
+Bundle-Version: 1.1.200.qualifier
 Bundle-Activator: org.eclipse.cdt.unittest.CDTUnitTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/visualizer/org.eclipse.cdt.visualizer.core/META-INF/MANIFEST.MF
+++ b/visualizer/org.eclipse.cdt.visualizer.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %plugin.name
 Bundle-SymbolicName: org.eclipse.cdt.visualizer.core;singleton:=true
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.2.200.qualifier
 Bundle-Activator: org.eclipse.cdt.visualizer.core.plugin.CDTVisualizerCorePlugin
 Bundle-Vendor: %provider.name
 Require-Bundle: org.eclipse.ui,


### PR DESCRIPTION
Beta versions of maven plugins are omitted from this upgrade.

A new version of Tycho brings in an update ECJ which means some of the class files are different, hence the need to bump versions of bundles too.

A new calendar year brings an update to Copyrights