### PR TITLE
[#1155] replace duplicate image descriptor

### DIFF
--- a/memory/org.eclipse.cdt.debug.ui.memory.floatingpoint/src/org/eclipse/cdt/debug/ui/memory/floatingpoint/FPRendering.java
+++ b/memory/org.eclipse.cdt.debug.ui.memory.floatingpoint/src/org/eclipse/cdt/debug/ui/memory/floatingpoint/FPRendering.java
@@ -1198,7 +1198,7 @@ class CopyAction extends Action {
 		setImageDescriptor(
 				DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_COPY_VIEW_TO_CLIPBOARD));
 		setHoverImageDescriptor(
-				DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_LCL_COPY_VIEW_TO_CLIPBOARD));
+				DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_COPY_VIEW_TO_CLIPBOARD));
 		setDisabledImageDescriptor(
 				DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_DLCL_COPY_VIEW_TO_CLIPBOARD));
 	}


### PR DESCRIPTION
due to this platform change: Remove hover and duplicate image descriptors in org.eclipse.ui.debug
(https://github.com/eclipse-platform/eclipse.platform/commit/be4a4aab487dd8b762da580d9af076fbd1ce2279)

fixes #1155