### PR TITLE
Restore the empty activity IDs

### DIFF
--- a/releng/org.eclipse.cdt/plugin.properties
+++ b/releng/org.eclipse.cdt/plugin.properties
@@ -17,3 +17,12 @@ cheatsheet.helloworld.desc=Create a Hello World Program in C++
 cheatsheet.helloworld.name=Hello World
 
 activity.name = Debug Update Modes
+activity.description.dsf = Debug Services Framework
+activity.name.dsf = CDT-DSF Debug Services Framework
+
+activity.description.dsfgdb = C/C++ debugging with the DSF GDB debugger
+activity.name.dsfgdb = CDT DSF-GDB - GDB Debugging
+activity.description.cdtdebug = Commands for C/C++ debugging
+activity.name.cdtdebug = CDT Debug - C/C++ Development Tools
+activity.description.cdigdb = C/C++ debugging with the CDI (legacy) GDB debugger
+activity.name.cdigdb = CDT CDI-GDB - GDB Debugging (Legacy)

--- a/releng/org.eclipse.cdt/plugin.xml
+++ b/releng/org.eclipse.cdt/plugin.xml
@@ -15,4 +15,42 @@
             pattern="org\.eclipse\.cdt\.dsf\.ui/org\.eclipse\.cdt\.dsf\.debug\.ui\.[A-Za-z]+\.viewmodel\.update\.actions\.refresh">
       </activityPatternBinding>
    </extension>
+
+<!-- In #974 I removed activities we were not using anymore, but it turns
+out if LaunchUtils.enableActivity is called on a removed id, strange
+things happen, such as other activities incorrectly being enabled.
+This may be a bug in platform, or just undefined behavior. But because
+extenders do have calls to LaunchUtils.enableActivity in their code,
+leave the empty activity ids behind. -->
+
+     <extension
+         point="org.eclipse.ui.activities">
+
+      <activity
+            name="%activity.name.dsf"
+            description="%activity.description.dsf"
+            id="org.eclipse.cdt.dsf.ui.dsfActivity">
+       </activity>
+
+      <activity
+            name="%activity.name.dsfgdb"
+            description="%activity.description.dsfgdb"
+            id="org.eclipse.cdt.debug.dsfgdbActivity">
+       </activity>
+
+       <activity
+            name="%activity.name.cdtdebug"
+            description="%activity.description.cdtdebug"
+            id="org.eclipse.cdt.debug.ui.cdtActivity">
+       </activity>
+
+		<defaultEnablement id="org.eclipse.cdt.debug.ui.cdtActivity" />
+
+        <activity
+            name="%activity.name.cdigdb"
+            description="%activity.description.cdigdb"
+            id="org.eclipse.cdt.debug.cdigdbActivity">
+       </activity>
+
+   </extension>
 </plugin>


### PR DESCRIPTION
In #974 I removed activities we were not using anymore, but it turns out if LaunchUtils.enableActivity is called on a removed id, strange things happen, such as other activities incorrectly being enabled. This may be a bug in platform, or just undefined behavior. But because extenders do have calls to LaunchUtils.enableActivity in their code, leave the empty activity ids behind.

Fixes #1044