### PR TITLE
Avoid null value being converted to "null" string in environment

### DIFF
--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/internal/core/envvar/EnvironmentVariableManager.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/internal/core/envvar/EnvironmentVariableManager.java
@@ -457,12 +457,24 @@ public class EnvironmentVariableManager implements IEnvironmentVariableManager {
 			case IEnvironmentVariable.ENVVAR_REPLACE:
 				env.put(name, var.getValue());
 				break;
-			case IEnvironmentVariable.ENVVAR_APPEND:
-				env.put(name, env.get(name) + var.getDelimiter() + var.getValue());
+			case IEnvironmentVariable.ENVVAR_APPEND: {
+				String oldValue = env.get(name);
+				if (oldValue == null) {
+					env.put(name, var.getValue());
+				} else {
+					env.put(name, oldValue + var.getDelimiter() + var.getValue());
+				}
 				break;
-			case IEnvironmentVariable.ENVVAR_PREPEND:
-				env.put(name, var.getValue() + var.getDelimiter() + env.get(name));
+			}
+			case IEnvironmentVariable.ENVVAR_PREPEND: {
+				String oldValue = env.get(name);
+				if (oldValue == null) {
+					env.put(name, var.getValue());
+				} else {
+					env.put(name, var.getValue() + var.getDelimiter() + oldValue);
+				}
 				break;
+			}
 			case IEnvironmentVariable.ENVVAR_REMOVE:
 				env.remove(name);
 				break;


### PR DESCRIPTION
If the CDT Variable is APPEND or PREPEND, and the incoming environment did not contain that variable name, the resulting environment would have null.

For example, if PATH was not set on the incoming environment, and PATH was supposed to be prepended with /usr/bin, this method would have set PATH=/usr/bin:null

This change ensures that the delimeter + null are not prended/appended when the incoming value is null.

Note that this fixes the "null" appearing in the output on the last point in this comment https://github.com/eclipse-cdt/cdt/pull/1067#issuecomment-2657796998