### PR TITLE
Improve CMake Build Settings labels - fixes #1120

### DIFF
--- a/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/CMakeBuildTab.java
+++ b/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/CMakeBuildTab.java
@@ -90,10 +90,11 @@ public class CMakeBuildTab extends CommonBuildTab {
 
 		generatorLabel = new Label(cmakeGroup, SWT.NONE);
 		generatorLabel.setText(Messages.CMakeBuildTab_Generator);
-
+		generatorLabel.setToolTipText(Messages.CMakeBuildTab_GeneratorTooltip);
 		CMakeGenerator[] generators = CMakeGenerator.values();
 		String[] generatorNames = Arrays.stream(generators).map(CMakeGenerator::getCMakeName).toArray(String[]::new);
 		generatorCombo = new Combo(cmakeGroup, SWT.DROP_DOWN);
+		generatorCombo.setToolTipText(Messages.CMakeBuildTab_GeneratorComboTooltip);
 		generatorCombo.setItems(generatorNames);
 		generatorCombo.select(0);
 		generatorCombo.addModifyListener(e -> updateLaunchConfigurationDialog());
@@ -106,29 +107,37 @@ public class CMakeBuildTab extends CommonBuildTab {
 
 		cmakeArgsLabel = new Label(cmakeGroup, SWT.NONE);
 		cmakeArgsLabel.setText(Messages.CMakeBuildTab_CMakeArgs);
+		cmakeArgsLabel.setToolTipText(Messages.CMakeBuildTab_cmakeArgsTooltip);
 
 		cmakeArgsText = new Text(cmakeGroup, SWT.BORDER);
+		cmakeArgsText.setToolTipText(Messages.CMakeBuildTab_cmakeArgsTooltip);
 		cmakeArgsText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		cmakeArgsText.addModifyListener(e -> updateLaunchConfigurationDialog());
 
 		buildCommandLabel = new Label(cmakeGroup, SWT.NONE);
 		buildCommandLabel.setText(Messages.CMakeBuildTab_BuildCommand);
+		buildCommandLabel.setToolTipText(Messages.CMakeBuildTab_buildCommandTooltip);
 
 		buildCommandText = new Text(cmakeGroup, SWT.BORDER);
+		buildCommandText.setToolTipText(Messages.CMakeBuildTab_buildCommandTooltip);
 		buildCommandText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		buildCommandText.addModifyListener(e -> updateLaunchConfigurationDialog());
 
 		allTargetLabel = new Label(cmakeGroup, SWT.NONE);
 		allTargetLabel.setText(Messages.CMakeBuildTab_AllTarget);
+		allTargetLabel.setToolTipText(Messages.CMakeBuildTab_allTargetTooltip);
 
 		allTargetText = new Text(cmakeGroup, SWT.BORDER);
+		allTargetText.setToolTipText(Messages.CMakeBuildTab_allTargetTooltip);
 		allTargetText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		allTargetText.addModifyListener(e -> updateLaunchConfigurationDialog());
 
 		cleanTargetLabel = new Label(cmakeGroup, SWT.NONE);
 		cleanTargetLabel.setText(Messages.CMakeBuildTab_CleanTarget);
+		cleanTargetLabel.setToolTipText(Messages.CMakeBuildTab_cleanTargetTooltip);
 
 		cleanTargetText = new Text(cmakeGroup, SWT.BORDER);
+		cleanTargetText.setToolTipText(Messages.CMakeBuildTab_cleanTargetTooltip);
 		cleanTargetText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		cleanTargetText.addModifyListener(e -> updateLaunchConfigurationDialog());
 

--- a/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/Messages.java
+++ b/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/Messages.java
@@ -19,10 +19,16 @@ public class Messages extends NLS {
 	public static String CMakeBuildTab_BuildType_Tooltip;
 	public static String CMakeBuildTab_BuildTypeCombo_Tooltip;
 	public static String CMakeBuildTab_AllTarget;
+	public static String CMakeBuildTab_allTargetTooltip;
+	public static String CMakeBuildTab_buildCommandTooltip;
 	public static String CMakeBuildTab_CleanTarget;
 	public static String CMakeBuildTab_Cmake;
 	public static String CMakeBuildTab_CMakeArgs;
+	public static String CMakeBuildTab_cleanTargetTooltip;
+	public static String CMakeBuildTab_cmakeArgsTooltip;
 	public static String CMakeBuildTab_Generator;
+	public static String CMakeBuildTab_GeneratorComboTooltip;
+	public static String CMakeBuildTab_GeneratorTooltip;
 	public static String CMakeBuildTab_NoneAvailable;
 	public static String CMakeBuildTab_Settings;
 	public static String CMakeBuildTab_Toolchain;

--- a/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/messages.properties
+++ b/cmake/org.eclipse.cdt.cmake.ui/src/org/eclipse/cdt/cmake/ui/internal/messages.properties
@@ -1,12 +1,18 @@
-CMakeBuildTab_BuildCommand=Build command
+CMakeBuildTab_BuildCommand=Build command:
 CMakeBuildTab_BuildType=Build type:
-CMakeBuildTab_BuildType_Tooltip=The build type (CMAKE_BUILD_TYPE) used by the generator.
-CMakeBuildTab_BuildTypeCombo_Tooltip=Typical build types (CMAKE_BUILD_TYPE) are listed. A custom build type can be entered.
-CMakeBuildTab_AllTarget=Build all target
-CMakeBuildTab_CleanTarget=Clean target
+CMakeBuildTab_BuildType_Tooltip=The build type (CMAKE_BUILD_TYPE) used by the generator
+CMakeBuildTab_BuildTypeCombo_Tooltip=Typical build types (CMAKE_BUILD_TYPE) are listed. A custom build type can be entered
+CMakeBuildTab_AllTarget=Build target:
+CMakeBuildTab_allTargetTooltip=Target to pass to --target CMake command line option, when user performs a project build
+CMakeBuildTab_buildCommandTooltip=The CMake executable to use. Maybe an absolute path to use a specific version
+CMakeBuildTab_CleanTarget=Clean target:
+CMakeBuildTab_cleanTargetTooltip=Target to pass to --target CMake command line option, when user performs a project clean
+CMakeBuildTab_cmakeArgsTooltip=-D <var>=<value> defines the value of a cache variable. Space separate multiple values
 CMakeBuildTab_Cmake=CMake
 CMakeBuildTab_CMakeArgs=Additional CMake arguments:
-CMakeBuildTab_Generator=Generator
+CMakeBuildTab_Generator=Generator:
+CMakeBuildTab_GeneratorComboTooltip=The kind of buildsystem to generate (-G). A custom generator can be entered
+CMakeBuildTab_GeneratorTooltip=The kind of buildsystem to generate (-G)
 CMakeBuildTab_NoneAvailable=No Toolchains Available for this Target
 CMakeBuildTab_Settings=CMake Settings
 CMakeBuildTab_Toolchain=Toolchain


### PR DESCRIPTION
The "Build all target" label was renamed to "Build target" to better reflect what the control does.

Also added tooltips to the tab's controls.