### PR TITLE
Add accessor for included pty instance

### DIFF
--- a/core/org.eclipse.cdt.core.native/about.properties
+++ b/core/org.eclipse.cdt.core.native/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2014, 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2014, 2025 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -24,7 +24,7 @@ blurb=C/C++ Development Tooling Native Utilities\n\
 Version: {featureVersion}\n\
 Build id: {0}\n\
 \n\
-Copyright (c) 2014, 2024 Contributors to the Eclipse Foundation
+Copyright (c) 2014, 2025 Contributors to the Eclipse Foundation
 \n\
 See the NOTICE file(s) distributed with this work for additional\n\
 information regarding copyright ownership.\n\

--- a/core/org.eclipse.cdt.core.native/src/org/eclipse/cdt/utils/spawner/Spawner.java
+++ b/core/org.eclipse.cdt.core.native/src/org/eclipse/cdt/utils/spawner/Spawner.java
@@ -423,6 +423,14 @@ public class Spawner extends Process {
 		return (raise(pid, SIG_NOOP) == 0);
 	}
 
+	/**
+	 * @since 6.3
+	 * @return the current pty instance for this spawner
+	 */
+	public PTY pty() {
+		return fPty;
+	}
+
 	private void exec(String[] cmdarray, String[] envp, String dirpath) throws IOException {
 		String command = cmdarray[0];
 		SecurityManager s = System.getSecurityManager();


### PR DESCRIPTION
Currently if I get passed a Process from by a method call I can check it for the Spawner and can already call special methods like hangup(). But there is no way to get access the the PTY used to create the Spawner so for example one can't call PTY#setTerminalSize or query any other properties.

This now adds a new method pty() that returns this instance for further investigation and actions.

See
- https://github.com/eclipse-platform/eclipse.platform/pull/1762#issuecomment-2708081348