### PR TITLE
Preserve the order of referenced projects (#1126)

### DIFF
--- a/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/internal/core/CommonBuilder.java
+++ b/build/org.eclipse.cdt.managedbuilder.core/src/org/eclipse/cdt/managedbuilder/internal/core/CommonBuilder.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -624,7 +625,7 @@ public class CommonBuilder extends ACBuilder implements IIncrementalProjectBuild
 	}
 
 	private IConfiguration[] getReferencedConfigs(IBuilder[] builders) {
-		Set<IConfiguration> set = new HashSet<>();
+		Set<IConfiguration> set = new LinkedHashSet<>(); //preserve order
 		for (IBuilder builder : builders) {
 			IConfiguration cfg = builder.getParent().getParent();
 			IConfiguration refs[] = ManagedBuildManager.getReferencedConfigurations(cfg);


### PR DESCRIPTION
With this it is guaranteed the reference projects are kept in order. This will fix the build problems described in #1126 with multiple projects referenced that may have dependencies between each other and the order matters.

Tested with CDT 11.3.0