### PR TITLE
Do not require org.eclipse.tm.terminal.view.core in the feature

### DIFF
--- a/terminal/features/org.eclipse.tm.terminal.view.feature/feature.xml
+++ b/terminal/features/org.eclipse.tm.terminal.view.feature/feature.xml
@@ -39,13 +39,6 @@
    </requires>
 
    <plugin
-         id="org.eclipse.tm.terminal.view.core"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.tm.terminal.view.ui"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
The plugin org.eclipse.tm.terminal.view.core [is moved to platform](https://github.com/eclipse-platform/eclipse.platform/pull/1959) and should therefore be handled like any other third party dependency. It actually is already part of the feature imports and the org.eclipse.tm.terminal.view.ui require bundle it, so mentioning that one is actually redundant and fixes it to that particular version otherwise.