### PR TITLE
Short circuit default initialization of array elements

### DIFF
--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/AggregateInitialization.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/AggregateInitialization.java
@@ -167,6 +167,12 @@ class AggregateInitialization {
 						if (cost.compareTo(worstCost) > 0) {
 							worstCost = cost;
 						}
+
+						if (fIndex > fInitializers.length) {
+							// Already checked default-initialization, short-circuit now
+							// as worst cost will no longer change
+							break;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Implement remaining TODO from bug 543038 where we already checked default init of array element and worst cost will no longer change.