### PR TITLE
Improve MinGW installation detection

### DIFF
--- a/build/org.eclipse.cdt.build.gcc.core/src/org/eclipse/cdt/build/gcc/core/internal/Msys2ToolChainProvider.java
+++ b/build/org.eclipse.cdt.build.gcc.core/src/org/eclipse/cdt/build/gcc/core/internal/Msys2ToolChainProvider.java
@@ -82,7 +82,7 @@ public class Msys2ToolChainProvider implements IToolChainProvider {
 		String installLocation = registry.getCurrentUserValue(key, "InstallLocation"); //$NON-NLS-1$
 		Path msysPath = Paths.get(installLocation);
 		boolean found = false;
-		for (String variant : List.of("mingw64", "ucrt64")) { //$NON-NLS-1$ //$NON-NLS-2$
+		for (String variant : List.of("ucrt64", "mingw64")) { //$NON-NLS-1$ //$NON-NLS-2$
 			Path gccPath = msysPath.resolve(variant + "\\bin\\gcc.exe"); //$NON-NLS-1$
 			if (Files.exists(gccPath)) {
 				IEnvironmentVariable[] vars = createEnvironmentVariables(msysPath, gccPath.getParent());

--- a/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/internal/core/MinGW.java
+++ b/core/org.eclipse.cdt.core/utils/org/eclipse/cdt/internal/core/MinGW.java
@@ -42,7 +42,8 @@ public class MinGW {
 	public static final String ENV_MSYS_HOME = "MSYS_HOME"; //$NON-NLS-1$
 	private static final String ENV_PATH = "PATH"; //$NON-NLS-1$
 	private static final Set<String> MSYS2_64BIT_NAMES = Set.of("MSYS2", "MSYS2 64bit"); //$NON-NLS-1$ //$NON-NLS-2$
-	private static final List<String> MSYS2_MINGW_SUBSYSTEMS = List.of("mingw64", "mingw32", "ucrt64"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	private static final List<String> MSYS2_MINGW_SUBSYSTEMS = List.of("ucrt64", "mingw64", "mingw32"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	private static final List<String> MSYS2_MINGW_SUBSYSTEM_SELECTION_TOOLS = List.of("clangd", "clang", "gcc"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
 	private static final boolean isWindowsPlatform = Platform.getOS().equals(Platform.OS_WIN32);
 
@@ -109,9 +110,14 @@ public class MinGW {
 						String installLocation = registry.getCurrentUserValue(compKey, "InstallLocation"); //$NON-NLS-1$
 						for (String subsys : MSYS2_MINGW_SUBSYSTEMS) {
 							String mingwLocation = installLocation + "\\" + subsys; //$NON-NLS-1$
-							File gccFile = new File(mingwLocation + "\\bin\\gcc.exe"); //$NON-NLS-1$
-							if (gccFile.canExecute()) {
-								rootValue = mingwLocation;
+							for (String toolName : MSYS2_MINGW_SUBSYSTEM_SELECTION_TOOLS) {
+								File toolFile = new File(mingwLocation + "\\bin\\" + toolName + ".exe"); //$NON-NLS-1$ //$NON-NLS-2$
+								if (toolFile.canExecute()) {
+									rootValue = mingwLocation;
+									break;
+								}
+							}
+							if (null != rootValue) {
 								break;
 							}
 						}

--- a/doc/org.eclipse.cdt.doc.user/concepts/cdt_c_before_you_begin.htm
+++ b/doc/org.eclipse.cdt.doc.user/concepts/cdt_c_before_you_begin.htm
@@ -36,13 +36,14 @@ Download and run the latest MSYS2 installer by following instructions on the <a 
 When you reach the UCRT64 environment prompt, use the following commands to install individual tools:</p>
 <p />
 <p><table style="border: 1px solid grey; border-collapse: collapse;">
-<tr><th style="border: 1px solid grey; padding: 5px;">Tool</th>   <th style="border: 1px solid grey; padding: 5px;">Installation command</th><tr>
-<tr><td style="border: 1px solid grey; padding: 5px;">clangd</td> <td style="border: 1px solid grey; padding: 5px;"><tt>pacman -S mingw-w64-ucrt-x86_64-clang-tools-extra</tt></td></tr>
-<tr><td style="border: 1px solid grey; padding: 5px;">cmake</td>  <td style="border: 1px solid grey; padding: 5px;"><tt>pacman -S mingw-w64-ucrt-x86_64-cmake</tt></td></tr>
-<tr><td style="border: 1px solid grey; padding: 5px;">gcc</td>    <td style="border: 1px solid grey; padding: 5px;"><tt>pacman -S mingw-w64-ucrt-x86_64-gcc</tt></td></tr>
-<tr><td style="border: 1px solid grey; padding: 5px;">gdb</td>    <td style="border: 1px solid grey; padding: 5px;"><tt>pacman -S mingw-w64-ucrt-x86_64-gdb</tt></td></tr>
-<tr><td style="border: 1px solid grey; padding: 5px;">make</td>   <td style="border: 1px solid grey; padding: 5px;"><tt>pacman -S make</tt></td></tr>
-<tr><td style="border: 1px solid grey; padding: 5px;">ninja</td>  <td style="border: 1px solid grey; padding: 5px;"><tt>pacman -S mingw-w64-ucrt-x86_64-ninja</tt></td></tr>
+<tr><th style="border: 1px solid grey; padding: 5px;">Tool</th>   <th style="border: 1px solid grey; padding: 5px;">Installation command</th>                                       <th style="border: 1px solid grey; padding: 5px;">Notes</th><tr>
+<tr><td style="border: 1px solid grey; padding: 5px;">clang</td>  <td style="border: 1px solid grey; padding: 5px;"><tt>pacman -S mingw-w64-ucrt-x86_64-clang</tt></td>             <td style="border: 1px solid grey; padding: 5px;">Provides the <i>LLVM with Clang</i> toolchain</td></tr>
+<tr><td style="border: 1px solid grey; padding: 5px;">clangd</td> <td style="border: 1px solid grey; padding: 5px;"><tt>pacman -S mingw-w64-ucrt-x86_64-clang-tools-extra</tt></td> <td style="border: 1px solid grey; padding: 5px;">Required by the <i>C/C++ Editor (LSP)</i></td></tr>
+<tr><td style="border: 1px solid grey; padding: 5px;">cmake</td>  <td style="border: 1px solid grey; padding: 5px;"><tt>pacman -S mingw-w64-ucrt-x86_64-cmake</tt></td>             <td style="border: 1px solid grey; padding: 5px;">Required for building <i>CMake</i> projects</td></tr>
+<tr><td style="border: 1px solid grey; padding: 5px;">gcc</td>    <td style="border: 1px solid grey; padding: 5px;"><tt>pacman -S mingw-w64-ucrt-x86_64-gcc</tt></td>               <td style="border: 1px solid grey; padding: 5px;">Provides the <i>MinGW GCC</i> toolchain</td></tr>
+<tr><td style="border: 1px solid grey; padding: 5px;">gdb</td>    <td style="border: 1px solid grey; padding: 5px;"><tt>pacman -S mingw-w64-ucrt-x86_64-gdb</tt></td>               <td style="border: 1px solid grey; padding: 5px;">Required for debugging</td></tr>
+<tr><td style="border: 1px solid grey; padding: 5px;">make</td>   <td style="border: 1px solid grey; padding: 5px;"><tt>pacman -S make</tt></td>                                    <td style="border: 1px solid grey; padding: 5px;">Required for building <i>Managed Build</i> projects</td></tr>
+<tr><td style="border: 1px solid grey; padding: 5px;">ninja</td>  <td style="border: 1px solid grey; padding: 5px;"><tt>pacman -S mingw-w64-ucrt-x86_64-ninja</tt></td></td>        <td style="border: 1px solid grey; padding: 5px;">Required for building <i>CMake</i> projects</td></tr>
 </table></p>
 </li>
 


### PR DESCRIPTION
- Look for `clang`, `gcc` or `clangd`
- Re-order search for MSYS2 MinGW subsystems
- Add clang installation info and notes to _Before you begin_ page

Relates to: https://github.com/eclipse-cdt/cdt-lsp/issues/424