### PR TITLE
Add SonarQube for Eclipse to the list of addons for CDT

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ There are many third-party addons for CDT to make it more productive.
 * [CDT LSP](https://github.com/eclipse-cdt/cdt-lsp#readme): LSP based C/C++ Editor provided by the Eclipse CDT project
 * [cmake4eclipse](https://github.com/15knots/cmake4eclipse#abstract): This Eclipse plug-in automatically generates build-scripts for the Eclipse CDT managed build system from CMake scripts.
 * [Sloeber](http://eclipse.baeyens.it/): Eclipse Plugins based on Arduino toolchains or a enhanced Arduino IDE.
+* [SonarQube for Eclipse](https://marketplace.eclipse.org/content/sonarqube-ide): Eclipse plug-in for static analysis for quality and security issues in your C/C++ code directly inside the IDE.
 * [CUTE](https://cute-test.com/): C++ unit testing plug-in
 * [Bracketeer](https://marketplace.eclipse.org/content/bracketeer-cc-cdt): Auto-comments on closing brackets and highlight of matching/mismatching brackets
 * And many more in the [Eclipse Marketplace](https://marketplace.eclipse.org/), for example, try the [CDT tag](https://marketplace.eclipse.org/category/free-tagging/cdt)


### PR DESCRIPTION
This is based on the discussion https://github.com/eclipse-cdt/cdt/discussions/988 as a first baby step.