### PR TITLE
Fix mismatched id/name for CBuildConfigProvider

### DIFF
--- a/core/org.eclipse.cdt.core/plugin.xml
+++ b/core/org.eclipse.cdt.core/plugin.xml
@@ -795,7 +795,7 @@
    <extension-point id="LanguageSettingsProvider" name="%LanguageSettingsProvider.name" schema="schema/LanguageSettingsProvider.exsd"/>
    <extension-point id="UNCPathConverter" name="%uncPathConverter.name" schema="schema/UNCPathConverter.exsd"/>
    <extension-point id="ProblemMarkerFilter" name="%problemMarkerFilter.name" schema="schema/ProblemMarkerFilter.exsd"/>
-   <extension-point id="buildConfigProvider" name="buildConfigProvider" schema="schema/buildConfigProvider.exsd"/>
+   <extension-point id="buildConfigProvider" name="CBuildConfigProvider" schema="schema/buildConfigProvider.exsd"/>
    <extension-point id="toolChainProvider" name="Tool Chain Provider" schema="schema/toolChainProvider.exsd"/>
    <extension-point id="CommandLauncherFactory" name="CommandLauncherFactory" schema="schema/CommandLauncherFactory.exsd"/>
 

--- a/core/org.eclipse.cdt.core/schema/buildConfigProvider.exsd
+++ b/core/org.eclipse.cdt.core/schema/buildConfigProvider.exsd
@@ -3,7 +3,7 @@
 <schema targetNamespace="org.eclipse.cdt.core" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
       <appInfo>
-         <meta.schema plugin="org.eclipse.cdt.core" id="CBuildConfigProvider" name="CBuildConfigProvider"/>
+         <meta.schema plugin="org.eclipse.cdt.core" id="buildConfigProvider" name="CBuildConfigProvider"/>
       </appInfo>
       <documentation>
          [Enter description of this extension point.]


### PR DESCRIPTION
This seems to only cause issues when using the plugin.xml GUI editor because it cannot find the exsd file due to the incorrect id.