### PR TITLE
Remove `org.eclipse.terminal.view.core.utils`

### DIFF
--- a/terminal/plugins/org.eclipse.tm.terminal.connector.cdtserial/META-INF/MANIFEST.MF
+++ b/terminal/plugins/org.eclipse.tm.terminal.connector.cdtserial/META-INF/MANIFEST.MF
@@ -22,5 +22,4 @@ Automatic-Module-Name: org.eclipse.tm.terminal.connector.cdtserial
 Import-Package: org.eclipse.terminal.connector;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.connector.provider;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.core;version="[1.0.0,2.0.0)",
- org.eclipse.terminal.view.core.utils;version="[1.0.0,2.0.0)",
  org.eclipse.terminal.view.ui.launcher;version="[1.0.0,2.0.0)"

--- a/terminal/plugins/org.eclipse.tm.terminal.connector.cdtserial/src/org/eclipse/tm/terminal/connector/cdtserial/activator/Activator.java
+++ b/terminal/plugins/org.eclipse.tm.terminal.connector.cdtserial/src/org/eclipse/tm/terminal/connector/cdtserial/activator/Activator.java
@@ -18,7 +18,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
-import org.eclipse.terminal.view.core.utils.TraceHandler;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -28,8 +27,6 @@ import org.osgi.framework.BundleContext;
 public class Activator extends AbstractUIPlugin {
 	// The shared instance
 	private static Activator plugin;
-	// The trace handler instance
-	private static volatile TraceHandler traceHandler;
 
 	/**
 	 * The constructor
@@ -54,18 +51,6 @@ public class Activator extends AbstractUIPlugin {
 			return getDefault().getBundle().getSymbolicName();
 		}
 		return "org.eclipse.tm.terminal.connector.serial"; //$NON-NLS-1$
-	}
-
-	/**
-	 * Returns the bundles trace handler.
-	 *
-	 * @return The bundles trace handler.
-	 */
-	public static TraceHandler getTraceHandler() {
-		if (traceHandler == null) {
-			traceHandler = new TraceHandler(getUniqueIdentifier());
-		}
-		return traceHandler;
 	}
 
 	@Override


### PR DESCRIPTION
Currently `Activator` exposes `TraceHandler` for public usage that looks more like a copy-paste from other similar bundles, where it was already removed.

Major bump is a great opportunity to remove this public method.