### PR TITLE
Make CMakeBuildConfiguration API

### DIFF
--- a/cmake/org.eclipse.cdt.cmake.core/META-INF/MANIFEST.MF
+++ b/cmake/org.eclipse.cdt.cmake.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.cmake.core;singleton:=true
-Bundle-Version: 1.5.600.qualifier
+Bundle-Version: 1.6.0.qualifier
 Bundle-Activator: org.eclipse.cdt.cmake.core.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/cmake/org.eclipse.cdt.cmake.core/plugin.xml
+++ b/cmake/org.eclipse.cdt.cmake.core/plugin.xml
@@ -15,7 +15,7 @@
    <extension
          point="org.eclipse.cdt.core.buildConfigProvider">
       <provider
-            class="org.eclipse.cdt.cmake.core.internal.CMakeBuildConfigurationProvider"
+            class="org.eclipse.cdt.cmake.core.CMakeBuildConfigurationProvider"
             id="org.eclipse.cdt.cmake.core.provider"
             natureId="org.eclipse.cdt.cmake.core.cmakeNature">
       </provider>

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/CMakeBuildConfiguration.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/CMakeBuildConfiguration.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package org.eclipse.cdt.cmake.core.internal;
+package org.eclipse.cdt.cmake.core;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,13 +26,13 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.eclipse.cdt.cmake.core.CMakeErrorParser;
-import org.eclipse.cdt.cmake.core.CMakeExecutionMarkerFactory;
-import org.eclipse.cdt.cmake.core.ICMakeExecutionMarkerFactory;
-import org.eclipse.cdt.cmake.core.ICMakeToolChainFile;
-import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
-import org.eclipse.cdt.cmake.core.ParsingConsoleOutputStream;
+import org.eclipse.cdt.cmake.core.internal.Activator;
+import org.eclipse.cdt.cmake.core.internal.CMakeConsoleWrapper;
+import org.eclipse.cdt.cmake.core.internal.CMakePropertiesController;
+import org.eclipse.cdt.cmake.core.internal.CMakeUtils;
+import org.eclipse.cdt.cmake.core.internal.CommandDescriptorBuilder;
 import org.eclipse.cdt.cmake.core.internal.CommandDescriptorBuilder.CommandDescriptor;
+import org.eclipse.cdt.cmake.core.internal.IOsOverridesSelector;
 import org.eclipse.cdt.cmake.core.properties.CMakeGenerator;
 import org.eclipse.cdt.cmake.core.properties.ICMakeProperties;
 import org.eclipse.cdt.cmake.core.properties.ICMakePropertiesController;
@@ -71,6 +71,9 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.ILaunchManager;
 import org.osgi.service.prefs.Preferences;
 
+/**
+ * @since 1.6
+ */
 public class CMakeBuildConfiguration extends CBuildConfiguration {
 
 	public static final String CMAKE_USE_UI_OVERRIDES = "cmake.use.ui.overrides"; //$NON-NLS-1$
@@ -86,7 +89,7 @@ public class CMakeBuildConfiguration extends CBuildConfiguration {
 	private ICMakeToolChainFile toolChainFile;
 
 	// lazily instantiated..
-	private CMakePropertiesController pc;
+	private ICMakePropertiesController pc;
 
 	private Map<IResource, IScannerInfo> infoPerResource;
 	/**
@@ -385,7 +388,7 @@ public class CMakeBuildConfiguration extends CBuildConfiguration {
 
 	/** Lazily creates the CMakePropertiesController for the project.
 	 */
-	private CMakePropertiesController getPropertiesController() {
+	private ICMakePropertiesController getPropertiesController() {
 		if (pc == null) {
 			final Path filePath = Path.of(getProject().getFile(".settings/CDT-cmake.yaml").getLocationURI()); //$NON-NLS-1$
 			pc = new CMakePropertiesController(filePath, () -> {

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/CMakeBuildConfigurationProvider.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/CMakeBuildConfigurationProvider.java
@@ -8,14 +8,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package org.eclipse.cdt.cmake.core.internal;
+package org.eclipse.cdt.cmake.core;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.cdt.cmake.core.ICMakeToolChainFile;
-import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
+import org.eclipse.cdt.cmake.core.internal.Activator;
 import org.eclipse.cdt.core.build.ICBuildConfiguration;
 import org.eclipse.cdt.core.build.ICBuildConfigurationManager;
 import org.eclipse.cdt.core.build.ICBuildConfigurationProvider;
@@ -27,6 +26,9 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 
+/**
+ * @since 1.6
+ */
 public class CMakeBuildConfigurationProvider implements ICBuildConfigurationProvider {
 
 	public static final String ID = "org.eclipse.cdt.cmake.core.provider"; //$NON-NLS-1$

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/CMakeExecutionMarkerFactory.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/CMakeExecutionMarkerFactory.java
@@ -16,7 +16,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 
 import org.eclipse.cdt.cmake.core.internal.Activator;
-import org.eclipse.cdt.cmake.core.internal.Messages;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.CoreException;

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/Messages.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/Messages.java
@@ -8,12 +8,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package org.eclipse.cdt.cmake.core.internal;
+package org.eclipse.cdt.cmake.core;
 
 import org.eclipse.osgi.util.NLS;
 
+/**
+ * @noextend This class is not intended to be subclassed by clients.
+ * @noinstantiate This class is not intended to be instantiated by clients.
+ * @noreference This class is not intended to be referenced by clients.
+ * @since 1.6
+ */
 public class Messages extends NLS {
-	private static final String BUNDLE_NAME = "org.eclipse.cdt.cmake.core.internal.messages"; //$NON-NLS-1$
+	private static final String BUNDLE_NAME = "org.eclipse.cdt.cmake.core.messages"; //$NON-NLS-1$
 	public static String CMakeBuildConfiguration_Building;
 	public static String CMakeBuildConfiguration_BuildingIn;
 	public static String CMakeBuildConfiguration_BuildingComplete;
@@ -22,8 +28,6 @@ public class Messages extends NLS {
 	public static String CMakeBuildConfiguration_Configuring;
 	public static String CMakeBuildConfiguration_ExitFailure;
 	public static String CMakeBuildConfiguration_NotFound;
-	public static String CMakeBuildConfiguration_ProcCompCmds;
-	public static String CMakeBuildConfiguration_ProcCompJson;
 	public static String CMakeBuildConfiguration_Failure;
 	public static String CMakeErrorParser_NotAWorkspaceResource;
 	static {

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeConsoleWrapper.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeConsoleWrapper.java
@@ -21,9 +21,8 @@ import org.eclipse.core.runtime.CoreException;
 /** Intercepts output to a console and forwards its error stream to a stream that does error parsing for processing.
 
  * @author Martin Weber
- *
  */
-class CMakeConsoleWrapper implements IConsole {
+public class CMakeConsoleWrapper implements IConsole {
 	private final IConsole delegate;
 	private final ConsoleOutputStream err;
 

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakePropertiesController.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakePropertiesController.java
@@ -41,7 +41,7 @@ import org.yaml.snakeyaml.representer.Representer;
  * us to delete file CMakeCache.txt to avoid complaints by cmake.
  * @author Martin Weber
  */
-class CMakePropertiesController implements ICMakePropertiesController {
+public class CMakePropertiesController implements ICMakePropertiesController {
 
 	private final Path storageFile;
 	private final Runnable cmakeCacheDirtyMarker;
@@ -62,7 +62,7 @@ class CMakePropertiesController implements ICMakePropertiesController {
 	 * 		the object to notify when modifications to the project properties force
 	 * us to delete file CMakeCache.txt to avoid complaints by cmake
 	 */
-	CMakePropertiesController(Path storageFile, Runnable cmakeCacheDirtyMarker) {
+	public CMakePropertiesController(Path storageFile, Runnable cmakeCacheDirtyMarker) {
 		this.storageFile = Objects.requireNonNull(storageFile);
 		this.cmakeCacheDirtyMarker = Objects.requireNonNull(cmakeCacheDirtyMarker);
 	}

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeToolChainFile.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeToolChainFile.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.cdt.cmake.core.CMakeBuildConfiguration;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainFile;
 import org.eclipse.cdt.core.build.IToolChain;
 import org.eclipse.cdt.core.build.IToolChainManager;

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeToolChainManager.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CMakeToolChainManager.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.eclipse.cdt.cmake.core.CMakeBuildConfiguration;
 import org.eclipse.cdt.cmake.core.CMakeToolChainEvent;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainFile;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainListener;

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CommandDescriptorBuilder.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/CommandDescriptorBuilder.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.eclipse.cdt.cmake.core.CMakeBuildConfiguration;
 import org.eclipse.cdt.cmake.core.properties.CMakeGenerator;
 import org.eclipse.cdt.cmake.core.properties.ICMakeProperties;
 import org.eclipse.cdt.cmake.core.properties.IOsOverrides;
@@ -29,7 +30,7 @@ import org.eclipse.core.variables.VariablesPlugin;
  *
  * @author Martin Weber
  */
-class CommandDescriptorBuilder {
+public class CommandDescriptorBuilder {
 
 	private final ICMakeProperties cmakeProperties;
 	private final IOsOverridesSelector overridesSelector;
@@ -37,7 +38,7 @@ class CommandDescriptorBuilder {
 	/**
 	 * @param cmakeProperties the project properties related to the cmake command
 	 */
-	CommandDescriptorBuilder(ICMakeProperties cmakeProperties, IOsOverridesSelector overridesSelector) {
+	public CommandDescriptorBuilder(ICMakeProperties cmakeProperties, IOsOverridesSelector overridesSelector) {
 		this.cmakeProperties = Objects.requireNonNull(cmakeProperties);
 		this.overridesSelector = Objects.requireNonNull(overridesSelector);
 	}
@@ -51,7 +52,7 @@ class CommandDescriptorBuilder {
 	 * @return the command-line arguments and environment to invoke cmake.
 	 * @throws CoreException
 	 */
-	CommandDescriptor makeCMakeCommandline(Path toolChainFile) throws CoreException {
+	public CommandDescriptor makeCMakeCommandline(Path toolChainFile) throws CoreException {
 		List<String> args = new ArrayList<>();
 		List<String> env = new ArrayList<>();
 
@@ -107,7 +108,7 @@ class CommandDescriptorBuilder {
 	 * @return the command-line arguments and environment to invoke cmake.
 	 * @throws CoreException
 	 */
-	CommandDescriptor makeCMakeBuildCommandline(String buildscriptTarget) throws CoreException {
+	public CommandDescriptor makeCMakeBuildCommandline(String buildscriptTarget) throws CoreException {
 		List<String> args = new ArrayList<>();
 		List<String> env = new ArrayList<>();
 
@@ -171,7 +172,7 @@ class CommandDescriptorBuilder {
 	 * Command-line arguments and additional environment variables to be used to run a process.
 	 * @author Martin Weber
 	 */
-	static final class CommandDescriptor {
+	public static final class CommandDescriptor {
 		private final List<String> arguments;
 		private final List<String> environment;
 

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/IOsOverridesSelector.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/IOsOverridesSelector.java
@@ -20,7 +20,7 @@ import org.eclipse.cdt.cmake.core.properties.IOsOverrides;
  *
  * @author Martin Weber
  */
-interface IOsOverridesSelector {
+public interface IOsOverridesSelector {
 	/**
 	 * Gets the overrides from the specified {@code ICMakeProperties} object that match the target
 	 * operating system. <br>

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/properties/AbstractOsOverrides.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/internal/properties/AbstractOsOverrides.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.eclipse.cdt.cmake.core.internal.CMakeBuildConfiguration;
+import org.eclipse.cdt.cmake.core.CMakeBuildConfiguration;
 import org.eclipse.cdt.cmake.core.properties.CMakeGenerator;
 import org.eclipse.cdt.cmake.core.properties.IOsOverrides;
 

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/messages.properties
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/messages.properties
@@ -16,7 +16,5 @@ CMakeBuildConfiguration_Configuring=Configuring in: %s\n
 CMakeBuildConfiguration_Cleaning=Cleaning %s
 CMakeBuildConfiguration_ExitFailure=%1$s exited with status %2$d. See CDT build console for details.
 CMakeBuildConfiguration_NotFound=CMakeFiles not found. Assuming clean.
-CMakeBuildConfiguration_ProcCompCmds=Processing compile commands %s
-CMakeBuildConfiguration_ProcCompJson=Processing compile_commands.json
 CMakeBuildConfiguration_Failure=Failure running cmake: %s\n
 CMakeErrorParser_NotAWorkspaceResource=Could not map %s to a workspace resource. Did the build run in a container?

--- a/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/CMakeBuildTab.java
+++ b/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/CMakeBuildTab.java
@@ -13,8 +13,8 @@ package org.eclipse.cdt.cmake.ui.internal;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.cdt.cmake.core.internal.CMakeBuildConfiguration;
-import org.eclipse.cdt.cmake.core.internal.CMakeBuildConfigurationProvider;
+import org.eclipse.cdt.cmake.core.CMakeBuildConfiguration;
+import org.eclipse.cdt.cmake.core.CMakeBuildConfigurationProvider;
 import org.eclipse.cdt.core.build.ICBuildConfiguration;
 import org.eclipse.cdt.launch.ui.corebuild.CommonBuildTab;
 import org.eclipse.debug.core.ILaunchConfiguration;

--- a/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/NewCMakeToolChainFilePage.java
+++ b/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/NewCMakeToolChainFilePage.java
@@ -12,9 +12,9 @@ package org.eclipse.cdt.cmake.ui.internal;
 
 import java.nio.file.Paths;
 
+import org.eclipse.cdt.cmake.core.CMakeBuildConfiguration;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainFile;
 import org.eclipse.cdt.cmake.core.ICMakeToolChainManager;
-import org.eclipse.cdt.cmake.core.internal.CMakeBuildConfiguration;
 import org.eclipse.cdt.core.build.IToolChain;
 import org.eclipse.cdt.core.build.IToolChainManager;
 import org.eclipse.core.runtime.CoreException;

--- a/core/org.eclipse.cdt.core.tests/model/org/eclipse/cdt/core/build/CBuildConfigurationManagerTests.java
+++ b/core/org.eclipse.cdt.core.tests/model/org/eclipse/cdt/core/build/CBuildConfigurationManagerTests.java
@@ -14,8 +14,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.eclipse.cdt.cmake.core.CMakeBuildConfigurationProvider;
 import org.eclipse.cdt.cmake.core.CMakeNature;
-import org.eclipse.cdt.cmake.core.internal.CMakeBuildConfigurationProvider;
 import org.eclipse.cdt.core.CCProjectNature;
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.CProjectNature;


### PR DESCRIPTION
For ISV integration/extension to CDT CMake, it is necessary to extend several non-API classes (eg: CMakeBuildConfiguration, CMakeBuildConfigurationProvider). This would cause "Discouraged access: The type XXX is not API" warnings.

The classes have now been made API so can be extended without warnings.

Addresses Issue: CDT CMake Improvements #1000, IDE-82683-REQ-017 Extending CMakeBuildConfiguration