### PR TITLE
[#943] Provide API for "org.eclipse.cdt.debug.gdbjtag.core.jtagDevice"

### DIFF
--- a/jtag/org.eclipse.cdt.debug.gdbjtag.core/META-INF/MANIFEST.MF
+++ b/jtag/org.eclipse.cdt.debug.gdbjtag.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.gdbjtag.core;singleton:=true
-Bundle-Version: 10.8.200.qualifier
+Bundle-Version: 10.9.0.qualifier
 Bundle-Activator: org.eclipse.cdt.debug.gdbjtag.core.Activator
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime,

--- a/jtag/org.eclipse.cdt.debug.gdbjtag.core/src/org/eclipse/cdt/debug/gdbjtag/core/GDBJtagDSFFinalLaunchSequence.java
+++ b/jtag/org.eclipse.cdt.debug.gdbjtag.core/src/org/eclipse/cdt/debug/gdbjtag/core/GDBJtagDSFFinalLaunchSequence.java
@@ -108,8 +108,6 @@ import org.eclipse.debug.core.ILaunchConfiguration;
  */
 public class GDBJtagDSFFinalLaunchSequence extends FinalLaunchSequence {
 
-	private static final String ATTR_JTAG_DEVICE = Activator.PLUGIN_ID + ".jtagDevice"; //$NON-NLS-1$
-
 	private abstract class DownloadStatusListener implements IEventListener {
 
 		private static final String ASYNC_CLASS_DOWNLOAD = "download"; //$NON-NLS-1$
@@ -808,8 +806,8 @@ public class GDBJtagDSFFinalLaunchSequence extends FinalLaunchSequence {
 		}
 
 		// Fall back to old behavior with name only if ID is missing
-		if (attributes.containsKey(ATTR_JTAG_DEVICE)) {
-			String deviceName = CDebugUtils.getAttribute(attributes, ATTR_JTAG_DEVICE, ""); //$NON-NLS-1$
+		if (attributes.containsKey(IGDBJtagConstants.ATTR_JTAG_DEVICE)) {
+			String deviceName = CDebugUtils.getAttribute(attributes, IGDBJtagConstants.ATTR_JTAG_DEVICE, ""); //$NON-NLS-1$
 			if (!deviceName.isEmpty()) {
 				return GDBJtagDeviceContributionFactory.getInstance().findByDeviceName(deviceName);
 			}

--- a/jtag/org.eclipse.cdt.debug.gdbjtag.core/src/org/eclipse/cdt/debug/gdbjtag/core/IGDBJtagConstants.java
+++ b/jtag/org.eclipse.cdt.debug.gdbjtag.core/src/org/eclipse/cdt/debug/gdbjtag/core/IGDBJtagConstants.java
@@ -33,6 +33,8 @@ public interface IGDBJtagConstants {
 	public static final String ATTR_PORT_NUMBER = Activator.PLUGIN_ID + ".portNumber"; //$NON-NLS-1$
 	/** @since 9.2 */
 	public static final String ATTR_JTAG_DEVICE_ID = Activator.PLUGIN_ID + ".jtagDeviceId"; //$NON-NLS-1$
+	/** @since 10.9 */
+	public static final String ATTR_JTAG_DEVICE = Activator.PLUGIN_ID + ".jtagDevice"; //$NON-NLS-1$
 
 	public static final boolean DEFAULT_USE_REMOTE_TARGET = true;
 	public static final String DEFAULT_IP_ADDRESS = "unspecified-ip-address"; //$NON-NLS-1$

--- a/jtag/org.eclipse.cdt.debug.gdbjtag.ui/META-INF/MANIFEST.MF
+++ b/jtag/org.eclipse.cdt.debug.gdbjtag.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.gdbjtag.ui;singleton:=true
-Bundle-Version: 9.1.100.qualifier
+Bundle-Version: 9.1.200.qualifier
 Bundle-Activator: org.eclipse.cdt.debug.gdbjtag.ui.Activator
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/jtag/org.eclipse.cdt.debug.gdbjtag.ui/src/org/eclipse/cdt/debug/gdbjtag/ui/GDBJtagDSFDebuggerTab.java
+++ b/jtag/org.eclipse.cdt.debug.gdbjtag.ui/src/org/eclipse/cdt/debug/gdbjtag/ui/GDBJtagDSFDebuggerTab.java
@@ -80,7 +80,6 @@ public class GDBJtagDSFDebuggerTab extends AbstractLaunchConfigurationTab {
 	private static final String TAB_NAME = Messages.getString("GDBJtagDebuggerTab.tabName"); //$NON-NLS-1$
 	private static final String TAB_ID = "org.eclipse.cdt.debug.gdbjtag.ui.debuggertab.dsf"; //$NON-NLS-1$
 	private static final String DEFAULT_JTAG_DEVICE_ID = "org.eclipse.cdt.debug.gdbjtag.core.jtagdevice.genericDevice"; //$NON-NLS-1$
-	private static final String ATTR_JTAG_DEVICE = "org.eclipse.cdt.debug.gdbjtag.core.jtagDevice"; //$NON-NLS-1$
 
 	private Text gdbCommand;
 	private Button useRemote;
@@ -381,7 +380,7 @@ public class GDBJtagDSFDebuggerTab extends AbstractLaunchConfigurationTab {
 		}
 
 		// Fall back to old behavior with name only if ID is missing
-		String deviceName = configuration.getAttribute(ATTR_JTAG_DEVICE, (String) null);
+		String deviceName = configuration.getAttribute(IGDBJtagConstants.ATTR_JTAG_DEVICE, (String) null);
 		if (deviceName != null) {
 			return GDBJtagDeviceContributionFactory.getInstance().findByDeviceName(deviceName);
 		}


### PR DESCRIPTION
* add `IGDBJtagConstants.ATTR_JTAG_DEVICE` and remove duplicated definitions

Fixes #943 