### PR TITLE
[#942] GDBControl discards ILaunchConfiguration in its constructor

### DIFF
--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/META-INF/MANIFEST.MF
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.cdt.dsf.gdb;singleton:=true
-Bundle-Version: 7.1.500.qualifier
+Bundle-Version: 7.2.0.qualifier
 Bundle-Activator: org.eclipse.cdt.dsf.gdb.internal.GdbPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/service/command/GDBControl.java
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/service/command/GDBControl.java
@@ -113,6 +113,11 @@ public class GDBControl extends AbstractMIControl implements IGDBControl {
 	private static final int STATUS_CODE_COMMAND_TIMED_OUT = 20100;
 
 	/**
+	 * @since 7.2
+	 */
+	protected final ILaunchConfiguration config;
+
+	/**
 	 * Event indicating that the back end process has started.
 	 */
 	private static class GDBControlInitializedDMEvent extends AbstractDMEvent<ICommandControlDMContext>
@@ -240,6 +245,7 @@ public class GDBControl extends AbstractMIControl implements IGDBControl {
 	protected GDBControl(DsfSession session, boolean useThreadAndFrameOptions, ILaunchConfiguration config,
 			CommandFactory factory) {
 		super(session, useThreadAndFrameOptions, factory);
+		this.config = config;
 	}
 
 	@Override


### PR DESCRIPTION
add protected final field to be available for successors 
adding final accessor method may break Embedded CDT

Fixes #942 