### PR TITLE
Update path to dash-licenses

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   call-license-check:
-    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    uses: eclipse-dash/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
     with:
       projectId: tools.cdt
     secrets:


### PR DESCRIPTION
When Eclipse Dash got moved to its own org, the path the shared workflow needed to be updated. This commit does that

Part of #1002