### PR TITLE
Do not require org.eclipse.tm.terminal.connector.process

### DIFF
--- a/terminal/features/org.eclipse.tm.terminal.connector.local.feature/feature.xml
+++ b/terminal/features/org.eclipse.tm.terminal.connector.local.feature/feature.xml
@@ -49,11 +49,4 @@
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.eclipse.tm.terminal.connector.process"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>


### PR DESCRIPTION
It is already mentioned in the requirement section and therefore duplicated requirement. Also org.eclipse.tm.terminal.connector.local has a require-bundle so it will be included anyways.

See
- https://github.com/eclipse-platform/eclipse.platform/pull/1970


FYI @jonahgraham 