### PR TITLE
Include system environment when debugging core build

### DIFF
--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/ICBuildConfiguration.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/core/build/ICBuildConfiguration.java
@@ -151,6 +151,9 @@ public interface ICBuildConfiguration extends IAdaptable, IScannerInfoProvider {
 	 * @param env
 	 *            build environment
 	 * @since 6.1
+	 * @implNote Ensure you pass a new non-empty map containing the base environment
+	 * as this method modifies the passed in map adding the ICBuildConfiguration specific
+	 * overrides, such as applying the project's build environment.
 	 */
 	default void setBuildEnvironment(Map<String, String> env) {
 	}

--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/internal/launching/CoreBuildLocalDebugLaunchDelegate.java
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb/src/org/eclipse/cdt/dsf/gdb/internal/launching/CoreBuildLocalDebugLaunchDelegate.java
@@ -34,6 +34,7 @@ import org.eclipse.cdt.dsf.gdb.launching.ServicesLaunchSequence;
 import org.eclipse.cdt.dsf.gdb.service.GdbDebugServicesFactory;
 import org.eclipse.cdt.dsf.gdb.service.command.IGDBControl;
 import org.eclipse.cdt.dsf.service.DsfServicesTracker;
+import org.eclipse.cdt.utils.spawner.EnvironmentReader;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -77,6 +78,11 @@ public class CoreBuildLocalDebugLaunchDelegate extends CoreBuildLaunchConfigDele
 		ICBuildConfiguration buildConfig = getBuildConfiguration(configuration, mode, target, monitor);
 
 		Map<String, String> buildEnv = new HashMap<>();
+		Properties environmentVariables = EnvironmentReader.getEnvVars();
+		for (String key : environmentVariables.stringPropertyNames()) {
+			String value = environmentVariables.getProperty(key);
+			buildEnv.put(key, value);
+		}
 		buildConfig.setBuildEnvironment(buildEnv);
 		Properties envProps = new Properties();
 		envProps.putAll(buildEnv);


### PR DESCRIPTION
When doing a local launch, the only environment passed to the debuggee was the modified variables, typically just PATH. This meant all the other environment was lost.

This change does the same thing as all the other calls to setBuildEnvironment and passes in the initial system environment.

I added a small note to the API of setBuildEnvironment to try to avoid this error in the future.

Note that this fixes the missing incoming environment part of the last point in this comment https://github.com/eclipse-cdt/cdt/pull/1067#issuecomment-2657796998