### PR TITLE
Revert "workaround test results appearing in incorrect spot"

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -28,5 +28,3 @@ jobs:
           junit_files: "test-results/**/*.xml"
           event_file: test-results/event.json
           event_name: ${{ github.event.workflow_run.event }}
-          # Workaround as suggested in https://github.com/EnricoMi/publish-unit-test-result-action/issues/12
-          check_run: false


### PR DESCRIPTION
This reverts commit ae3aebcf7f0ddd82b2f83c9963e5621e37beb136.

Part of #1002