### PR TITLE
Fixes User Defined Toolchain clang type forgetfulness

### DIFF
--- a/build/org.eclipse.cdt.build.gcc.core/src/org/eclipse/cdt/build/gcc/core/GCCUserToolChainProvider.java
+++ b/build/org.eclipse.cdt.build.gcc.core/src/org/eclipse/cdt/build/gcc/core/GCCUserToolChainProvider.java
@@ -154,6 +154,7 @@ public class GCCUserToolChainProvider implements IUserToolChainProvider {
 		toolChains.add(newtc);
 
 		newtc.addProperty(ID, gcc.getId());
+		newtc.addProperty(TYPE, gcc.getTypeId());
 		newtc.addProperty(ARCH, gcc.getProperty(IToolChain.ATTR_ARCH));
 		newtc.addProperty(PATH, gcc.getPath().toString());
 


### PR DESCRIPTION
When a User Defined Toolchain of type clang was created (Preferences > C/C++ > Core Build Toolchains > User Defined Toolchains) the Type was reported correctly as clang. But after restarting the workbench the Type was reported as GCC. This is now fixed so the Type always shows as clang for a clang toolchain.

![clang tc added - before workbench restart](https://github.com/user-attachments/assets/1bcfe416-3915-4350-912a-1a06074ed9f2)
