### PR TITLE
Allow general mixing of attributes and alignas (#1271)

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPAttributeTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPAttributeTests.java
@@ -572,4 +572,26 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTNamespaceDefinition.class);
 	}
+
+	//	[[attr]] __attribute__((__visibility__("default"))) [[attr2]] __attribute__((__section__(".foo"))) int i;
+	public void testMixedAttributeSpecifiers() throws Exception {
+		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
+		List<IASTAttributeSpecifier> specifiers = getAttributeSpecifiers(tu);
+		assertEquals(4, specifiers.size());
+		IASTAttributeSpecifier simpleDeclarationAttribute1 = specifiers.get(0);
+		IASTNode parent1 = simpleDeclarationAttribute1.getParent();
+		assertInstance(parent1, IASTSimpleDeclaration.class);
+		IASTAttributeSpecifier simpleDeclarationAttribute2 = specifiers.get(1);
+		IASTNode parent2 = simpleDeclarationAttribute2.getParent();
+		assertInstance(parent2, IASTSimpleDeclaration.class);
+		IASTAttributeSpecifier simpleDeclarationAttribute3 = specifiers.get(2);
+		IASTNode parent3 = simpleDeclarationAttribute3.getParent();
+		assertInstance(parent3, IASTSimpleDeclaration.class);
+		IASTAttributeSpecifier simpleDeclarationAttribute4 = specifiers.get(3);
+		IASTNode parent4 = simpleDeclarationAttribute4.getParent();
+		assertInstance(parent4, IASTSimpleDeclaration.class);
+		assertSame(parent1, parent2);
+		assertSame(parent1, parent3);
+		assertSame(parent1, parent4);
+	}
 }

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
@@ -11851,6 +11851,13 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
 	}
 
+	// int var1 alignas(16);
+	// int var2 __attribute__((section(".example"))) alignas(16);
+	// int var3 alignas(16) __attribute__((section(".example")));
+	public void testAlignaAsAfterDeclarator() throws Exception {
+		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
+	}
+
 	// int operator "" _A(unsigned long long i) { return 1; }
 	// int operator "" _B(long double d) { return 1; }
 	// int operator "" _C(const char* s, unsigned int sz) { return sz; }


### PR DESCRIPTION
Regular C++ attributes (eg [[maybe_unused]]), older GCC-style attributes (__attribute__((unused))), and alignas() specifications can be intermingled.

Fix the parser to handle several cases that it disallowed previously.