### PR TITLE
Templated default constructor should mask implicit constructor (#1265)

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
@@ -1399,6 +1399,23 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertTrue(ctor instanceof ICPPConstructor);
 	}
 
+	//	struct Foo { template <typename T> Foo() {} };
+	//	template <typename T, typename U>
+	//	struct Bar { constexpr static int val = 99; };
+	//	template <typename T>
+	//	struct Bar<T, decltype(T())> { };
+	//	constexpr int v = Bar<Foo,Foo>::val;
+	public void testImplicitConstructors_1265() throws Exception {
+		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
+		NameCollector collector = new NameCollector(true);
+		tu.accept(collector);
+
+		assertEquals(collector.size(), 19);
+
+		ICPPVariable v = (ICPPVariable) collector.getName(18).resolveBinding();
+		assertEquals(99, v.getInitialValue().numberValue().intValue());
+	}
+
 	//	struct A {
 	//	  A(int);
 	//	};
@@ -1618,6 +1635,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	class J {private: J(const J *, int j, int k=3);}; // J * rather than J &
 	//	class K {protected: K(volatile K *, int i=4, int l=2);}; // K * rather than K  &
 	//	class L {L(const volatile L &, int i=1, long k=2, int* x) {}}; // param int* x has no initializer
+	//	class M {public: template <typename T> M(){}}; // same signature as implicit
 	public void testNotExplicitCopyConstructor_183160() throws Exception {
 		BufferedReader br = new BufferedReader(new StringReader(getAboveComment()));
 		for (String line = br.readLine(); line != null; line = br.readLine()) {

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/ImplicitsAnalysis.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/ImplicitsAnalysis.java
@@ -30,6 +30,7 @@ import org.eclipse.cdt.core.dom.ast.IType;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTCompositeTypeSpecifier;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTFunctionDeclarator;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTParameterDeclaration;
+import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTTemplateDeclaration;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPBase;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPClassType;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPConstructor;
@@ -86,6 +87,8 @@ final class ImplicitsAnalysis {
 		IASTDeclaration[] members = compositeTypeSpecifier.getMembers();
 		char[] name = compositeTypeSpecifier.getName().getLookupKey();
 		for (IASTDeclaration member : members) {
+			if (member instanceof ICPPASTTemplateDeclaration)
+				member = ((ICPPASTTemplateDeclaration) member).getDeclaration();
 			IASTDeclarator dcltor = null;
 			IASTDeclSpecifier spec = null;
 			if (member instanceof IASTSimpleDeclaration) {


### PR DESCRIPTION
The implicit constructor creation checks look for an explicit constructor first, but fail to consider templated constructors. This change fixes that, fixing problems that result due to SFINAE.