### PR TITLE
Implement getCompositeEvaluation for fold expression

### DIFF
--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/EvalFoldExpression.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/semantics/EvalFoldExpression.java
@@ -68,6 +68,18 @@ public class EvalFoldExpression extends CPPDependentEvaluation {
 		return fOperator;
 	}
 
+	public boolean getIsComma() {
+		return fIsComma;
+	}
+
+	public boolean getIsLeftFold() {
+		return fIsLeftFold;
+	}
+
+	public ICPPEvaluation[] getExpansionPatterns() {
+		return fPackEvals;
+	}
+
 	public ICPPEvaluation getInitExpression() {
 		return fInitEval;
 	}

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/index/composite/cpp/CPPCompositesFactory.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/index/composite/cpp/CPPCompositesFactory.java
@@ -101,6 +101,7 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalCompoundStatem
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalConditional;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalConstructor;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalFixed;
+import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalFoldExpression;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalFunctionCall;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalFunctionSet;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.EvalID;
@@ -566,6 +567,31 @@ public class CPPCompositesFactory extends AbstractCompositeFactory {
 			IType a2 = getCompositeType(a);
 			if (a != a2 || templateDefinition != compositeTemplateDefinition)
 				e = new EvalUnaryTypeID(e.getOperator(), a2, compositeTemplateDefinition);
+			return e;
+		}
+		if (eval instanceof EvalFoldExpression e) {
+			ICPPEvaluation init = e.getInitExpression();
+			ICPPEvaluation init2 = getCompositeEvaluation(init);
+
+			boolean anyChanged = init != init2 || templateDefinition != compositeTemplateDefinition;
+
+			ICPPEvaluation[] evals = e.getExpansionPatterns();
+			ICPPEvaluation[] packEvals = getCompositeEvaluationArray(evals);
+
+			if (!anyChanged) {
+				for (int i = 0; i < evals.length; ++i) {
+					if (evals[i] != packEvals[i]) {
+						anyChanged = true;
+						break;
+					}
+				}
+			}
+
+			if (anyChanged) {
+				e = new EvalFoldExpression(e.getOperator(), e.getIsComma(), e.getIsLeftFold(), packEvals, init2,
+						compositeTemplateDefinition);
+			}
+
 			return e;
 		}
 


### PR DESCRIPTION
Not sure if there is any unit test for this, so reproduced manually:
- open c++ project which uses `type_traits` header and C++ standard is >= 17 so fold expressions are enabled
- open type search dialog (`Ctrl+Shift+T`) and type `a` and wait

GCC (not sure which version though) started using fold expression for `__gnu_cxx::__promoted_t` and there will be an attempt to convert that fold expression into composites ending up with error window popping up. This change adds missing implementation to composites factory.