### PR TITLE
GDB Remote launch targets load attributes when editing.

### DIFF
--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb.ui/META-INF/MANIFEST.MF
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.cdt.dsf.gdb.ui;singleton:=true
-Bundle-Version: 2.8.800.qualifier
+Bundle-Version: 2.8.900.qualifier
 Bundle-Activator: org.eclipse.cdt.dsf.gdb.internal.ui.GdbUIPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="[3.207.200,4)",

--- a/dsf-gdb/org.eclipse.cdt.dsf.gdb.ui/src/org/eclipse/cdt/dsf/gdb/internal/ui/launching/NewGdbRemoteTCPTargetWizard.java
+++ b/dsf-gdb/org.eclipse.cdt.dsf.gdb.ui/src/org/eclipse/cdt/dsf/gdb/internal/ui/launching/NewGdbRemoteTCPTargetWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 QNX Software Systems and others.
+ * Copyright (c) 2019, 2025 QNX Software Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -50,6 +50,16 @@ public class NewGdbRemoteTCPTargetWizard extends LaunchTargetWizard {
 			Composite control = new Composite(parent, SWT.NONE);
 			control.setLayout(new GridLayout());
 
+			String targetName = ""; //$NON-NLS-1$
+			String targetHostName = ""; //$NON-NLS-1$
+			String targetPort = ""; //$NON-NLS-1$
+			ILaunchTarget launchTarget = getLaunchTarget();
+			if (launchTarget != null) {
+				targetName = launchTarget.getId();
+				targetHostName = launchTarget.getAttribute(IGDBLaunchConfigurationConstants.ATTR_HOST, targetHostName);
+				targetPort = launchTarget.getAttribute(IGDBLaunchConfigurationConstants.ATTR_PORT, targetPort);
+			}
+
 			// Target name
 
 			Group nameGroup = new Group(control, SWT.NONE);
@@ -72,14 +82,15 @@ public class NewGdbRemoteTCPTargetWizard extends LaunchTargetWizard {
 					nameText.setEnabled(!same);
 				}
 			});
-			sameAsHostname.setSelection(true);
+			sameAsHostname.setSelection(targetName.equals(targetHostName));
 
 			Label nameLabel = new Label(nameGroup, SWT.NONE);
 			nameLabel.setText(LaunchUIMessages.getString("NewGdbRemoteTCPTargetWizard.TargetName")); //$NON-NLS-1$
 
 			nameText = new Text(nameGroup, SWT.BORDER);
+			nameText.setText(targetName);
 			nameText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-			nameText.setEnabled(false);
+			nameText.setEnabled(!targetName.equals(targetHostName));
 			nameText.addModifyListener(new ModifyListener() {
 				@Override
 				public void modifyText(ModifyEvent e) {
@@ -98,6 +109,7 @@ public class NewGdbRemoteTCPTargetWizard extends LaunchTargetWizard {
 			hostLabel.setText(LaunchUIMessages.getString("NewGdbRemoteTCPTargetWizard.HostName")); //$NON-NLS-1$
 
 			hostText = new Text(connGroup, SWT.BORDER);
+			hostText.setText(targetHostName);
 			hostText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 			hostText.addModifyListener(new ModifyListener() {
 				@Override
@@ -113,6 +125,8 @@ public class NewGdbRemoteTCPTargetWizard extends LaunchTargetWizard {
 			portLabel.setText(LaunchUIMessages.getString("NewGdbRemoteTCPTargetWizard.Port")); //$NON-NLS-1$
 
 			portText = new Text(connGroup, SWT.BORDER);
+			portText.setText(targetPort);
+
 			portText.addModifyListener(new ModifyListener() {
 				@Override
 				public void modifyText(ModifyEvent e) {

--- a/launchbar/org.eclipse.launchbar.core/META-INF/MANIFEST.MF
+++ b/launchbar/org.eclipse.launchbar.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.launchbar.core;singleton:=true
-Bundle-Version: 3.0.100
+Bundle-Version: 3.0.200
 Bundle-Activator: org.eclipse.launchbar.core.internal.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.33.0,4)",

--- a/launchbar/org.eclipse.launchbar.core/src/org/eclipse/launchbar/core/internal/target/LaunchTargetWorkingCopy.java
+++ b/launchbar/org.eclipse.launchbar.core/src/org/eclipse/launchbar/core/internal/target/LaunchTargetWorkingCopy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 QNX Software Systems and others.
+ * Copyright (c) 2016, 2025 QNX Software Systems and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -102,6 +102,7 @@ public class LaunchTargetWorkingCopy extends PlatformObject implements ILaunchTa
 					target.attributes.remove(key);
 				}
 			}
+			target.attributes.put("name", target.getId()); //$NON-NLS-1$
 			target.attributes.flush();
 			return target;
 		} catch (BackingStoreException e) {


### PR DESCRIPTION
When a GDB Remote TCP or Serial launch target was opened for editing the current attribute values were not shown.

GDB Remote TCP always looks like this when you edit it:
![image](https://github.com/user-attachments/assets/0988198a-5a7c-4f65-bd38-66730128feeb)

GDB Remote Serial always looks like this:
![image](https://github.com/user-attachments/assets/6167d001-0b86-43dd-9248-4d40a7a61d7e)
