### PR TITLE
Fix XML syntax error in freemarker manifest

### DIFF
--- a/cmake/org.eclipse.cdt.cmake.core/templates/simple/manifest.xml
+++ b/cmake/org.eclipse.cdt.cmake.core/templates/simple/manifest.xml
@@ -6,6 +6,6 @@
 	<file src="/templates/simple/config.h.in"
 		dest="/${projectName}/config.h.in"/>
 	<file src="/templates/simple/main.cpp"
-		dest="/${projectName}/${projectName?replace(" ", "_")}.cpp"
+		dest='/${projectName}/${projectName?replace(" ", "_")}.cpp'
 		open="true"/>
 </templateManifest>


### PR DESCRIPTION
The extra " inside XML property was actually being processed properly by freemarker (surprisingly!), but XML editors/viewers reported an error.