### PR TITLE
Add UI for user to control build type

### DIFF
--- a/cmake/org.eclipse.cdt.cmake.core.tests/src/org/eclipse/cdt/cmake/core/CMakeBuildConfigurationTests.java
+++ b/cmake/org.eclipse.cdt.cmake.core.tests/src/org/eclipse/cdt/cmake/core/CMakeBuildConfigurationTests.java
@@ -35,6 +35,7 @@ import org.eclipse.cdt.utils.CommandLineUtil;
 import org.eclipse.core.resources.IBuildConfiguration;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.launchbar.core.target.ILaunchTarget;
 import org.eclipse.launchbar.core.target.ILaunchTargetManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -89,6 +90,106 @@ public class CMakeBuildConfigurationTests extends BaseTestCase5 {
 		ICMakeProperties cMakeProperties = cmBuildConfig.getCMakeProperties();
 
 		assertThat(cMakeProperties.getGenerator(), is(CMakeGenerator.WatcomWMake));
+	}
+
+	/**
+	 * Test for IDE_82683_REQ_013 part of #1000
+	 * <br>
+	 * Testing {@link ICMakeProperties#getBuildType()} <br>
+	 * <br>
+	 * This test verify default build type is used in case:
+	 * {@link ICMakeBuildConfiguration#CMAKE_USE_DEFAULT_CMAKE_SETTINGS} is <code>true<code>
+	 */
+	@Test
+	public void getCMakePropertiesTestGetDefaultBuildType() {
+		// CMAKE_USE_DEFAULT_CMAKE_SETTINGS = "true"
+		CMakeBuildConfiguration cmBuildConfig;
+		ICMakeProperties cMakeProperties;
+		// Test for ILaunchManager.RUN_MODE
+		cmBuildConfig = new CMakeBuildConfiguration(buildConfig, "cmBuildConfigName", mockToolchain, null,
+				ILaunchManager.RUN_MODE, LOCAL_LAUNCH_TARGET);
+		cMakeProperties = cmBuildConfig.getCMakeProperties();
+		assertThat(cMakeProperties.getBuildType(), is("Release"));
+
+		// Test for ILaunchManager.DEBUG_MODE
+		cmBuildConfig = new CMakeBuildConfiguration(buildConfig, "cmBuildConfigName", mockToolchain, null,
+				ILaunchManager.DEBUG_MODE, LOCAL_LAUNCH_TARGET);
+		cMakeProperties = cmBuildConfig.getCMakeProperties();
+		assertThat(cMakeProperties.getBuildType(), is("Debug"));
+
+		// Test for ILaunchManager.PROFILE_MODE
+		cmBuildConfig = new CMakeBuildConfiguration(buildConfig, "cmBuildConfigName", mockToolchain, null,
+				ILaunchManager.PROFILE_MODE, LOCAL_LAUNCH_TARGET);
+		cMakeProperties = cmBuildConfig.getCMakeProperties();
+		assertThat(cMakeProperties.getBuildType(), is("Release"));
+	}
+
+	/**
+	 * Test for IDE_82683_REQ_013 part of #1000
+	 * <br>
+	 * This test verify default build type is used in case:
+	 * {@link ICMakeBuildConfiguration#CMAKE_USE_DEFAULT_CMAKE_SETTINGS} is <code>true<code>
+	 */
+	@Test
+	public void getCMakePropertiesLoadISVSelectBuildType_UseDefaultBuildType_1() {
+		ICMakeProperties cMakeProperties;
+		CMakeBuildConfiguration cmBuildConfig = new CMakeBuildConfiguration(buildConfig, "cmBuildConfigName",
+				mockToolchain, null, ILaunchManager.RUN_MODE, LOCAL_LAUNCH_TARGET);
+		// Setup ISV properties for CMakeBuildConfiguration
+		// CMAKE_USE_DEFAULT_CMAKE_SETTINGS = "true"
+		// CMAKE_BUILD_TYPE = "RelWithDebInfo"
+		cmBuildConfig.removeProperty(CMakeBuildConfiguration.CMAKE_BUILD_TYPE);
+		cmBuildConfig.setProperty(CMakeBuildConfiguration.CMAKE_USE_DEFAULT_CMAKE_SETTINGS, "true");
+		cmBuildConfig.setProperty(CMakeBuildConfiguration.CMAKE_BUILD_TYPE, "RelWithDebInfo");
+		// Expected: default build type is used (in this case: "Release" for ILaunchManager.RUN_MODE)
+		cMakeProperties = cmBuildConfig.getCMakeProperties();
+		assertThat(cMakeProperties.getBuildType(), is("Release"));
+	}
+
+	/**
+	 * Test for IDE_82683_REQ_013 part of #1000
+	 * <br>
+	 * This test verify default build type is used in case ISV build type is blank:
+	 * {@link ICMakeBuildConfiguration#CMAKE_USE_DEFAULT_CMAKE_SETTINGS} is <code>false<code> and
+	 * {@link ICMakeBuildConfiguration#CMAKE_BUILD_TYPE} is blank
+	 */
+	@Test
+	public void getCMakePropertiesLoadISVSelectBuildType_ISVBuildTypeIsBlank() {
+		ICMakeProperties cMakeProperties;
+		CMakeBuildConfiguration cmBuildConfig = new CMakeBuildConfiguration(buildConfig, "cmBuildConfigName",
+				mockToolchain, null, ILaunchManager.RUN_MODE, LOCAL_LAUNCH_TARGET);
+		// Setup ISV properties for CMakeBuildConfiguration
+		// CMAKE_USE_DEFAULT_CMAKE_SETTINGS = "false"
+		// CMAKE_BUILD_TYPE = ""
+		cmBuildConfig.removeProperty(CMakeBuildConfiguration.CMAKE_BUILD_TYPE);
+		cmBuildConfig.setProperty(CMakeBuildConfiguration.CMAKE_USE_DEFAULT_CMAKE_SETTINGS, "false");
+		cmBuildConfig.setProperty(CMakeBuildConfiguration.CMAKE_BUILD_TYPE, "");
+		// Expected: "Release" build type is used (in this case: "Release" for ILaunchManager.RUN_MODE)
+		cMakeProperties = cmBuildConfig.getCMakeProperties();
+		assertThat(cMakeProperties.getBuildType(), is("Release"));
+	}
+
+	/**
+	 * Test for IDE_82683_REQ_013 part of #1000
+	 * <br>
+	 * This test verify ISV's selected build type is used in case:
+	 * {@link ICMakeBuildConfiguration#CMAKE_USE_DEFAULT_CMAKE_SETTINGS} is <code>false<code> and
+	 * {@link ICMakeBuildConfiguration#CMAKE_BUILD_TYPE} is NOT blank
+	 */
+	@Test
+	public void getCMakePropertiesLoadISVSelectBuildType_UseISVBuildTypeNotBlank() {
+		ICMakeProperties cMakeProperties;
+		CMakeBuildConfiguration cmBuildConfig = new CMakeBuildConfiguration(buildConfig, "cmBuildConfigName",
+				mockToolchain, null, ILaunchManager.RUN_MODE, LOCAL_LAUNCH_TARGET);
+		// Setup ISV properties for CMakeBuildConfiguration
+		// CMAKE_USE_DEFAULT_CMAKE_SETTINGS = "false"
+		// CMAKE_BUILD_TYPE = "RelWithDebInfo"
+		cmBuildConfig.removeProperty(CMakeBuildConfiguration.CMAKE_BUILD_TYPE);
+		cmBuildConfig.setProperty(CMakeBuildConfiguration.CMAKE_USE_DEFAULT_CMAKE_SETTINGS, "false");
+		cmBuildConfig.setProperty(CMakeBuildConfiguration.CMAKE_BUILD_TYPE, "RelWithDebInfo");
+		// Expected: "RelWithDebInfo" build type is used
+		cMakeProperties = cmBuildConfig.getCMakeProperties();
+		assertThat(cMakeProperties.getBuildType(), is("RelWithDebInfo"));
 	}
 
 	/**

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/CMakeBuildConfiguration.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/CMakeBuildConfiguration.java
@@ -139,6 +139,12 @@ public class CMakeBuildConfiguration extends CBuildConfiguration implements ICMa
 			cmakeProperties.setAllTarget(allTarget);
 		}
 
+		String buildType = properties.get(CMAKE_BUILD_TYPE);
+		if (buildType == null || buildType.isBlank()) {
+			buildType = getDefaultProperties().get(CMAKE_BUILD_TYPE);
+		}
+		cmakeProperties.setBuildType(buildType);
+
 		return cmakeProperties;
 	}
 
@@ -177,13 +183,6 @@ public class CMakeBuildConfiguration extends CBuildConfiguration implements ICMa
 			ICMakeProperties cmakeProperties = getCMakeProperties();
 
 			runCMake |= !Files.exists(buildDir.resolve("CMakeCache.txt")); //$NON-NLS-1$
-
-			// Causes CMAKE_BUILD_TYPE to be set according to the launch mode
-			if (ILaunchManager.DEBUG_MODE.equals(getLaunchMode())) {
-				cmakeProperties.setBuildType("Debug"); //$NON-NLS-1$
-			} else {
-				cmakeProperties.setBuildType("Release"); //$NON-NLS-1$
-			}
 
 			if (!runCMake) {
 				ICMakeGenerator generator = cmakeProperties.getGenerator();
@@ -571,7 +570,8 @@ public class CMakeBuildConfiguration extends CBuildConfiguration implements ICMa
 				CMAKE_ARGUMENTS, CMAKE_ARGUMENTS_DEFAULT, //
 				CMAKE_BUILD_COMMAND, CMAKE_BUILD_COMMAND_DEFAULT, //
 				CMAKE_ALL_TARGET, CMAKE_ALL_TARGET_DEFAULT, //
-				CMAKE_CLEAN_TARGET, CMAKE_CLEAN_TARGET_DEFAULT //
+				CMAKE_CLEAN_TARGET, CMAKE_CLEAN_TARGET_DEFAULT, //
+				CMAKE_BUILD_TYPE, ILaunchManager.DEBUG_MODE.equals(getLaunchMode()) ? "Debug" : "Release" //$NON-NLS-1$ //$NON-NLS-2$
 		);
 	}
 

--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/ICMakeBuildConfiguration.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/ICMakeBuildConfiguration.java
@@ -71,6 +71,12 @@ public interface ICMakeBuildConfiguration {
 	public static final String CMAKE_CLEAN_TARGET_DEFAULT = "clean"; //$NON-NLS-1$
 
 	/**
+	 * Name of the build type set by user. Default of this value will be set based on Launch Mode
+	 * (i.e. Debug for Debug launch mode, Release for Run and other launch modes)
+	 */
+	public static final String CMAKE_BUILD_TYPE = "cmake.build.type"; //$NON-NLS-1$
+
+	/**
 	 * Converts the {@link ICBuildConfiguration}'s properties, using the keys defined above
 	 * into an {@link ICMakeProperties} that configures the CMake build processes.
 	 * @return A ICMakeProperties object. Must not be null.

--- a/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/Messages.java
+++ b/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/Messages.java
@@ -15,6 +15,9 @@ import org.eclipse.osgi.util.NLS;
 public class Messages extends NLS {
 
 	public static String CMakeBuildTab_BuildCommand;
+	public static String CMakeBuildTab_BuildType;
+	public static String CMakeBuildTab_BuildType_Tooltip;
+	public static String CMakeBuildTab_BuildTypeCombo_Tooltip;
 	public static String CMakeBuildTab_AllTarget;
 	public static String CMakeBuildTab_CleanTarget;
 	public static String CMakeBuildTab_Cmake;
@@ -25,6 +28,7 @@ public class Messages extends NLS {
 	public static String CMakeBuildTab_Toolchain;
 	public static String CMakeBuildTab_useDefaultCmakeSettings;
 	public static String CMakeBuildTab_useDefaultCmakeSettingsTip;
+	public static String CMakeBuildTab_UsedForLaunchMode;
 	public static String CMakePreferencePage_Add;
 	public static String CMakePreferencePage_ConfirmRemoveDesc;
 	public static String CMakePreferencePage_ConfirmRemoveTitle;

--- a/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/messages.properties
+++ b/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/messages.properties
@@ -1,4 +1,7 @@
 CMakeBuildTab_BuildCommand=Build command
+CMakeBuildTab_BuildType=Build type:
+CMakeBuildTab_BuildType_Tooltip=The build type (CMAKE_BUILD_TYPE) used by the generator.
+CMakeBuildTab_BuildTypeCombo_Tooltip=Typical build types (CMAKE_BUILD_TYPE) are listed. A custom build type can be entered.
 CMakeBuildTab_AllTarget=Build all target
 CMakeBuildTab_CleanTarget=Clean target
 CMakeBuildTab_Cmake=CMake
@@ -9,6 +12,7 @@ CMakeBuildTab_Settings=CMake Settings
 CMakeBuildTab_Toolchain=Toolchain
 CMakeBuildTab_useDefaultCmakeSettings=Use default CMake settings
 CMakeBuildTab_useDefaultCmakeSettingsTip=Use the default CMake settings that are provided by the toolchain and Core Build System
+CMakeBuildTab_UsedForLaunchMode=used for launch mode: {0}
 CMakePreferencePage_Add=Add...
 CMakePreferencePage_ConfirmRemoveDesc=Do you wish to deregister the selected files?
 CMakePreferencePage_ConfirmRemoveTitle=Deregister CMake ToolChain File


### PR DESCRIPTION
User can control the value of the CMake built type (CMAKE_BUILD_TYPE), for example Debug or Release via new UI in CMakeBuildTab

Addresses Issue: CDT CMake Improvements #1000, IDE-82683-REQ-013

![New UI for selecting build type](https://github.com/user-attachments/assets/028de1ac-4b19-4bdc-bf45-73c2f8e4ff36)
