### PR TITLE
Workaround LLDB-MI =breakpoint-modified quirk

### DIFF
--- a/llvm/org.eclipse.cdt.llvm.dsf.lldb.core/META-INF/MANIFEST.MF
+++ b/llvm/org.eclipse.cdt.llvm.dsf.lldb.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.cdt.llvm.dsf.lldb.core;singleton:=true
-Bundle-Version: 1.102.400.qualifier
+Bundle-Version: 1.102.500.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.debug.core;bundle-version="[3.23.0,4)",

--- a/llvm/org.eclipse.cdt.llvm.dsf.lldb.core/src/org/eclipse/cdt/llvm/dsf/lldb/core/internal/service/LLDBBreakpointsSynchronizer.java
+++ b/llvm/org.eclipse.cdt.llvm.dsf.lldb.core/src/org/eclipse/cdt/llvm/dsf/lldb/core/internal/service/LLDBBreakpointsSynchronizer.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 John Dallaway and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * Contributors:
+ *     John Dallaway - Initial implementation (#1319)
+ *******************************************************************************/
+
+package org.eclipse.cdt.llvm.dsf.lldb.core.internal.service;
+
+import org.eclipse.cdt.dsf.mi.service.MIBreakpointsSynchronizer;
+import org.eclipse.cdt.dsf.mi.service.command.output.MIBreakpoint;
+import org.eclipse.cdt.dsf.service.DsfSession;
+
+public class LLDBBreakpointsSynchronizer extends MIBreakpointsSynchronizer {
+
+	public LLDBBreakpointsSynchronizer(DsfSession session) {
+		super(session);
+	}
+
+	@Override
+	protected boolean isTargetBreakpointConditionModified(MIBreakpoint miBpt, String condition) {
+		// assume not modified due to =breakpoint-modified async record issue:
+		// https://github.com/lldb-tools/lldb-mi/issues/125
+		return false;
+	}
+
+}

--- a/llvm/org.eclipse.cdt.llvm.dsf.lldb.core/src/org/eclipse/cdt/llvm/dsf/lldb/core/internal/service/LLDBServiceFactory.java
+++ b/llvm/org.eclipse.cdt.llvm.dsf.lldb.core/src/org/eclipse/cdt/llvm/dsf/lldb/core/internal/service/LLDBServiceFactory.java
@@ -11,6 +11,7 @@
  * Contributors:
  *     Ericsson - Initial implementation
  *     John Dallaway - Use LLDB memory service (#1191)
+ *     John Dallaway - Use LLDB breakpoints synchronizer service (#1319)
  *******************************************************************************/
 
 package org.eclipse.cdt.llvm.dsf.lldb.core.internal.service;
@@ -21,6 +22,7 @@ import org.eclipse.cdt.dsf.debug.service.IProcesses;
 import org.eclipse.cdt.dsf.debug.service.IRunControl;
 import org.eclipse.cdt.dsf.debug.service.command.ICommandControl;
 import org.eclipse.cdt.dsf.gdb.service.GdbDebugServicesFactory;
+import org.eclipse.cdt.dsf.mi.service.MIBreakpointsSynchronizer;
 import org.eclipse.cdt.dsf.service.DsfSession;
 import org.eclipse.cdt.llvm.dsf.lldb.core.internal.service.commands.LLDBCommandFactory;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -65,6 +67,11 @@ public class LLDBServiceFactory extends GdbDebugServicesFactory {
 	@Override
 	protected IMemory createMemoryService(DsfSession session) {
 		return new LLDBMemory(session);
+	}
+
+	@Override
+	protected MIBreakpointsSynchronizer createBreakpointsSynchronizerService(DsfSession session) {
+		return new LLDBBreakpointsSynchronizer(session);
 	}
 
 }


### PR DESCRIPTION
We ignore modified breakpoint/watchpoint conditions received via a `=breakpoint-modified` async event record from LLDB-MI. The `cond` field of these records is not reliable at present.

Workaround for: https://github.com/lldb-tools/lldb-mi/issues/125