### PR TITLE
Extend Mach-O load command support

### DIFF
--- a/core/org.eclipse.cdt.core/.settings/.api_filters
+++ b/core/org.eclipse.cdt.core/.settings/.api_filters
@@ -26,4 +26,68 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="utils/org/eclipse/cdt/utils/macho/MachO64.java" type="org.eclipse.cdt.utils.macho.MachO64$LoadCommand">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.cdt.utils.macho.MachO64.LoadCommand"/>
+                <message_argument value="LC_BUILD_VERSION"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.cdt.utils.macho.MachO64.LoadCommand"/>
+                <message_argument value="LC_CODE_SIGNATURE"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.cdt.utils.macho.MachO64.LoadCommand"/>
+                <message_argument value="LC_DATA_IN_CODE"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.cdt.utils.macho.MachO64.LoadCommand"/>
+                <message_argument value="LC_DYLD_CHAINED_FIXUPS"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.cdt.utils.macho.MachO64.LoadCommand"/>
+                <message_argument value="LC_DYLD_EXPORTS_TRIE"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.cdt.utils.macho.MachO64.LoadCommand"/>
+                <message_argument value="LC_FUNCTION_STARTS"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.cdt.utils.macho.MachO64.LoadCommand"/>
+                <message_argument value="LC_MAIN"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.cdt.utils.macho.MachO64.LoadCommand"/>
+                <message_argument value="LC_SOURCE_VERSION"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="utils/org/eclipse/cdt/utils/macho/MachO64.java" type="org.eclipse.cdt.utils.macho.MachO64$MachOhdr">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.cdt.utils.macho.MachO64.MachOhdr"/>
+                <message_argument value="CPU_TYPE_ARM"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.cdt.utils.macho.MachO64.MachOhdr"/>
+                <message_argument value="CPU_TYPE_ARM64"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core; singleton:=true
-Bundle-Version: 9.1.100.qualifier
+Bundle-Version: 9.2.0.qualifier
 Bundle-Activator: org.eclipse.cdt.core.CCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
We skip load commands that are not processed by the symbol loader and log commands that are not recognized.

Relates to: #1204