### PR TITLE
Run DSF-GDB tests when releng may have changed

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,12 +15,18 @@ jobs:
     - uses: dorny/paths-filter@v3
       id: filter
       with:
+        # dsf filters are to know when to run dsf-gdb tests (See ref below)
+        # it includes any changes to debug, or anything likely to affect gdb
+        # testing
         filters: |
           dsf:
             - 'dsf-gdb/**'
             - 'dsf/**'
             - 'debug/**'
             - 'jtag/**'
+            - 'pom.xml'
+            - 'releng/**'
+            - '.github/**'
           docs:
             - 'doc/org.eclipse.cdt.doc.user/**'
     - name: Set up JDK 21
@@ -50,6 +56,7 @@ jobs:
           -Dmaven.test.failure.ignore=true \
           -DexcludedGroups=flakyTest,slowTest \
           -Ddsf.gdb.tests.timeout.multiplier=50 \
+          -Ddsf-gdb.skip.tests=$(test ${{ steps.filter.outputs.dsf }} == 'false' && echo 'true' || echo 'false') \
           -Dindexer.timeout=300
     - name: Upload Logs
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
On a recent update to the target platform, the DSF-GDB tests did not run because none of the changes matched the dsf filter. Going forward, include running DSF tests when any releng changes happen.

This replaces commit 8d0642568c0. That commit ran the tests all the time, which was too slow.

Part of #1037