### PR TITLE
Refresh compile_commands.json during the build

### DIFF
--- a/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/CMakeBuildConfiguration.java
+++ b/cmake/org.eclipse.cdt.cmake.core/src/org/eclipse/cdt/cmake/core/CMakeBuildConfiguration.java
@@ -237,6 +237,7 @@ public class CMakeBuildConfiguration extends CBuildConfiguration implements ICMa
 			}
 
 			// parse compile_commands.json file
+			getCompileCommandsFile().refreshLocal(IResource.DEPTH_ZERO, monitor);
 			processCompileCommandsFile(console, monitor);
 
 			infoStream.write(String.format(Messages.CMakeBuildConfiguration_BuildingIn, buildDir.toString()));
@@ -346,6 +347,10 @@ public class CMakeBuildConfiguration extends CBuildConfiguration implements ICMa
 		}
 	}
 
+	private IFile getCompileCommandsFile() throws CoreException {
+		return getBuildContainer().getFile(new org.eclipse.core.runtime.Path("compile_commands.json")); //$NON-NLS-1$
+	}
+
 	/**
 	 * @param console the console to print the compiler output during built-ins detection to or
 	 *                <code>null</code> if no separate console is to be allocated. Ignored if
@@ -353,7 +358,7 @@ public class CMakeBuildConfiguration extends CBuildConfiguration implements ICMa
 	 * @param monitor the job's progress monitor
 	 */
 	private void processCompileCommandsFile(IConsole console, IProgressMonitor monitor) throws CoreException {
-		IFile file = getBuildContainer().getFile(new org.eclipse.core.runtime.Path("compile_commands.json")); //$NON-NLS-1$
+		IFile file = getCompileCommandsFile();
 		CompileCommandsJsonParser parser = new CompileCommandsJsonParser(
 				new ParseRequest(file, new CMakeIndexerInfoConsumer(this::setScannerInformation),
 						CommandLauncherManager.getInstance().getCommandLauncher(this), console));


### PR DESCRIPTION
CMake compile_commands.json file is not found even though it has been created. During a CMake build's generation stage, it generates the compile_commands.json file inside the build folder. However, when it comes to be used it is not found because it hasn't been reliably refreshed.

To solve this, the file resource is refreshed