### PR TITLE
Function resolution: prefer definition over declaration (#1263)

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCPPBindingResolutionBugsTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCPPBindingResolutionBugsTest.java
@@ -1447,4 +1447,18 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	public void testStructNameIntroducedInNamespace() throws Exception {
 		checkBindings();
 	}
+
+	// constexpr int getNum(int) { return 3; }
+	// constexpr int getNum(long) { return 6; }
+
+	// constexpr int getNum(int);
+	// constexpr int getNum(long);
+	// constexpr int v3 = getNum((int)0);
+	// constexpr int v6 = getNum((long)0);
+	public void testFuncDefnFromIndex() throws Exception {
+		ICPPVariable v3 = getBindingFromASTName("v3 ", 2, ICPPVariable.class);
+		ICPPVariable v6 = getBindingFromASTName("v6 ", 2, ICPPVariable.class);
+		assertEquals(3, v3.getInitialValue().numberValue().intValue());
+		assertEquals(6, v6.getInitialValue().numberValue().intValue());
+	}
 }

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/CPPSemantics.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/CPPSemantics.java
@@ -252,6 +252,7 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPUsingDirective;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPVariable;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPASTInternalScope;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPClassSpecializationScope;
+import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPComputableFunction;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPDeferredClassInstance;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPEvaluation;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPInternalBinding;
@@ -3049,13 +3050,20 @@ public class CPPSemantics {
 				}
 				if (ok) {
 					if (fn instanceof IIndexBinding) {
+						int otherIdx = 0;
 						for (ICPPFunction other : result) {
-							if (other == null || other instanceof IIndexBinding)
+							if (other == null)
 								break;
 							if (other.getType().isSameType(ft)) {
+								if (other.isConstexpr() && !(other instanceof ICPPASTFunctionDefinition)
+										&& fn instanceof ICPPComputableFunction) {
+									// If the function is constexpr, prefer the definition since that can be evaluated
+									result[otherIdx] = fn;
+								}
 								ok = false;
 								break;
 							}
+							otherIdx++;
 						}
 					}
 					if (ok) {


### PR DESCRIPTION
For constexpr functions, the definition may be found in a separate header to a declaration. For evaluation purposes the definition is needed; therefore, when resolving a function call, select the definition in favour of the declaration, even if it comes from the index.

Fixes #1263.