### PR TITLE
Only import the terminal.control

### DIFF
--- a/terminal/features/org.eclipse.tm.terminal.control.feature/feature.xml
+++ b/terminal/features/org.eclipse.tm.terminal.control.feature/feature.xml
@@ -35,15 +35,9 @@
    </license>
 
    <requires>
+      <import plugin="org.eclipse.tm.terminal.control" version="5.5.0" match="compatible"/>
       <import plugin="org.eclipse.core.runtime"/>
       <import plugin="org.eclipse.ui"/>
    </requires>
-
-   <plugin
-         id="org.eclipse.tm.terminal.control"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
 
 </feature>


### PR DESCRIPTION
The terminal control is migrated to the Eclipse platform, as those it should be handled like a thrid-party dependency an not directly included with an exact version in the feature.

This now changes it to a requirement with a lower bound of 5.5 excluding the next major version. That way CDT and other consumers can gracefully upgrade to the new platform variant.

In general I think one would not need the feature at all today, as dependencies will be pulled in anyways if installing any of the other ones, but removing it is currently a bit out of scope, so this seems the most compatible way.

FYI @merks 