### PR TITLE
Remove generation of adoc files in code cleanliness

### DIFF
--- a/releng/scripts/do_generate_asciidoc.sh
+++ b/releng/scripts/do_generate_asciidoc.sh
@@ -18,8 +18,6 @@ SCRIPT=$( basename "${BASH_SOURCE[0]}" )
 # Make sure that asciidocs are up to date
 ##
 for p in doc/org.eclipse.cdt.doc.user; do
-    echo "Rebuilding $p asciidocs to make sure they match source"
-
     echo "Ensure adoc files start with expected contents"
     ref_header=$p/adoc-headers.txt
     git ls-files -- $p/**/*.adoc | while read i ; do
@@ -29,11 +27,4 @@ for p in doc/org.eclipse.cdt.doc.user; do
         tail --lines=+${end_line:=0} $i >> $tmpfile
         mv -f $tmpfile $i
     done
-
-    echo "Generate html from adoc files"
-    logfile=asciidoc-${p//\//-}.log
-    if ! ${MVN:-mvn} -B -V generate-resources -DuseSimrelRepo -f $p >${logfile} 2>&1; then
-        echo "Rebuilding of $p asciidocs failed. The log (${logfile}) is part of the artifacts of the build"
-        exit 1
-    fi
 done


### PR DESCRIPTION
This was supposed to be a check to ensure adoc generation was working, but it interferes with the overall check code cleanliness as it leads to jgit dirty errors.

The generation of the docs is done as part of the build too, so it is redundant to do them here.