### PR TITLE
Update test result reporting to use latest ubuntu

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   unit-test-results:
     name: Unit Test Results
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: github.event.workflow_run.conclusion != 'skipped'
 
     steps:


### PR DESCRIPTION
While the builds have been running, for a few months the job that collates the results and reports them hasn't run due to Ubuntu 20.04 EOL on GitHub actions (https://github.com/actions/runner-images/issues/11101)

Fixes the lack of reporting part of https://github.com/eclipse-cdt/cdt/issues/1290