### PR TITLE
Also use clang executable to identify LLVM tools installation

### DIFF
--- a/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/META-INF/MANIFEST.MF
+++ b/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.managedbuilder.llvm.ui;singleton:=true
-Bundle-Version: 1.4.400.qualifier
+Bundle-Version: 1.4.500.qualifier
 Bundle-Activator: org.eclipse.cdt.managedbuilder.llvm.ui.LlvmUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/src/org/eclipse/cdt/managedbuilder/llvm/ui/LlvmEnvironmentVariableSupplier.java
+++ b/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/src/org/eclipse/cdt/managedbuilder/llvm/ui/LlvmEnvironmentVariableSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2016 Nokia Siemens Networks Oyj, Finland.
+ * Copyright (c) 2010, 2025 Nokia Siemens Networks Oyj, Finland.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,11 +13,13 @@
  *      Leo Hippelainen - Initial implementation
  *      Petri Tuononen - Initial implementation
  *      Marc-Andre Laperle (Ericsson)
+ *      John Dallaway - Improve LLVM tools installation detection (#1175)
  *******************************************************************************/
 package org.eclipse.cdt.managedbuilder.llvm.ui;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 
 import org.eclipse.cdt.internal.core.MinGW;
 import org.eclipse.cdt.managedbuilder.core.IConfiguration;
@@ -48,6 +50,7 @@ public class LlvmEnvironmentVariableSupplier implements IConfigurationEnvironmen
 	private static final String ENV_VAR_NAME_INCLUDE_PATH = "INCLUDE_PATH"; //$NON-NLS-1$
 	private static final String ENV_VAR_NAME_LIBRARY_PATH = "LLVM_LIB_SEARCH_PATH"; //$NON-NLS-1$
 	private static final String ENV_VAR_NAME_LIBRARIES = "LIBRARIES"; //$NON-NLS-1$
+	private static final List<String> LLVM_BIN_SELECTION_TOOLS = List.of("llvm-ar", "clang"); //$NON-NLS-1$ //$NON-NLS-2$
 
 	/**
 	 * Initializes llvm environment variable paths from the system environment variables.
@@ -268,7 +271,7 @@ public class LlvmEnvironmentVariableSupplier implements IConfigurationEnvironmen
 			llvmPath = llvmPath + Separators.getFileSeparator() + subPath;
 		}
 		// Return a full path for LLVM executable if it's valid, otherwise null.
-		return getBinDirIfLlvm_ar(llvmPath);
+		return getBinDirIfLlvm(llvmPath);
 	}
 
 	/**
@@ -276,23 +279,24 @@ public class LlvmEnvironmentVariableSupplier implements IConfigurationEnvironmen
 	 * as a parameter is found and executable exists in that path.
 	 *
 	 * @param binPathTemp User provided bin directory path
-	 * @return bin path where llvm-ar is located if executable exists
+	 * @return bin path where LLVM is located if executable exists
 	 */
-	private static String getBinDirIfLlvm_ar(String binPathTemp) {
+	private static String getBinDirIfLlvm(String binPathTemp) {
 		//if given directory is found
 		if (new Path(binPathTemp).toFile().isDirectory()) {
-			String llvm_executable = "llvm-ar"; //$NON-NLS-1$
-			File arFileFullPath = null;
-			// If OS is Windows -> add .exe to the executable name.
-			if (System.getProperty("os.name").toLowerCase().indexOf("win") >= 0) { //$NON-NLS-1$//$NON-NLS-2$
-				llvm_executable = llvm_executable + ".exe"; //$NON-NLS-1$
-			}
-			// Form full executable path
-			arFileFullPath = new File(binPathTemp, llvm_executable);
-			// Check if file exists -> proper LLVM installation exists.
-			if (arFileFullPath.isFile()) {
-				// Return path where llvm-ar exists.
-				return binPathTemp;
+			for (String llvm_executable : LLVM_BIN_SELECTION_TOOLS) {
+				File arFileFullPath = null;
+				// If OS is Windows -> add .exe to the executable name.
+				if (System.getProperty("os.name").toLowerCase().indexOf("win") >= 0) { //$NON-NLS-1$//$NON-NLS-2$
+					llvm_executable = llvm_executable + ".exe"; //$NON-NLS-1$
+				}
+				// Form full executable path
+				arFileFullPath = new File(binPathTemp, llvm_executable);
+				// Check if file exists -> proper LLVM installation exists.
+				if (arFileFullPath.isFile()) {
+					// Return path where LLVM executable exists.
+					return binPathTemp;
+				}
 			}
 		}
 		return null;


### PR DESCRIPTION
Use either `clang` or `llvm-ar` to locate an LLVM tools installation. The XCode _Command Line Tools_ do not include `llvm-ar`. Other installations of LLVM tools that lie ahead of `/usr/bin` on the `PATH` will take precedence.

Relates to: #1175