### PR TITLE
Build not configured correctly

### DIFF
--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core; singleton:=true
-Bundle-Version: 9.2.0.qualifier
+Bundle-Version: 9.2.100.qualifier
 Bundle-Activator: org.eclipse.cdt.core.CCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core/src/org/eclipse/cdt/internal/core/build/CBuildConfigurationManager.java
+++ b/core/org.eclipse.cdt.core/src/org/eclipse/cdt/internal/core/build/CBuildConfigurationManager.java
@@ -247,6 +247,12 @@ public class CBuildConfigurationManager
 		ICBuildConfiguration config = null;
 		boolean resetBinaryParser = false;
 		synchronized (configs) {
+			// Due to an unlucky order of events, by a call of BuildConfiguration.getAdapter(ICBuildConfiguration.class)
+			// in a parallel process, buildConfig could have been added to "noConfigs, just before it was added to
+			// "configs". E.g. by CCorePlugin.getScannerInfoProvider() in the Indexer job.
+			if (noConfigs.contains(buildConfig) && configs.containsKey(buildConfig)) {
+				noConfigs.remove(buildConfig);
+			}
 			if (!noConfigs.contains(buildConfig)) {
 				config = configs.get(buildConfig);
 				if (config == null) {


### PR DESCRIPTION
Under some circumstances it can happen that a BuildConfiguration is registered in the CBuildConfigurationManger as both a valid and invalid ICBuildConfiguration counterpart. This results in a "Build not configured correctly" error when trying to build a CoreBuild project. This change removes valid build configurations from the invalid list before looking for the counterpart.