### PR TITLE
Set CC and CXX environment variables for clang toolchain

### DIFF
--- a/build/org.eclipse.cdt.build.gcc.core/src/org/eclipse/cdt/build/gcc/core/ClangToolChain.java
+++ b/build/org.eclipse.cdt.build.gcc.core/src/org/eclipse/cdt/build/gcc/core/ClangToolChain.java
@@ -11,8 +11,12 @@
 package org.eclipse.cdt.build.gcc.core;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.eclipse.cdt.core.build.IToolChainProvider;
+import org.eclipse.cdt.core.envvar.EnvironmentVariable;
 import org.eclipse.cdt.core.envvar.IEnvironmentVariable;
 
 /**
@@ -28,7 +32,29 @@ public class ClangToolChain extends GCCToolChain {
 
 	public ClangToolChain(IToolChainProvider provider, Path pathToToolChain, String arch,
 			IEnvironmentVariable[] envVars) {
-		super(provider, pathToToolChain, arch, envVars);
+		super(provider, pathToToolChain, arch, addClangEnvVars(envVars));
+	}
+
+	private static IEnvironmentVariable[] addClangEnvVars(IEnvironmentVariable[] envVars) {
+		List<IEnvironmentVariable> envVarsNew = new ArrayList<>(Arrays.asList(envVars));
+		/*
+		 * Set CC and CXX environment variables for clang and clang++. This is equivalent to setting these in the
+		 * CMakeLists.txt:
+		 * set(CMAKE_C_COMPILER clang)
+		 * set(CMAKE_CXX_COMPILER clang++)
+		 */
+		addIfAbsent("cc", "clang", envVarsNew); //$NON-NLS-1$ //$NON-NLS-2$
+		addIfAbsent("cxx", "clang++", envVarsNew); //$NON-NLS-1$ //$NON-NLS-2$
+
+		return envVarsNew.toArray(new EnvironmentVariable[0]);
+	}
+
+	private static void addIfAbsent(String name, String value, List<IEnvironmentVariable> envVarsNew) {
+		boolean isAbsent = envVarsNew.stream().noneMatch(ev -> ev.getName().equals(name));
+
+		if (isAbsent) {
+			envVarsNew.add(new EnvironmentVariable(name, value, IEnvironmentVariable.ENVVAR_APPEND, null));
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Sets the C and C++ compiler environment variables so CMake uses Clang instead of the system default compiler.

Fixes #1140