### PR TITLE
Convert org.eclipse.cdt.core.parser.tests.ast2.SemanticTestBase to JUnit5

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPAttributeTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPAttributeTests.java
@@ -15,6 +15,11 @@
 
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -58,21 +63,9 @@ import org.eclipse.cdt.core.parser.IToken;
 import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.internal.core.dom.parser.ASTNode;
 import org.eclipse.cdt.internal.core.dom.parser.ASTTokenList;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class AST2CPPAttributeTests extends AST2TestBase {
-
-	public AST2CPPAttributeTests() {
-	}
-
-	public AST2CPPAttributeTests(String name) {
-		super(name);
-	}
-
-	public static TestSuite suite() {
-		return suite(AST2CPPAttributeTests.class);
-	}
 
 	private IASTTranslationUnit parseAndCheckBindings() throws Exception {
 		String code = getAboveComment();
@@ -154,18 +147,21 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	}
 
 	//	auto t = []() mutable throw(char const *) [[attr]] { throw "exception"; };
+	@Test
 	public void testAttributedLambda() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTFunctionDeclarator.class);
 	}
 
 	//	int * arr = new int[1][[attr]]{2};
+	@Test
 	public void testAttributedNewArrayExpression() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTArrayModifier.class);
 	}
 
 	//	int (* matrix) = new int[2][[attr1]][2][[attr2]];
+	@Test
 	public void testAttributedMultidimensionalNewArrayExpression() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		List<IASTAttributeSpecifier> specifiers = getAttributeSpecifiers(tu);
@@ -180,6 +176,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	void foo() {
 	//	  [[attr]] label:;
 	//	}
+	@Test
 	public void testAttributeInLabeledStatement() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTLabelStatement.class);
@@ -192,6 +189,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	    ;
 	//	  }
 	//	}
+	@Test
 	public void testAttributedSwitchLabels() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		List<IASTAttributeSpecifier> specifiers = getAttributeSpecifiers(tu);
@@ -202,6 +200,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	  int i{0};
 	//	  [[attr]] i++;
 	//	}
+	@Test
 	public void testAttributedExpressionStatement() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTExpressionStatement.class);
@@ -210,6 +209,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	void foo() {
 	//	  [[attr]] {}
 	//	}
+	@Test
 	public void testAttributedCompoundStatement() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTCompoundStatement.class);
@@ -218,6 +218,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	void foo() {
 	//	  [[attr]] if(false);
 	//	}
+	@Test
 	public void testAttributedSelectionStatement() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTIfStatement.class);
@@ -226,6 +227,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	void foo() {
 	//	  [[attr]] while(false);
 	//	}
+	@Test
 	public void testAttributedIterationStatement() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTWhileStatement.class);
@@ -234,6 +236,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	void foo() {
 	//	  [[attr]] return;
 	// }
+	@Test
 	public void testAttributedJumpStatement() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTReturnStatement.class);
@@ -242,6 +245,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	void foo() {
 	//	  [[attr]] try{} catch(...) {}
 	//	}
+	@Test
 	public void testAttributedTryBlockStatement() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTTryBlockStatement.class);
@@ -250,6 +254,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	void foo() {
 	//	  if([[attr]]int i{0});
 	//	}
+	@Test
 	public void testAttributedConditionWithInitializer() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTSimpleDeclaration.class);
@@ -259,18 +264,21 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	  int a[1]{0};
 	//	  for([[attr]]auto i : a){}
 	//	}
+	@Test
 	public void testAttributedForRangeDeclaration() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTSimpleDeclaration.class);
 	}
 
 	//	using number [[attr]] = int;
+	@Test
 	public void testAttributedAliasDeclaration() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTAliasDeclaration.class);
 	}
 
 	//	enum [[attr]] e {};
+	@Test
 	public void testAttributedEnumDeclaration() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTEnumerationSpecifier.class);
@@ -278,6 +286,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 
 	//	namespace NS{}
 	//	[[attr]] using namespace NS;
+	@Test
 	public void testAttributedUsingDirective() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTUsingDirective.class);
@@ -286,6 +295,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	void foo() throw(char const *) [[noreturn]] -> void {
 	//	  throw "exception";
 	//	}
+	@Test
 	public void testTrailingNoreturnFunctionDefinition() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTFunctionDeclarator.class);
@@ -294,60 +304,70 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	[[noreturn]] void foo() throw(char const *) {
 	//	  throw "exception";
 	//	}
+	@Test
 	public void testLeadingNoreturnFunctionDefinition() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTFunctionDefinition.class);
 	}
 
 	//	void foo() throw(char const *) [[noreturn]];
+	@Test
 	public void testTrailingNoReturnFunctionDeclaration() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTFunctionDeclarator.class);
 	}
 
 	//	[[noreturn]] void foo() throw(char const *);
+	@Test
 	public void testLeadingNoReturnFunctionDeclaration() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTSimpleDeclaration.class);
 	}
 
 	//	class [[attr]] C{};
+	@Test
 	public void testAttributedClass() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTCompositeTypeSpecifier.class);
 	}
 
 	//	void f() { try { } catch ([[attr]] int& id) {} }
+	@Test
 	public void testAttributedExceptionDeclaration() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTSimpleDeclaration.class);
 	}
 
 	//	struct [[attr]] S;
+	@Test
 	public void testAttributedElaboratedTypeSpecifier() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTElaboratedTypeSpecifier.class);
 	}
 
 	//	static int [[int_attr]] v;
+	@Test
 	public void testAttributedDeclSpecifier() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTSimpleDeclSpecifier.class);
 	}
 
 	//auto [[maybe_unused]] variable;
+	@Test
 	public void testAttributeAutoDeclSpecifer() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTSimpleDeclSpecifier.class);
 	}
 
 	//	const volatile unsigned long int [[attr]] cvuli;
+	@Test
 	public void testAttributedTypeSpecifier() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTSimpleDeclSpecifier.class);
 	}
 
 	//	int * [[pointer_attribute]] * [[pointer_attribute]] ipp;
+	@Test
 	public void testAttributedPtrOperators() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		List<IASTAttributeSpecifier> specifiers = getAttributeSpecifiers(tu);
@@ -360,42 +380,49 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	}
 
 	//	int & [[ref_attribute]] iRef;
+	@Test
 	public void testAttributedRefOperator() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTReferenceOperator.class);
 	}
 
 	//	int && [[rvalue_ref_attribute]] iRvalueRef;
+	@Test
 	public void testAttributedRvalueRefOperator() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTReferenceOperator.class);
 	}
 
 	//	void foo() [[function_attr]];
+	@Test
 	public void testAttributedFunctionDeclaration() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTFunctionDeclarator.class);
 	}
 
 	//	int ipp [[declarator_attr]];
+	@Test
 	public void testAttributedDeclarator() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTDeclarator.class);
 	}
 
 	//	int iArr[5] [[arr_attr]];
+	@Test
 	public void testAttributedArrayDeclarator() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTArrayModifier.class);
 	}
 
 	//	[[attr]] int i;
+	@Test
 	public void testAttributedSimpleDeclaration() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTSimpleDeclaration.class);
 	}
 
 	//	[[attr]] void bar(){}
+	@Test
 	public void testAttributedFunctionDefinition() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTFunctionDefinition.class);
@@ -404,6 +431,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	struct S {
 	//	  [[ctor_attr]] S() = delete;
 	//	};
+	@Test
 	public void testDeletedCtor() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTFunctionDefinition.class);
@@ -412,6 +440,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	struct S {
 	//	  [[dtor_attr]] ~S() = default;
 	//	};
+	@Test
 	public void testDefaultedDtor() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTFunctionDefinition.class);
@@ -420,18 +449,21 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	void bar() {
 	//	  [[attr]] int i;
 	//	}
+	@Test
 	public void testAttributedSimpleDeclarationInStatement() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTSimpleDeclaration.class);
 	}
 
 	//	[[]] int i;
+	@Test
 	public void testEmptyAttributeSpecifier() throws Exception {
 		IASTAttribute[] attributes = getAttributes();
 		assertEquals(IASTAttribute.EMPTY_ATTRIBUTE_ARRAY, attributes);
 	}
 
 	//	[[attr]] [[attr2]] [[attr3]] int i;
+	@Test
 	public void testMultipleSequentialAttributeSpecifiers() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		List<IASTAttributeSpecifier> specifiers = getAttributeSpecifiers(tu);
@@ -450,6 +482,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	}
 
 	//	[[attr1, attr2]] int i;
+	@Test
 	public void testMultipleAttributes() throws Exception {
 		IASTAttribute[] attributes = getAttributes();
 		assertEquals(2, attributes.length);
@@ -460,6 +493,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	}
 
 	//	[[attribute ...]] int i;
+	@Test
 	public void testPackExpansionAttribute() throws Exception {
 		IASTAttribute[] attributes = getAttributes();
 		assertEquals(1, attributes.length);
@@ -469,6 +503,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	}
 
 	//	[[scope::attribute]] int i;
+	@Test
 	public void testScopedAttribute() throws Exception {
 		IASTAttribute[] attributes = getAttributes();
 		assertEquals(1, attributes.length);
@@ -479,6 +514,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	}
 
 	//	[[attr()]] int i;
+	@Test
 	public void testAttributeWithEmptyArgument() throws Exception {
 		IASTAttribute[] attributes = getAttributes();
 		assertEquals(1, attributes.length);
@@ -489,6 +525,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	}
 
 	//	[[attr(this(is){[my]}(argument[with]{some},parentheses))]] int i;
+	@Test
 	public void testAttributeWithBalancedArgument() throws Exception {
 		IASTAttribute[] attributes = getAttributes();
 		assertEquals(1, attributes.length);
@@ -501,6 +538,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	}
 
 	//	[[attr(class)]] int i;
+	@Test
 	public void testAttributeWithKeywordArgument() throws Exception {
 		IASTAttribute[] attributes = getAttributes();
 		assertEquals(1, attributes.length);
@@ -514,18 +552,21 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	}
 
 	//	struct S __attribute__((__packed__)) {};
+	@Test
 	public void testGCCAttributedStruct() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTCompositeTypeSpecifier.class);
 	}
 
 	//	int a __attribute__ ((aligned ((64))));
+	@Test
 	public void testGCCAttributedVariableDeclarator_bug391572() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTDeclarator.class);
 	}
 
 	//	int a __attribute__ (());
+	@Test
 	public void testEmptyGCCAttribute() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTDeclarator.class);
@@ -534,6 +575,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	struct S {
 	//	  void foo() override __attribute__((attr));
 	//	};
+	@Test
 	public void testGCCAttributeAfterOverride_bug413615() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTFunctionDeclarator.class);
@@ -542,6 +584,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	//	enum E {
 	//		value1 [[attr1]], value2 [[attr2]] = 1
 	//	};
+	@Test
 	public void testAttributedEnumerator_Bug535269() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), IASTEnumerator.class, IASTEnumerator.class);
@@ -549,6 +592,7 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 
 	//void f([[attr1]] int [[attr2]] p) {
 	//}
+	@Test
 	public void testAttributedFunctionParameter_Bug535275() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTParameterDeclaration.class,
@@ -556,24 +600,28 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 	}
 
 	//namespace [[attr]] NS {}
+	@Test
 	public void testAttributedNamedNamespace_Bug535274() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTNamespaceDefinition.class);
 	}
 
 	//namespace [[attr]] {}
+	@Test
 	public void testAttributedUnnamedNamespace_Bug535274() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTNamespaceDefinition.class);
 	}
 
 	//namespace NS __attribute__((__visibility__("default"))) {}
+	@Test
 	public void testGnuAndCppMixedAttributedNamedNamespace_Bug535274() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		checkAttributeRelations(getAttributeSpecifiers(tu), ICPPASTNamespaceDefinition.class);
 	}
 
 	//	[[attr]] __attribute__((__visibility__("default"))) [[attr2]] __attribute__((__section__(".foo"))) int i;
+	@Test
 	public void testMixedAttributeSpecifiers() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP, ScannerKind.GNU);
 		List<IASTAttributeSpecifier> specifiers = getAttributeSpecifiers(tu);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPImplicitNameTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPImplicitNameTests.java
@@ -16,6 +16,12 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 
 import org.eclipse.cdt.core.dom.ast.IASTImplicitDestructorName;
@@ -31,25 +37,13 @@ import org.eclipse.cdt.core.dom.ast.cpp.ICPPMethod;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPTemplateInstance;
 import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.internal.core.parser.ParserException;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for classes implementing {@link IASTImplicitNameOwner} and {@link IASTImplicitDestructorNameOwner}
  * interfaces.
  */
 public class AST2CPPImplicitNameTests extends AST2TestBase {
-
-	public AST2CPPImplicitNameTests() {
-	}
-
-	public AST2CPPImplicitNameTests(String name) {
-		super(name);
-	}
-
-	public static TestSuite suite() {
-		return suite(AST2CPPImplicitNameTests.class);
-	}
 
 	protected BindingAssertionHelper getAssertionHelper() throws ParserException, IOException {
 		String code = getAboveComment();
@@ -103,6 +97,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  -p;
 	//	  +p;
 	//	}
+	@Test
 	public void testBinaryExpressions() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IASTTranslationUnit tu = ba.getTranslationUnit();
@@ -147,6 +142,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  int* y;
 	//	  *y; //2
 	//	}
+	@Test
 	public void testPointerDereference() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertImplicitName("*x;", 1, ICPPFunction.class);
@@ -165,6 +161,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  X (Y::*px1) = &Y::x;  // not the overloaded operator
 	//	  X* px2 = &y; // overloaded
 	//	}
+	@Test
 	public void testPointerToMember() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IASTTranslationUnit tu = ba.getTranslationUnit();
@@ -198,6 +195,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  SecondLevelProxy p2;
 	//	  p2->doA();
 	//	}
+	@Test
 	public void testArrowOperator() throws Exception {
 		String contents = getAboveComment();
 		IASTTranslationUnit tu = parse(contents, ParserLanguage.CPP);
@@ -226,6 +224,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  (p1++).x; //1
 	//	  (++p1).x; //2
 	//	}
+	@Test
 	public void testUnaryPrefixAndPostfix() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertImplicitName("++).x; //1", 2, ICPPFunction.class);
@@ -252,6 +251,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  D d;
 	//	  test(a, b, c, d); // func
 	//	}
+	@Test
 	public void testCommaOperator1() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		// expression lists are used in function calls but they should not resolve to the comma operator
@@ -287,6 +287,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	int test(A a, B b, C c, D d) {
 	//	  (a, b, c, d).ee; // expr
 	//	}
+	@Test
 	public void testCommaOperator2() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 
@@ -318,6 +319,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  x(); // 2
 	//	  x(1, 2); // 3
 	//	}
+	@Test
 	public void testFunctionCallOperator() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IASTTranslationUnit tu = ba.getTranslationUnit();
@@ -359,6 +361,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  B b;
 	//	  b = a; // should not resolve
 	//	}
+	@Test
 	public void testCopyAssignmentOperator() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNoImplicitName("= a;", 1);
@@ -377,6 +380,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  func(x[0]); //1
 	//	  func(y[q]); //2
 	//	}
+	@Test
 	public void testArraySubscript() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IASTTranslationUnit tu = ba.getTranslationUnit();
@@ -412,6 +416,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  delete[] x;
 	//    delete 1;
 	//	}
+	@Test
 	public void testDelete() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IASTImplicitName[] names = ba.getImplicitNames("delete x;", 6);
@@ -446,6 +451,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	    B* b = new B;
 	//	    delete b;
 	//	}
+	@Test
 	public void testOverloadedDelete_Bug351547() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		IBinding m = bh.assertNonProblem("operator delete(void * a)", 15);
@@ -473,6 +479,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	    A *a = new A;
 	//	    B* b = new B;
 	//	}
+	@Test
 	public void testOverloadedNew_Bug354585() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		IBinding m = bh.assertNonProblem("operator new(size_t a)", 12);
@@ -492,6 +499,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  X* xs = new X[5];
 	//	  delete[] x;
 	//	}
+	@Test
 	public void testImplicitNewAndDelete() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNoImplicitName("new X", 3);
@@ -511,6 +519,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  int* p = new (nothrow) int[5];
 	//    int* p2 = new (5, 6) int[5];
 	//	}
+	@Test
 	public void testNew() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IASTImplicitName n1 = ba.assertImplicitName("new (nothrow) X", 3, ICPPFunction.class);
@@ -529,6 +538,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	int test() {
 	//	  throw;
 	//	}
+	@Test
 	public void testEmptyThrow() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNoImplicitName("throw;", 5);
@@ -558,6 +568,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  C(int p) : u(), v(p) {}
 	//	};
 	//	B C::t = 1;
+	@Test
 	public void testConstructorCall() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IASTTranslationUnit tu = ba.getTranslationUnit();
@@ -597,6 +608,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//		if (aa==b) {
 	//		}
 	//	}
+	@Test
 	public void testBuiltinOperators_294543() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IASTTranslationUnit tu = ba.getTranslationUnit();
@@ -613,6 +625,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//		int x;
 	//	    x = A().a;
 	//	}
+	@Test
 	public void testTemporaryDestruction() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IASTImplicitDestructorName[] names = ba.getImplicitDestructorNames("x = A().a");
@@ -628,6 +641,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//		A x;
 	//	    x = A();
 	//	}
+	@Test
 	public void testTemporaryNotCreatedWhenBoundToVariable() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IASTImplicitDestructorName[] names = ba.getImplicitDestructorNames("x = A()");
@@ -641,6 +655,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	int test() {
 	//		return (new A())->a;
 	//	}
+	@Test
 	public void testTemporaryNotCreatesInNewExpression() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IASTImplicitDestructorName[] names = ba.getImplicitDestructorNames("(new A())->a");
@@ -654,6 +669,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	void test() {
 	//		A& x = A();
 	//	}
+	@Test
 	public void testTemporaryBoundToReference() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IASTImplicitDestructorName[] names = ba.getImplicitDestructorNames("A()");
@@ -671,6 +687,7 @@ public class AST2CPPImplicitNameTests extends AST2TestBase {
 	//	  const S& s2 = S(1);
 	//	  S s3;
 	//	}//1
+	@Test
 	public void testOrderOfDestruction() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IASTImplicitDestructorName[] names = ba.getImplicitDestructorNames("}//1", 1);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPSpecTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPSpecTest.java
@@ -16,6 +16,11 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import org.eclipse.cdt.core.dom.ast.ASTTypeUtil;
 import org.eclipse.cdt.core.dom.ast.IASTCompositeTypeSpecifier;
 import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
@@ -44,31 +49,22 @@ import org.eclipse.cdt.core.dom.ast.cpp.ICPPTemplateInstance;
 import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPUnknownBinding;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.CPPVisitor;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Examples taken from the c++-specification.
  */
 public class AST2CPPSpecTest extends AST2SpecTestBase {
 
-	public AST2CPPSpecTest() {
-	}
-
-	public AST2CPPSpecTest(String name) {
-		super(name);
-	}
-
-	public static TestSuite suite() {
-		return suite(AST2CPPSpecTest.class);
-	}
-
 	// int x=x+++++y;
+	@Test
 	public void test2_4s5() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
 
 	// int a=12, b=014, c=0XC;
+	@Test
 	public void test2_13_1s1() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -76,6 +72,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// ??=define arraycheck(a,b) a??(b??) ??!??! b??(a??)
 	// // becomes
 	// #define arraycheck(a,b) a[b] || b[a]
+	@Test
 	public void test2_3s2() throws Exception { // TODO exists bug 64993
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -102,6 +99,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// typedef int Int; // declares Int
 	// extern X anotherX; // declares anotherX
 	// using N::d; // declares N::d
+	@Test
 	public void test3_1s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -115,6 +113,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// C b = a;
 	// b = a;
 	// }
+	@Test
 	public void test3_1s4a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -127,6 +126,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// ~C() { }
 	// };
 	//
+	@Test
 	public void test3_1s4b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -134,6 +134,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// struct X; // declare X as a struct type
 	// struct X* x1; // use X in pointer formation
 	// X* x2; // use X in pointer formation
+	@Test
 	public void test3_2s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -146,6 +147,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// X::X(int = 0) { }
 	// class D: public X { };
 	// D d2; // X(int) called by D()
+	@Test
 	public void test3_2s5_a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -159,6 +161,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// class D: public X { }; // X(int, int) called by D();
 	// // D()'s implicit definition
 	// // violates the ODR
+	@Test
 	public void test3_2s5_b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -169,6 +172,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int i = j, j;
 	// j = 42;
 	// }
+	@Test
 	public void test3_3s2() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -177,6 +181,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int x = 12;
 	// { int x = x; }
 	// }
+	@Test
 	public void test3_3_1s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -185,6 +190,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// const int i = 2;
 	// { int i[i]; }
 	// }
+	@Test
 	public void test3_3_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -193,6 +199,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// const int x = 12;
 	// { enum { x = x }; }
 	// }
+	@Test
 	public void test3_3_1s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -219,6 +226,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// }
 	// int q(); // error: different return type
 	// }
+	@Test
 	public void test3_3_5s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -236,6 +244,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // 3) scope of namespace A
 	// // 4) global scope, before the definition of A::N::f
 	// }
+	@Test
 	public void test3_4_1s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -243,6 +252,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// namespace M {
 	// class B { };
 	// }
+	@Test
 	public void test3_4_1s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -265,6 +275,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // 4) scope of namespace M::N
 	// // 5) scope of namespace M
 	// // 6) global scope, before the definition of M::N::X::f
+	@Test
 	public void test3_4_1s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -279,6 +290,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// friend void A::f1(AT); // parameter type is A::AT
 	// friend void A::f2(BT); // parameter type is B::BT
 	// };
+	@Test
 	public void test3_4_1s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -293,6 +305,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	A::n = 42; // OK
 	//	A b; // illformed: A does not name a type
 	//	}
+	@Test
 	public void test3_4_3s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 1);
 	}
@@ -305,6 +318,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int main() {
 	// f(parm); //OK: calls NS::f
 	// }
+	@Test
 	public void test3_4_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -318,6 +332,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// X C::arr[number]; // illformed:
 	// // equivalent to: ::X C::arr[C::number];
 	// // not to: C::X C::arr[C::number];
+	@Test
 	public void test3_4_3s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -342,6 +357,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// AB *p;
 	// p->AB::~AB(); // explicitly calls the destructor for A
 	// }
+	@Test
 	public void test3_4_3s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -395,6 +411,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // S is { Y::h(int), Z::h(double) } and overload
 	// // resolution chooses Z::h(double)
 	// }
+	@Test
 	public void test3_4_3_2s2() throws Exception {
 		String[] problems = { "AB::x", "x", "AB::i", "i" };
 		parse(getAboveComment(), ParserLanguage.CPP, problems); // qualified names are counted double, so 4
@@ -428,6 +445,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// {
 	// BD::a++; //OK: S is { A::a, A::a }
 	// }
+	@Test
 	public void test3_4_3_2s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -449,6 +467,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// A::b++; //OK: both A and B searched (once), S is { B::b }
 	// B::b++; //OK: b declared directly in B, S is { B::b }
 	// }
+	@Test
 	public void test3_4_3_2s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -467,6 +486,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int i = C::x; // OK, A::x (of type int)
 	// int j = C::y; // ambiguous, A::y or B::y
 	// }
+	@Test
 	public void test3_4_3_2s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -479,6 +499,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// }
 	// void A::f1(int) { } // illformed,
 	// // f1 is not a member of A
+	@Test
 	public void test3_4_3_2s6a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -496,6 +517,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// using namespace A;
 	// using namespace C::D;
 	// void B::f1(int){} // OK, defines A::B::f1(int)
+	@Test
 	public void test3_4_3_2s6b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -528,6 +550,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// struct Base::Data; // error: cannot introduce a qualified type (7.1.5.3)
 	// struct Base::Datum; // error: Datum undefined
 	// struct Base::Data* pBase; // OK: refers to nested Data
+	@Test
 	public void test3_4_4s3() throws Exception {
 		String[] problems = { "::Glob", "Glob", "Base::Datum", "Datum" };
 		parse(getAboveComment(), ParserLanguage.CPP, problems);
@@ -543,6 +566,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// extern int i; //3: external linkage
 	// }
 	// }
+	@Test
 	public void test3_5s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -562,6 +586,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// }
 	// void q() { //
 	// } // some other, unrelated q
+	@Test
 	public void test3_5s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -573,12 +598,14 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// typedef A B;
 	// extern B b; // illformed
 	// }
+	@Test
 	public void test3_5s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// int main(int argc, char* argv[]) { //
 	// }
+	@Test
 	public void test3_6_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -603,6 +630,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void* q = pb; // OK: pb points to valid memory
 	// pb->f(); //undefined behavior, lifetime of *pb has ended
 	// }
+	@Test
 	public void test3_8s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -627,6 +655,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// c1 = c2; // welldefined
 	// c1.f(); //welldefined; c1 refers to a new object of type C
 	// }
+	@Test
 	public void test3_8s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -639,6 +668,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// B b;
 	// new (&b) T;
 	// } //undefined behavior at block exit
+	@Test
 	public void test3_8s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -652,6 +682,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// b.~B();
 	// new (&b) const B; // undefined behavior
 	// }
+	@Test
 	public void test3_8s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -665,6 +696,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// memcpy(&obj, buf, N); // at this point, each subobject of obj of scalar type
 	// // holds its original value
 	// }
+	@Test
 	public void test3_9s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -676,6 +708,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// memcpy(t1p, t2p, sizeof(T)); // at this point, every subobject of POD type in *t1p contains
 	// // the same value as the corresponding subobject in *t2p
 	// }
+	@Test
 	public void test3_9s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -702,11 +735,13 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		xp++; //OK: X is complete
 	//		arrp++; //ill-formed: UNKA can't be completed
 	//	}
+	@Test
 	public void test3_9s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// int& f();
+	@Test
 	public void test3_10s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -717,6 +752,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// i = ++i + 1; // the behavior is unspecified
 	// i = i + 1; // the value of i is incremented
 	// }
+	@Test
 	public void test5s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -727,6 +763,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// {
 	// B* bp = dynamic_cast<B*>(dp); // equivalent to B* bp = dp;
 	// }
+	@Test
 	public void test5_2_7s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -757,6 +794,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // cast from virtual base
 	// E* ep1 = dynamic_cast<E*>(ap); // succeeds
 	// }
+	@Test
 	public void test5_2_7s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -771,6 +809,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// typeid(D) == typeid(d2); // yields true
 	// typeid(D) == typeid(const D&); // yields true
 	// }
+	@Test
 	public void test5_2_8s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -782,6 +821,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int foo() {
 	// static_cast<D&>(br); // produces lvalue to the original d object
 	// }
+	@Test
 	public void test5_2_9s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -791,6 +831,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int foo() {
 	// &B::i; // has type int A::*
 	// }
+	@Test
 	public void test5_3_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -798,6 +839,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void test() {
 	//    new (int (*[10])());
 	// };
+	@Test
 	public void test5_3_4s3() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 		IASTFunctionDefinition fdef = getDeclaration(tu, 0);
@@ -818,6 +860,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//    new T[5];
 	//    new (2,f) T[5];
 	// };
+	@Test
 	public void test5_3_4s12() throws Exception {
 		// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=236856
 
@@ -860,12 +903,14 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int n=2;
 	// int x=new float[n][5];
 	// int y=new float[5][n];
+	@Test
 	public void test5_3_4s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// const char* strchr(const char* s, int c);
 	// bool b = noexcept (strchr("abc", 'b'));
+	@Test
 	public void test5_3_7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -878,6 +923,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// return (A*)( p ); // illformed
 	// // static_cast interpretation
 	// }
+	@Test
 	public void test5_4s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -885,6 +931,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int foo() {
 	// (ptr_to_obj->*ptr_to_mfct)(10);
 	// }
+	@Test
 	public void test5_5s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -898,6 +945,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// p <= q; // Both converted to const void * before comparison
 	// pi <= pci; // Both converted to const int *const * before comparison
 	// }
+	@Test
 	public void test5_9s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -914,6 +962,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int (D::*pdl)() = pl;
 	// int (D::*pdr)() = pr;
 	// bool x = (pdl == pdr); // false
+	@Test
 	public void test5_10s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -923,6 +972,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int a=0, t=1, c=2;
 	// f(a, (t=3, t+2), c);
 	// }
+	@Test
 	public void test5_18s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -936,6 +986,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int i;
 	// }
 	// }
+	@Test
 	public void test6_4s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -948,6 +999,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int x; // illformed,redeclaration of x
 	// }
 	// }
+	@Test
 	public void test6_4s3() throws Exception {
 		// raised bug 90618
 		// gcc does not report an error, either, so leave it as it is.
@@ -963,6 +1015,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int i;
 	// }
 	// }
+	@Test
 	public void test6_5s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -981,6 +1034,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// i = 0;
 	// }
 	// }
+	@Test
 	public void test6_5_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -992,6 +1046,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// a[i] = i;
 	// int j = i; // j = 42
 	// }
+	@Test
 	public void test6_5_3s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1009,6 +1064,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	// call for a followed by construction
 	//	// again immediately following label ly
 	//	}
+	@Test
 	public void test6_7s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 1);
 	}
@@ -1018,6 +1074,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// static int s = foo(2*i); // recursive call - undefined
 	// return i+1;
 	// }
+	@Test
 	public void test6_7s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1031,6 +1088,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// T(f) = { 1, 2 }; // declaration
 	// T(*g)(double(3)); // declaration
 	// }
+	@Test
 	public void test6_8s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -1048,6 +1106,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// T(d),e,f=3; //declaration
 	// extern int h;
 	// T(g)(h,2); //declaration
+	@Test
 	public void test6_8s2() throws Exception { // TODO raised bug 90622
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1071,6 +1130,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // properly since it depends
 	// // on T2 being a typename
 	// }
+	@Test
 	public void test6_8s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1078,12 +1138,14 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// typedef char* Pc;
 	// void f(const Pc); // void f(char* const) (not const char*)
 	// void g(const int Pc); // void g(const int)
+	@Test
 	public void test7_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// void h(unsigned Pc); // void h(unsigned int)
 	// void k(unsigned int Pc); // void k(unsigned int)
+	@Test
 	public void test7_1s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1091,6 +1153,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// thread_local int e;
 	// static thread_local int f;
 	// extern thread_local int g;
+	@Test
 	public void test7_1_1s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1119,6 +1182,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// static int c; // error: inconsistent linkage
 	// extern int d; // d has external linkage
 	// static int d; // error: inconsistent linkage
+	@Test
 	public void test7_1_1s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1132,6 +1196,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// g(a); //error: S is incomplete
 	// f(); //error: S is incomplete
 	// }
+	@Test
 	public void test7_1_1s8a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1140,6 +1205,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// mutable const int* p; // OK
 	// mutable int* const q; // illformed
 	// };
+	@Test
 	public void test7_1_1s8b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1147,6 +1213,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// typedef int MILES, *KLICKSP;
 	// MILES distance;
 	// extern KLICKSP metricp;
+	@Test
 	public void test7_1_3s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1156,6 +1223,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// typedef int I;
 	// typedef int I;
 	// typedef I I;
+	@Test
 	public void test7_1_3s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1163,6 +1231,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// class complex { //
 	// };
 	// typedef int complex; // error: redefinition
+	@Test
 	public void test7_1_3s3a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1170,6 +1239,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// typedef int complex;
 	// class complex { //
 	// }; // error: redefinition
+	@Test
 	public void test7_1_3s3b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1181,11 +1251,13 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// typedef struct S T;
 	// S a = T(); // OK
 	// struct T * p; // error
+	@Test
 	public void test7_1_3s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// typedef struct { } *ps, S; // S is the class name for linkage purposes
+	@Test
 	public void test7_1_3s5a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1194,6 +1266,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// S(); //error: requires a return type because S is
 	// // an ordinary member function, not a constructor
 	// } S;
+	@Test
 	public void test7_1_3s5b() throws Exception {
 		IASTTranslationUnit tu = parseWithErrors(getAboveComment(), ParserLanguage.CPP);
 		IASTCompositeTypeSpecifier comp = getCompositeType(tu, 0);
@@ -1215,6 +1288,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	return x * x;
 	//	}
 	//	constexpr pixel large(4);
+	@Test
 	public void test7_1_5s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1233,6 +1307,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int* iq = const_cast<int*>(ciq); // cast required
 	// *iq = 4; // undefined: modifies a const object
 	// }
+	@Test
 	public void test7_1_5_1s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1256,12 +1331,14 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// p->x.i = 99; // wellformed: mutable member can be modified
 	// p->x.j = 99; // undefined: modifies a const member
 	// }
+	@Test
 	public void test7_1_5_1s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// enum { a, b, c=0 };
 	// enum { d, e, f=e+2 };
+	@Test
 	public void test7_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1270,6 +1347,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// const int x = 12;
 	// { enum { x = x }; }
 	// }
+	@Test
 	public void test7_2s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1281,6 +1359,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// if (*cp == blue) // ...
 	// return 0;
 	// }
+	@Test
 	public void test7_2s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1302,6 +1381,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(p->left); // OK
 	// // ...
 	// }
+	@Test
 	public void test7_2s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -1314,6 +1394,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void g() { i++; } // Inner::i
 	// }
 	// }
+	@Test
 	public void test7_3_1s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1333,6 +1414,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// A::i++; // A::unique::i
 	// j++; // A::unique::j
 	// }
+	@Test
 	public void test7_3_1_1s1() throws Exception {
 		String[] problems = { "i" };
 		parse(getAboveComment(), ParserLanguage.CPP, problems);
@@ -1342,6 +1424,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void f() { //
 	// }
 	// }
+	@Test
 	public void test7_3_1_2s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1359,6 +1442,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// namespace R {
 	// void Q::V::g() {  } // error: R doesn't enclose Q
 	// }
+	@Test
 	public void test7_3_1_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 2);
 	}
@@ -1388,6 +1472,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// A::X::f(x); //error: f is not a member of A::X
 	// A::X::Y::g(); // error: g is not a member of A::X::Y
 	// }
+	@Test
 	public void test7_3_1_2s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 4);
 	}
@@ -1396,6 +1481,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// namespace CWVLN = Company_with_very_long_name;
 	// namespace CWVLN = Company_with_very_long_name; // OK: duplicate
 	// namespace CWVLN = CWVLN;
+	@Test
 	public void test7_3_2s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1411,6 +1497,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void f(int) { f('c'); } // calls B::f(char)
 	// void g(int) { g('c'); } // recursively calls D::g(int)
 	// };
+	@Test
 	public void test7_3_3s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1424,6 +1511,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// using B::x; // OK: x is a union member of base B
 	// using C::g; // error: C isn't a base of D2
 	// };
+	@Test
 	public void test7_3_3s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -1438,6 +1526,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// using A::f<double>; // illformed
 	// using A::X<int>; // illformed
 	// };
+	@Test
 	public void test7_3_3s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1453,6 +1542,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// using X::s; // error: X::s is a class member
 	// // and this is not a member declaration.
 	// }
+	@Test
 	public void test7_3_3s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1470,6 +1560,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// X::f(); //calls ::f
 	// X::g(); //calls A::g
 	// }
+	@Test
 	public void test7_3_3s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1494,6 +1585,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// using B::i;
 	// using B::i; // error: double member declaration
 	// };
+	@Test
 	public void test7_3_3s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1516,6 +1608,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // that is, for A::f(int) and A::f(char).
 	// f('a'); //calls f(char)
 	// }
+	@Test
 	public void test7_3_3s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1541,6 +1634,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// p->g(1); //calls B::g(int)
 	// p->g('a'); //calls D::g(char)
 	// }
+	@Test
 	public void test7_3_3s12() throws Exception { // raised bug 161562 for that
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1571,6 +1665,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// x = 99; // assigns to A::x
 	// struct x x1; // x1 has class type B::x
 	// }
+	@Test
 	public void test7_3_3s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1593,6 +1688,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void f(int); // error:
 	// // f(int) conflicts with C::f(int) and B::f(int)
 	// }
+	@Test
 	public void test7_3_3s11() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -1611,6 +1707,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// return d>
 	// x(); // ambiguous: B::x or C::x
 	// }
+	@Test
 	public void test7_3_3s14() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -1628,6 +1725,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// public:
 	// using A::g; // B::g is a public synonym for A::g
 	// };
+	@Test
 	public void test7_3_3s15() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1657,6 +1755,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void f4() {
 	// i = 5; // illformed; neither i is visible
 	// }
+	@Test
 	public void test7_3_4s1() throws Exception {
 		String[] problems = { "i", "i" };
 		parse(getAboveComment(), ParserLanguage.CPP, problems);
@@ -1674,6 +1773,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// using namespace N;
 	// i = 7; // error: both M::i and N::i are visible
 	// }
+	@Test
 	public void test7_3_4s2a() throws Exception {
 		String[] problems = { "i" };
 		parse(getAboveComment(), ParserLanguage.CPP, problems);
@@ -1699,6 +1799,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int n = j; // D::j hides B::j
 	// }
 	// }
+	@Test
 	public void test7_3_4s2b() throws Exception {
 		String[] problems = { "k" };
 		parse(getAboveComment(), ParserLanguage.CPP, problems);
@@ -1729,6 +1830,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(1); //error: ambiguous: D::f(int) or E::f(int)?
 	// f('a'); //OK: D::f(char)
 	// }
+	@Test
 	public void test7_3_4s5() throws Exception {
 		String[] problems = { "d1", "f" };
 		parse(getAboveComment(), ParserLanguage.CPP, problems);
@@ -1738,6 +1840,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// extern "C" {
 	// double sqrt(double); // C linkage
 	// }
+	@Test
 	public void test7_5s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -1753,6 +1856,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void (*pf2)(FUNC*); // the name of the variable pf2 has C++ linkage and
 	// // the type of pf2 is pointer to C++ function that
 	// // takes one parameter of type pointer to C function
+	@Test
 	public void test7_5s4a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1777,6 +1881,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // C function
 	// };
 	// }
+	@Test
 	public void test7_5s4b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1800,12 +1905,14 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // definition for the function h
 	// // with C language linkage
 	// // A::h and ::h refer to the same function
+	@Test
 	public void test7_5s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// extern "C" double f();
 	// static double f(); // error
+	@Test
 	public void test7_5s7a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1814,11 +1921,13 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// extern "C" {
 	// int i; // definition
 	// }
+	@Test
 	public void test7_5s7b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// extern "C" static void f(); // error
+	@Test
 	public void test7_5s7c() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1829,6 +1938,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int (*p3i)[3];
 	// int *f();
 	// int (*pf)(double);
+	@Test
 	public void test8_1s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1843,6 +1953,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// S y((int)a); // object declaration
 	// S z = int(a); // object declaration
 	// }
+	@Test
 	public void test8_2s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1853,6 +1964,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// S<int()> x; // typeid
 	// S<int(1)> y; // expression (illformed)
+	@Test
 	public void test8_2s4() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), ParserLanguage.CPP, true, 1);
 		NameCollector col = new NameCollector();
@@ -1872,6 +1984,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// sizeof(int(1)); // expression
 	// // sizeof(int()); // typeid (illformed)
 	// }
+	@Test
 	public void test8_2s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1881,6 +1994,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// (int(1)); //expression
 	// // (int())1; //typeid (illformed)
 	// }
+	@Test
 	public void test8_2s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1893,6 +2007,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(1); //error: cannot convert 1 to function pointer
 	// f(g); //OK
 	// }
+	@Test
 	public void test8_2s7a() throws Exception { // TODO raised bug 90633
 		final String code = getAboveComment();
 		parse(code, ParserLanguage.CPP, true, 1);
@@ -1905,6 +2020,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// class C { };
 	// void h(int *(C[10])); // void h(int *(*_fp)(C _parm[10]));
 	// // not: void h(int *C[10]);
+	@Test
 	public void test8_2s7b() throws Exception {
 		final String code = getAboveComment();
 		parse(code, ParserLanguage.CPP, true, 0);
@@ -1920,11 +2036,13 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void A::B::f() { } // illformed: the declarator must not be
 	// // qualified with A::
 	// }
+	@Test
 	public void test8_3s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// int unsigned i;
+	@Test
 	public void test8_3s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1940,6 +2058,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// pc = p;
 	// ppc = &pc;
 	// }
+	@Test
 	public void test8_3_1s2a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1955,6 +2074,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// p = pc; // error
 	// ppc = &p; // error
 	// }
+	@Test
 	public void test8_3_1s2b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1965,6 +2085,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// *ppc = &ci; // OK, but would make p point to ci ...
 	// *p = 5; // clobber ci
 	// }
+	@Test
 	public void test8_3_1s2c() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -1972,6 +2093,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// typedef int& A;
 	// const A aref = 3; // illformed;
 	// // nonconst reference initialized with rvalue
+	@Test
 	public void test8_3_2s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2003,6 +2125,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		link* q = new link;
 	//		h(q);
 	//	}
+	@Test
 	public void test8_3_2s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2026,6 +2149,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// (obj.*pmf)(7); //call a function member of obj
 	// // with the argument 7
 	// }
+	@Test
 	public void test8_3_3s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2033,17 +2157,20 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// typedef int A[5], AA[2][3];
 	// typedef const A CA; // type is ''array of 5 const int''
 	// typedef const AA CAA; // type is ''array of 2 array of 3 const int''
+	@Test
 	public void test8_3_4s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// float fa[17], *afp[17];
 	// static int x3d[3][5][7];
+	@Test
 	public void test8_3_4s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// int x[3][5];
+	@Test
 	public void test8_3_4s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2054,6 +2181,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// printf("hello world");
 	// printf("a=%d b=%d", a, b);
 	// }
+	@Test
 	public void test8_3_5s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2063,12 +2191,14 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// const F f; // illformed:
 	// // not equivalent to: void f() const;
 	// };
+	@Test
 	public void test8_3_5s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// #define FILE int
 	// int fseek(FILE*, long, int);
+	@Test
 	public void test8_3_5s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2077,6 +2207,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// F fv; // OK: equivalent to void fv();
 	// // F fv { } // illformed
 	// void fv() { } // OK: definition of fv
+	@Test
 	public void test8_3_5s7a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2088,6 +2219,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// FIC f; // OK
 	// };
 	// FIC S::*pm = &S::f; // OK
+	@Test
 	public void test8_3_5s7b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2098,12 +2230,14 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// *fpi(int),
 	// (*pif)(const char*, const char*),
 	// (*fpif(int))(int);
+	@Test
 	public void test8_3_5s9a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// typedef int IFUNC(int);
 	// IFUNC* fpif(int);
+	@Test
 	public void test8_3_5s9b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2112,6 +2246,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void f() {
 	// point(1,2); point(1); point();
 	// }
+	@Test
 	public void test8_3_6s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2137,6 +2272,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// {
 	// f(6); //OK, calls f(6, 7)
 	// }
+	@Test
 	public void test8_3_6s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -2151,6 +2287,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// g(); // g(f(::a))
 	// }
 	// }
+	@Test
 	public void test8_3_6s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2163,6 +2300,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// { } // specified in class scope
 	// void C::g(int i = 88, int j) // in this translation unit,
 	// { }
+	@Test
 	public void test8_3_6s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2173,6 +2311,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// extern void g(int x = i); // error
 	// // ...
 	// }
+	@Test
 	public void test8_3_6s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2180,6 +2319,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// class A {
 	// void f(A* p = this) { } // error
 	// };
+	@Test
 	public void test8_3_6s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2190,6 +2330,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// typedef int I;
 	// int g(float I, int b = I(2)); // error: parameter I found
 	// int h(int a, int b = sizeof(a)); // error, parameter a used
+	@Test
 	public void test8_3_6s9a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -2202,6 +2343,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int mem2(int i = b); // OK; use X::b
 	// static int b;
 	// };
+	@Test
 	public void test8_3_6s9b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2214,6 +2356,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// }
 	// int (*p1)(int) = &f;
 	// int (*p2)() = &f; // error: type mismatch
+	@Test
 	public void test8_3_6s9c() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2231,6 +2374,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// pa->f(); //OK, calls pa->B::f(7)
 	// pb->f(); //error: wrong number of arguments for B::f()
 	// }
+	@Test
 	public void test8_3_6s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -2240,6 +2384,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int m = (a > b) ? a : b;
 	// return (m > c) ? m : c;
 	// }
+	@Test
 	public void test8_4s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2257,6 +2402,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//  void g() volatile const& {}
 	//  void h() volatile const&& {}
 	//};
+	@Test
 	public void test8s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2265,6 +2411,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// {
 	// //printf("a = %d",a);
 	// }
+	@Test
 	public void test8_4s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2276,6 +2423,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// int X::a = 1;
 	// int X::b = a; // X::b = X::a
+	@Test
 	public void test8_5s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2287,11 +2435,13 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int j;
 	// } b;
 	// } a = { 1, { 2, 3 } };
+	@Test
 	public void test8_5_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// int x[] = { 1, 3, 5 };
+	@Test
 	public void test8_5_1s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2301,17 +2451,20 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// static int s;
 	// int j;
 	// } a = { 1, 2 };
+	@Test
 	public void test8_5_1s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// char cv[4] = { 'a', 's', 'd', 'f', 0 }; // error
+	@Test
 	public void test8_5_1s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// struct S { int a; char* b; int c; };
 	// S ss = { 1, "asdf" };
+	@Test
 	public void test8_5_1s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2321,6 +2474,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// S s;
 	// int i;
 	// } a = { { } , 3 };
+	@Test
 	public void test8_5_1s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2329,6 +2483,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// float y[4][3] = {
 	// { 1 }, { 2 }, { 3 }, { 4 }
 	// };
+	@Test
 	public void test8_5_1s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2338,6 +2493,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// { 2, 4, 6 },
 	// { 3, 5, 7 },
 	// };
+	@Test
 	public void test8_5_1s11a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2345,6 +2501,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// float y[4][3] = {
 	// 1, 3, 5, 2, 4, 6, 3, 5, 7
 	// };
+	@Test
 	public void test8_5_1s11b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2359,6 +2516,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// A a;
 	// B b = { 4, a, a };
+	@Test
 	public void test8_5_1s12() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2369,17 +2527,20 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// u c = 1; // error
 	// u d = { 0, "asdf" }; // error
 	// u e = { "asdf" }; // error
+	@Test
 	public void test8_5_1s15() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// char msg[] = "Syntax error on line %s";
+	@Test
 	public void test8_5_2s1() throws Exception {
 		// raised bug 90647
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// 	char cv[4] = "asdf"; // error
+	@Test
 	public void test8_5_2s2() throws Exception {
 		// we do not check the size of an array, which is ok.
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
@@ -2387,6 +2548,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 
 	// int& r1; // error: initializer missing
 	// extern int& r2; // OK
+	@Test
 	public void test8_5_3s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2414,6 +2576,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		f5(b);
 	//		f6(B());
 	//	}
+	@Test
 	public void test8_5_3s5a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2425,6 +2588,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		int i = 2;
 	//		f2(i);    // error: type mismatch and reference not const
 	//	}
+	@Test
 	public void test8_5_3s5b() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper(ParserLanguage.CPP);
 		helper.assertProblem("f1(2", "f1");
@@ -2450,6 +2614,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		f4(x);    // bound directly to the result of operator B
 	//		f3(X());  // error: lvalue-to-rvalue conversion applied to result of operator int&
 	//	}
+	@Test
 	public void test8_5_3s5c() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper(ParserLanguage.CPP);
 		helper.assertNonProblem("f1(f", "f1");
@@ -2473,6 +2638,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		f2(d);    // error: copying lvalue of related type
 	//		f2(i);
 	//	}
+	@Test
 	public void test8_5_3s5d() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper(ParserLanguage.CPP);
 		helper.assertNonProblem("f1(2", "f1");
@@ -2495,6 +2661,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int f(Y);
 	// struct S { int a; };
 	// struct S { int a; }; // error, double definition
+	@Test
 	public void test9_1s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -2513,6 +2680,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// stat(ps); //call stat()
 	// // ...
 	// }
+	@Test
 	public void test9_1s2a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2526,6 +2694,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// struct s { char* p; }; // define local struct s
 	// struct s; // redeclaration, has no effect
 	// }
+	@Test
 	public void test9_1s2b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2539,6 +2708,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // ...
 	// friend Vector operator*(Matrix&, Vector&);
 	// };
+	@Test
 	public void test9_1s2c() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2549,11 +2719,13 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// struct s* p = new struct s; // global s
 	// p->a = s; // local s
 	// }
+	@Test
 	public void test9_1s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// class A * A;
+	@Test
 	public void test9_1s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2565,6 +2737,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// tnode *right;
 	// };
 	// tnode s, *sp;
+	@Test
 	public void test9_2s11() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2575,6 +2748,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void f(T);
 	// };
 	// void X::f(T t = count) { }
+	@Test
 	public void test9_3s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2589,6 +2763,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// fv S::* pmfv1 = &S::memfunc1;
 	// fv S::* pmfv2 = &S::memfunc2;
 	// fvc S::* pmfv3 = &S::memfunc3;
+	@Test
 	public void test9_3s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2614,6 +2789,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// n1.set("abc",&n2,0);
 	// n2.set("def",0,0);
 	// }
+	@Test
 	public void test9_3_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -2622,6 +2798,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void g() const;
 	// void h() const volatile;
 	// };
+	@Test
 	public void test9_3_1s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2633,6 +2810,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int h() const { return a++; } // error
 	// };
 	// int s::f() const { return a; }
+	@Test
 	public void test9_3_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2651,6 +2829,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// y.f();
 	// y.g(); //error
 	// }
+	@Test
 	public void test9_3_2s4() throws Exception {
 		String[] problems = { "g" };
 		final String code = getAboveComment();
@@ -2670,6 +2849,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// process::reschedule(); // OK: no object necessary
 	// g().reschedule(); // g() is called
 	// }
+	@Test
 	public void test9_4s2a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2682,6 +2862,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// static int i;
 	// };
 	// int Y::i = g(); // equivalent to Y::g();
+	@Test
 	public void test9_4s2b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2692,6 +2873,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// process* process::running = get_main();
 	// process* process::run_chain = running;
+	@Test
 	public void test9_4_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -2704,6 +2886,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// p = "Jennifer";
 	// // ...
 	// }
+	@Test
 	public void test9_5s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2713,6 +2896,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// aa = 1; // error
 	// ptr->aa = 1; // OK
 	// }
+	@Test
 	public void test9_5s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -2727,6 +2911,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// if (a.b == t) // shall yield true
 	// {  }
 	// }
+	@Test
 	public void test9_6s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2754,6 +2939,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// };
 	// inner* p = 0; // error: inner not in scope
+	@Test
 	public void test9_7s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -2767,6 +2953,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// int enclose::inner::x = 1;
 	// void enclose::inner::f(int i) {  }
+	@Test
 	public void test9_7s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2777,6 +2964,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// class I1 {}; // definition of nested class
 	// };
 	// class E::I2 {}; // definition of nested class
+	@Test
 	public void test9_7s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2796,6 +2984,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // ...
 	// }
 	// local* p = 0; // error: local not in scope
+	@Test
 	public void test9_8s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -2810,6 +2999,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// Y c; // error
 	// X::Y d; // OK
 	// X::I e; // OK
+	@Test
 	public void test9_9s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -2826,6 +3016,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// public:
 	// int c;
 	// };
+	@Test
 	public void test10s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2834,12 +3025,14 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// class B {  };
 	// class C {  };
 	// class D : public A, public B, public C {  };
+	@Test
 	public void test10_1s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// class X {  };
 	// class Y : public X, public X {  }; // illformed
+	@Test
 	public void test10_1s3a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2850,6 +3043,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// class C : public A, public B { void f();  }; // wellformed
 	// class D : public A, public L { void f();  }; // wellformed
 	//
+	@Test
 	public void test10_1s3b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2883,6 +3077,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// pc->h(); //OK
 	// pc->h(1); //OK
 	// }
+	@Test
 	public void test10_2s3a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -2895,6 +3090,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// i; //finds U::i in two ways: as W::i and U::i in V
 	// // no ambiguity because U::i is static
 	// }
+	@Test
 	public void test10_2s3b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2910,6 +3106,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// class C : public A, public B {
 	// int f() { return A::f() + B::f(); }
 	// };
+	@Test
 	public void test10_2s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2932,6 +3129,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// e; // OK: only one e (enumerator)
 	// pd->a++; //error, ambiguous: two as in D
 	// }
+	@Test
 	public void test10_2s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -2946,6 +3144,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// class C : public virtual V, public W { };
 	// class D : public B, public C { void glorp(); };
+	@Test
 	public void test10_2s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2962,6 +3161,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// A* pa = &d; // error, ambiguous: C's A or B's A?
 	// V* pv = &d; // OK: only one V subobject
 	// }
+	@Test
 	public void test10_2s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -2980,6 +3180,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// c.f(); //calls B::f, the final overrider
 	// c.C::f(); //calls A::f because of the usingdeclaration
 	// }
+	@Test
 	public void test10_3s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3021,6 +3222,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // convert the result to B*
 	// dp->vf2(); //illformed: argument mismatch
 	// }
+	@Test
 	public void test10_3s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3046,6 +3248,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// ap->f(); //calls D::B1::f
 	// dp->f(); //illformed: ambiguous
 	// }
+	@Test
 	public void test10_3s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3064,6 +3267,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// struct Okay : VB1, VB2 {
 	// void f();
 	// };
+	@Test
 	public void test10_3s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3077,6 +3281,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// VB1a* vb1ap = new Da;
 	// vb1ap->f(); //calls VB2::f
 	// }
+	@Test
 	public void test10_3s11() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3084,6 +3289,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// class B { public: virtual void f(); };
 	// class D : public B { public: void f(); };
 	// void D::f() { B::f(); }
+	@Test
 	public void test10_3s12() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3099,6 +3305,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// virtual void draw() = 0; // pure virtual
 	// // ...
 	// };
+	@Test
 	public void test10_4s2a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3117,6 +3324,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// shape f(); // error
 	// void g(shape); // error
 	// shape& h(shape&); // OK
+	@Test
 	public void test10_4s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3127,6 +3335,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void rotate(int) {}
 	// // ab_circle::draw() is a pure virtual
 	// };
+	@Test
 	public void test10_4s4a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3137,6 +3346,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void rotate(int) {}
 	// void draw(); // a definition is required somewhere
 	// };
+	@Test
 	public void test10_4s4b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3147,6 +3357,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// struct S {
 	// int a; // S::a is public by default
 	// };
+	@Test
 	public void test11s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3162,6 +3373,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// A::BB x; // OK, typedef name A::BB is public
 	// A::B y; // access error, A::B is private
 	// }
+	@Test
 	public void test11s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3176,6 +3388,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// A::I g(A::I p = A::x);
 	// A::I g(A::I p) { return 0; }
 	// A::I A::x = 0;
+	@Test
 	public void test11s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3186,6 +3399,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// };
 	// int D::E::m = 1; // OK, no access error on private E
+	@Test
 	public void test11s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3196,6 +3410,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int b; // X::b is public
 	// int c; // X::c is public
 	// };
+	@Test
 	public void test11_1s1a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3209,6 +3424,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// public:
 	// int d; // S::d is public
 	// };
+	@Test
 	public void test11s1b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3218,6 +3434,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// private:
 	// class A { }; // error: cannot change access
 	// };
+	@Test
 	public void test11_1s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3231,6 +3448,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// struct D6 : B {  }; // B public by default
 	// class D7 : protected B {  };
 	// struct D8 : protected B {  };
+	@Test
 	public void test11_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3256,6 +3474,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// B* bp2 = (B*)this; // OK with cast
 	// bp2->mi = 3; // OK: access through a pointer to B.
 	// }
+	@Test
 	public void test11_2s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3271,6 +3490,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// p->i = 1; // OK: B* can be implicitly cast to A*,
 	// // and f has access to i in A
 	// }
+	@Test
 	public void test11_2s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3289,6 +3509,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// friend_set(&obj,10);
 	// obj.member_set(10);
 	// }
+	@Test
 	public void test11_4s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3306,6 +3527,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // to declare members of nested class of X
 	// };
 	// };
+	@Test
 	public void test11_4s2a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3320,6 +3542,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// class Z {
 	// int v[X::a]; // error: X::a is private
 	// };
+	@Test
 	public void test11_4s2b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3328,6 +3551,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// friend char* X::foo(int);
 	// // ...
 	// };
+	@Test
 	public void test11_4s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3336,6 +3560,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// friend void f() { } // definition of global f, a friend of M,
 	// // not the definition of a member function
 	// };
+	@Test
 	public void test11_4s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3361,6 +3586,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // despite being derived from a friend
 	// }
 	// };
+	@Test
 	public void test11_4s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3381,6 +3607,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// X *px; // OK, but ::X is found
 	// Z *pz; // error, no Z is found
 	// }
+	@Test
 	public void test11_4s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3425,6 +3652,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// p1->i = 2; // illformed
 	// p2->i = 3; // illformed
 	// }
+	@Test
 	public void test11_5s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3446,6 +3674,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // D::f() is invoked
 	// pd->f(); //error: D::f() is private
 	// }
+	@Test
 	public void test11_6s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3456,6 +3685,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// class C : public A, public B {
 	// void f() { W::f(); } // OK
 	// };
+	@Test
 	public void test11_7s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3476,6 +3706,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// return p->y; // error: I::y is private
 	// }
 	// };
+	@Test
 	public void test11_8s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3491,6 +3722,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// C::B *t; // error, C::B is inaccessible
 	// };
 	// };
+	@Test
 	public void test11_8s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3500,6 +3732,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// C(); //declares the constructor
 	// };
 	// C::C() { } // defines the constructor
+	@Test
 	public void test12_1s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3518,6 +3751,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// << '\
 	// ';
 	// }
+	@Test
 	public void test12_1s15() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3537,6 +3771,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// X b = f(X(2));
 	// a = f(a);
 	// }
+	@Test
 	public void test12_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3552,6 +3787,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// C obj1;
 	// const C& cr = C(16)+C(23);
 	// C obj2;
+	@Test
 	public void test12_2s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3570,6 +3806,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int b = a; // error:
 	// // a.operator X().operator int() not tried
 	// int c = X(a); // OK: a.operator X().operator int()
+	@Test
 	public void test12_3s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3591,6 +3828,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // ...
 	// }
 	// }
+	@Test
 	public void test12_3s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3608,6 +3846,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// a = 2; // a = X(2)
 	// f(3); // f(X(3))
 	// }
+	@Test
 	public void test12_3_1s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3625,6 +3864,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// Z* p = new Z(1); // OK: direct initialization syntax used
 	// Z a4 = (Z)1; // OK: explicit cast used
 	// Z a5 = static_cast<Z>(1); // OK: explicit cast used
+	@Test
 	public void test12_3_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3640,6 +3880,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// i = (int)a;
 	// i = a;
 	// }
+	@Test
 	public void test12_3_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3651,6 +3892,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// if (a) { // ...
 	// }
 	// }
+	@Test
 	public void test12_3_2s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3671,6 +3913,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		B_ptr->B_alias::~B(); //4        // calls B's destructor
 	//		B_ptr->B_alias::~B_alias(); //5  // calls B's destructor
 	//	}
+	@Test
 	public void test12_4s12() throws Exception {
 		final String code = getAboveComment();
 		parse(code, ParserLanguage.CPP, false, 0);
@@ -3703,6 +3946,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(p);
 	// p->X::~X(); //cleanup
 	// }
+	@Test
 	public void test12_4s13() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3720,6 +3964,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// new D1[i]; // calls ::operator new[](size_t)
 	// new D1; // illformed: ::operator new(size_t) hidden
 	// }
+	@Test
 	public void test12_5s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3734,6 +3979,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void operator delete(void*, size_t);
 	// void operator delete[](void*);
 	// };
+	@Test
 	public void test12_5s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3763,6 +4009,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // copy it into f
 	// complex g = { 1, 2 }; // error; constructor is required
 	// }
+	@Test
 	public void test12_6_1s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3782,6 +4029,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// float f;
 	// complex c;
 	// } x = { 99, 88.8, 77.7 };
+	@Test
 	public void test12_6_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3791,6 +4039,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// struct B { };
 	// struct C: public A, public B { C(); };
 	// C::C(): global_A() { } // meminitializer for base A
+	@Test
 	public void test12_6_2s2a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3799,6 +4048,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// struct B: public virtual A { };
 	// struct C: public A, public B { C(); };
 	// C::C(): A() { } // illformed: which A?
+	@Test
 	public void test12_6_2s2b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -3813,6 +4063,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// D::D(int a) : B2(a+1), B1(a+2), c(a+3), b(a+4)
 	// {  }
 	// D d(10);
+	@Test
 	public void test12_6_2s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3848,6 +4099,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// A a(2); // use V(int)
 	// B b(3); // use V()
 	// C c(4); // use V()
+	@Test
 	public void test12_6_2s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3861,6 +4113,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// const int& r;
 	// X(int i): r(a), b(i), i(i), j(this->i) {}
 	// };
+	@Test
 	public void test12_6_2s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3888,6 +4141,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // but base C not yet initialized
 	// i(f()) {} // welldefined: bases are all initialized
 	// };
+	@Test
 	public void test12_6_2s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3905,6 +4159,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// extern X xobj;
 	// int* p3 = &xobj.i; // OK, X is a POD class
 	// X xobj;
+	@Test
 	public void test12_7s1_a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3917,6 +4172,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// Y() : p(&x.j) // undefined, x is not yet constructed
 	// { }
 	// };
+	@Test
 	public void test12_7s1_b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3947,6 +4203,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// v->g(); // v is base of B, the call is welldefined, calls B::g
 	// a->f(); //undefined behavior, a's type not a base of B
 	// }
+	@Test
 	public void test12_7s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3974,6 +4231,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// dynamic_cast<B*>(a); // undefined behavior,
 	// // a has type A*, A not a base of B
 	// }
+	@Test
 	public void test12_7s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3987,6 +4245,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// X a(1); // calls X(int);
 	// X b(a, 0); // calls X(const X&, int);
 	// X c = b; // calls X(const X&, int);
+	@Test
 	public void test12_8s2a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -3997,6 +4256,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// X(const X&);
 	// X(X&); //OK
 	// };
+	@Test
 	public void test12_8s2b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4007,6 +4267,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// const X cx;
 	// X x = cx; // error - X::X(X&) cannot copy cx into x
+	@Test
 	public void test12_8s2c() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4018,6 +4279,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void g() {
 	// S a( f() ); // does not instantiate member template
 	// }
+	@Test
 	public void test12_8s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4026,6 +4288,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void h(int (*)()); // redeclaration of h(int())
 	// void h(int x()) { } // definition of h(int())
 	// void h(int (*x)()) { } // illformed: redefinition of h(int())
+	@Test
 	public void test12_8s3d() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 1);
 	}
@@ -4033,6 +4296,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// struct X {
 	// X(const X&, int);
 	// };
+	@Test
 	public void test12_8s4a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4041,6 +4305,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// X(const X&, int);
 	// };
 	// X::X(const X& x, int i =0) {  }
+	@Test
 	public void test12_8s4b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4055,6 +4320,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// x = cx; // error:
 	// // X::operator=(X&) cannot assign cx into x
 	// }
+	@Test
 	public void test12_8s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4063,6 +4329,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// struct A : virtual V { };
 	// struct B : virtual V { };
 	// struct C : B, A { };
+	@Test
 	public void test12_8s13() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4080,6 +4347,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// return t;
 	// }
 	// Thing t2 = f();
+	@Test
 	public void test12_8s15() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4090,6 +4358,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// abs(1); //call abs(int);
 	// abs(1.0); //call abs(double);
 	// }
+	@Test
 	public void test13s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4103,6 +4372,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void g() const; // OK: no static g
 	// void g() const volatile; // OK: no static g
 	// };
+	@Test
 	public void test12_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4112,6 +4382,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void f(Int i); // OK: redeclaration of f(int)
 	// void f(int i) {  }
 	// void f(Int i) {  } // error: redefinition of f(int)
+	@Test
 	public void test12_1s3a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 1);
 	}
@@ -4119,6 +4390,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// enum E { a };
 	// void f(int i) { }
 	// void f(E i) {  }
+	@Test
 	public void test12_1s3b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4131,6 +4403,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int g(char[5][10]); // same as g(char(*)[10]);
 	// int g(char[7][10]); // same as g(char(*)[10]);
 	// int g(char(*)[20]); // different from g(char(*)[10]);
+	@Test
 	public void test12_1s3c() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4140,6 +4413,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int f (const int); // redeclaration of f(int)
 	// int f (int) {  } // definition of f(int)
 	// int f (cInt) {  } // error: redefinition of f(int)
+	@Test
 	public void test12_8s3e() throws Exception {
 		String[] problems = { "f" };
 		parse(getAboveComment(), ParserLanguage.CPP, problems);
@@ -4155,6 +4429,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f (1); // OK: call f(int, int)
 	// f (); // Error: f(int, int) or f()?
 	// }
+	@Test
 	public void test12_8s3f() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -4167,6 +4442,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// public:
 	// int f(char*);
 	// };
+	@Test
 	public void test13_2s1a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4186,6 +4462,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// pd->B::f(1); //OK
 	// pd->f("Ben"); //OK, calls D::f
 	// }
+	@Test
 	public void test13_2s1b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -4205,6 +4482,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// callee(88, 99); // error: only callee(int) in scope
 	// }
 	// }
+	@Test
 	public void test13_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -4220,6 +4498,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// buffer(int s) { p = new char[size = s]; }
 	// // ...
 	// };
+	@Test
 	public void test13_2s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4235,6 +4514,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // ...
 	// };
 	// T a = 1; // illformed: T(C(1)) not tried
+	@Test
 	public void test13_3_1s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4249,6 +4529,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// } a;
 	// int i = a(1); // Calls f1 via pointer returned from
 	// // conversion function
+	@Test
 	public void test13_3_1_1_2s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4268,6 +4549,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // user defined types exist which
 	// // would perform the operation.
 	// }
+	@Test
 	public void test13_3_1_2s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4280,6 +4562,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// A a, b;
 	// a + b; // operator+(a,b) chosen over int(a) + int(b)
 	// }
+	@Test
 	public void test13_3_1_2s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4294,6 +4577,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // a conversion to int
 	// float x = a; // ambiguous: both possibilities require conversions,
 	// // and neither is better than the other
+	@Test
 	public void test13_3_3s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4313,6 +4597,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // &i -> int* is better than &i -> const int*
 	// // and c -> int is better than c -> short
 	// }
+	@Test
 	public void test13_3_3s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -4326,6 +4611,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// B b;
 	// f(b); //ambiguous because b -> C via constructor and
 	// // b -> A via constructor or conversion function.
+	@Test
 	public void test13_3_3_1_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -4336,6 +4622,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int f(B&);
 	// int i = f(b); // Calls f(B&), an exact match, rather than
 	// // f(A&), a conversion
+	@Test
 	public void test13_3_3_1_4s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4344,6 +4631,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int f(int *);
 	// int i;
 	// int j = f(&i); // Calls f(int *)
+	@Test
 	public void test13_3_3_2s3a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4365,6 +4653,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// a.f(); //CallsX::f() const
 	// b.f(); //Calls X::f()
 	// }
+	@Test
 	public void test13_3_3_2s3b() throws Exception {
 		String[] problems = { "g" };
 		parse(getAboveComment(), ParserLanguage.CPP, problems);
@@ -4377,6 +4666,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int f(float);
 	// int i = f(a); // Calls f(int), because short -> int is
 	// // better than short -> float.
+	@Test
 	public void test13_3_3_2s3c() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4388,6 +4678,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int f(A *);
 	// int f(B *);
 	// int i = f(pc); // Calls f(B *)
+	@Test
 	public void test13_3_3_2s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4401,6 +4692,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int (*p3)(long) = &X::f; // OK
 	// int (X::*p4)(long) = &X::f; // error: mismatch
 	// int (*p6)(long) = &(X::f); // OK
+	@Test
 	public void test13_4s5b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4414,6 +4706,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// complex z = a.operator+(b); // complex z = a+b;
 	// void* p = operator new(sizeof(int)*n);
 	// }
+	@Test
 	public void test13_5s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4437,6 +4730,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// dobj1 = dobj2; // calls implicitlydeclared
 	// // D::operator=(const D&)
 	// }
+	@Test
 	public void test13_5_3s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4459,6 +4753,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// operator++(b); //explicit call: like ++b;
 	// operator++(b, 0); // explicit call: like b++;
 	// }
+	@Test
 	public void test13_5_7s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4472,6 +4767,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int& ri = i; // error: nonconst reference bound to temporary
 	// const int& cri = i; // OK: const reference bound to temporary
 	// }
+	@Test
 	public void test14_1s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -4479,6 +4775,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<double d> class X; // error
 	// template<double* pd> class Y; // OK
 	// template<double& rd> class Z; // OK
+	@Test
 	public void test14_1s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4491,40 +4788,47 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int v[5];
 	// R<v> y; // OK due to implicit argument conversion
 	// S<v> z; // OK due to both adjustment and conversion
+	@Test
 	public void test14_1s8() throws Exception { // TODO raised bug 90668
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// template<class T1, class T2 = int> class A;
 	// template<class T1 = int, class T2> class A;
+	@Test
 	public void test14_1s10a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// template<class T1 = int, class T2 = int> class A;
+	@Test
 	public void test14_1s10b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// template<class T1 = int, class T2> class B; // error
+	@Test
 	public void test14_1s11() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// template<class T = int> class X;
 	// template<class T = int> class X {  }; // error
+	@Test
 	public void test14_1s12() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// template<class T, T* p, class U = T> class X {  };
 	// template<class T> void f(T* p = new T);
+	@Test
 	public void test14_1s13() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// template<int i = (3 > 4) > // OK
 	// class Y {  };
+	@Test
 	public void test14_1s15() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4535,6 +4839,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// Y< X<1> > x3; // OK
 	// // with C++0x this is no longer valid:
 	// // Y<X<6>> 1> > x4; // OK: Y< X< (6>>1) > >
+	@Test
 	public void test14_2s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4555,6 +4860,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// T::template adjust<100>();
 	// // OK: < starts explicit qualification
 	// }
+	@Test
 	public void test14_2s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -4579,6 +4885,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// v1[3] = 7;
 	// v2[3] = v3.elem(4) = dcomplex(7,8);
 	// }
+	@Test
 	public void test14_3s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4594,6 +4901,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // OK: even though Y::S is private
 	// };
 	// X<Y::S> y; // error: S not accessible
+	@Test
 	public void test14_3s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4605,6 +4913,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// p->A<int>::~A(); // OK: destructor call
 	// q->A<int>::~A<int>(); // OK: destructor call
 	// }
+	@Test
 	public void test14_3s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4616,6 +4925,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// X<S> x3; // error: local type used as templateargument
 	// X<S*> x4; // error: pointer to local type used as templateargument
 	// }
+	@Test
 	public void test14_3_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4626,6 +4936,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// typedef int function();
 	// A<function> a; // illformed: would declare A<function>::t
 	// // as a static member function
+	@Test
 	public void test14_3_1s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4644,6 +4955,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // so c.y.x has type int
 	// // V<int*> within C<A> uses the partial specialization,
 	// // so c.z.x has type long
+	@Test
 	public void test14_3_3s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4651,6 +4963,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class E, int size> class buffer {  };
 	// buffer<char,2*512> x;
 	// buffer<char,1024> y;
+	@Test
 	public void test14_2s1a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4660,6 +4973,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// list<int,&error_handler2> x2;
 	// list<int,&error_handler2> x3;
 	// list<char,&error_handler2> x4;
+	@Test
 	public void test14_4s1b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -4673,6 +4987,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// T& elem(int i) { return v[i]; }
 	// // ...
 	// };
+	@Test
 	public void test14_5_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4682,6 +4997,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void f2();
 	// };
 	// template<class T2, class T1> void A<T2,T1>::f1() { } // OK
+	@Test
 	public void test14_5_1s3a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4701,6 +5017,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// if (i<0 || sz<=i) error("Array: range error");
 	// return v[i];
 	// }
+	@Test
 	public void test14_5_1_1s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4711,6 +5028,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// v1[3] = 7; // Array<int>::operator[]()
 	// v2[3] = dcomplex(7,8); // Array<dcomplex>::operator[]()
 	// }
+	@Test
 	public void test14_5_1_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -4721,6 +5039,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// A<int>::B* b1; // OK: requires A to be defined but not A::B
 	// template<class T> class A<T>::B { };
 	// A<int>::B b2; // OK: requires A::B to be defined
+	@Test
 	public void test14_5_1_2s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4735,6 +5054,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// {
 	// // ...
 	// }
+	@Test
 	public void test14_5_2s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4747,6 +5067,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void f(int i) { f<>(i); } // overriding function that calls
 	// // the template instantiation
 	// };
+	@Test
 	public void test14_5_2s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4764,6 +5085,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// ip = a.operator int*(); // explicit call to template operator
 	// // A::operator int*()
 	// }
+	@Test
 	public void test14_5_2s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4772,6 +5094,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// static T s;
 	// };
 	// template<class T> T X<T>::s = 0;
+	@Test
 	public void test14_5_1_3s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4788,6 +5111,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class P> friend class frd;
 	// // ...
 	// };
+	@Test
 	public void test14_5_4s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4807,6 +5131,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// }
 	// }
+	@Test
 	public void test14_5_4s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -4815,6 +5140,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class T> friend class B; // OK
 	// template<class T> friend void f(T){  } // OK
 	// };
+	@Test
 	public void test14_5_4s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4825,6 +5151,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// template<class T> struct A { X::Y ab; }; // OK
 	// template<class T> struct A<T*> { X::Y ab; }; // OK
+	@Test
 	public void test14_5_4s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4837,6 +5164,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class T> friend struct A<T>::B;
 	// template<class T> friend void A<T>::f();
 	// };
+	@Test
 	public void test14_5_4s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4849,6 +5177,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// A<char>::B<int*> abcip; // uses #2
 	// A<short>::B<int*> absip; // uses #3
 	// A<char>::B<int> abci; // uses #1
+	@Test
 	public void test14_5_5_3s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4858,12 +5187,14 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class T1, class T2, int I> class A<T1*, T2, I> { }; // #3
 	// template<class T> class A<int, T*, 5> { }; // #4
 	// template<class T1, class T2, int I> class A<T1, T2*, I> { }; // #5
+	@Test
 	public void test14_5_5s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// template <int I, int J> struct B {};
 	// template <int I> struct B<I, I> {}; // OK
+	@Test
 	public void test14_5_5s9b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4877,6 +5208,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// A<int, int*, 1> a2; // uses #2, T is int, I is 1
 	// A<int, char*, 5> a3; // uses #4, T is char
 	// A<int, char*, 1> a4; // uses #5, T1 is int, T2 is char, I is 1
+	@Test
 	public void test14_5_5_1s2a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4887,6 +5219,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class T>                   class A<int, T*, 5> { }; // #4
 	// template<class T1, class T2, int I> class A<T1, T2*, I> { }; // #5
 	// A<int*, int*, 2> a5; // ambiguous: matches #3 and #5 : expect problem
+	@Test
 	public void test14_5_5_1s2b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 1);
 	}
@@ -4896,6 +5229,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<int I>                 class X<I, I, int> { }; // #2
 	// template<int I, int J> void f(X<I, J, int>); // #A
 	// template<int I>        void f(X<I, I, int>); // #B
+	@Test
 	public void test14_5_5_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4927,12 +5261,14 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// a2.f(); //illformed, no definition of f for A<T,2>
 	// // the primary template is not used here
 	// }
+	@Test
 	public void test14_5_5_3s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
 
 	// template<class T> class Array { };
 	// template<class T> void sort(Array<T>&);
+	@Test
 	public void test14_5_6s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4944,6 +5280,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(p); // call
 	// // f<int>(int*)
 	// }
+	@Test
 	public void test14_5_6_1s1a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4955,6 +5292,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(p); // call
 	// // f<int*>(int*)
 	// }
+	@Test
 	public void test14_5_6_1s1b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -4965,6 +5303,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template <int I> void f/*2*/(A<I>, A<I+10>);
 	// // Guaranteed to be different
 	// template <int I> void f/*3*/(A<I>, A<I+11>);
+	@Test
 	public void test14_5_6_1s8a() throws Exception {
 		final String content = getAboveComment();
 		IASTTranslationUnit tu = parse(content, ParserLanguage.CPP, true, 0);
@@ -4979,6 +5318,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // Illformed, no diagnostic required
 	// template <int I> void f(A<I>, A<I+10>);
 	// template <int I> void f(A<I>, A<I+1+2+3+4>);
+	@Test
 	public void test14_5_6_1s8b() throws Exception {
 		//test is only for syntax, semantics are not checked here.
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
@@ -4996,6 +5336,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		B<A> b;
 	//		b * a; // calls #1a
 	//	}
+	@Test
 	public void test14_5_6_2s3() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -5024,6 +5365,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// const A<int> z2;
 	// h(z2); // h(const T&) is called because h(A<T>&) is not callable
 	// }
+	@Test
 	public void test14_5_6_2s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5037,6 +5379,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(ip); //calls #2
 	// g(ip); //calls #4
 	// }
+	@Test
 	public void test14_5_6_2s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5061,6 +5404,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // no visible declarations of B and a8
 	// }
 	// };
+	@Test
 	public void test14_6s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5073,6 +5417,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// typename T::X x; // illformed: finds the data member X
 	// // not the member type X
 	// }
+	@Test
 	public void test14_6s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5083,6 +5428,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void f(A<T>::B); // illformed: typename required before A<T>::B
 	// typename A::B g(); // OK
 	// };
+	@Test
 	public void test14_6s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5104,6 +5450,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // not instantiated
 	// }
 	// };
+	@Test
 	public void test14_6s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5124,6 +5471,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// }
 	// // ...
 	// };
+	@Test
 	public void test14_6s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5145,12 +5493,14 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // by two calls of f(int)
 	// g('a'); //will cause three calls of f(char)
 	// }
+	@Test
 	public void test14_6s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
 
 	// template<class T, T* p, class U = T> class X {  };
 	// template<class T> void f(T* p = new T);
+	@Test
 	public void test14_6_1s3a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5160,6 +5510,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// X<T>* p2;
 	// X<int>* p3;
 	// };
+	@Test
 	public void test14_6_1s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5169,6 +5520,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// Y* p; // meaning Y<int>
 	// Y<char>* q; // meaning Y<char>
 	// };
+	@Test
 	public void test14_6_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5176,6 +5528,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<typename T> class Array {};
 	// template<class T> class X : public Array<T> {  };
 	// template<class T> class Y : public T { };
+	@Test
 	public void test14_6_1s3b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5187,6 +5540,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// }
 	// };
 	// template<class X> class X; // error: templateparameter redeclared
+	@Test
 	public void test14_6_1s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5198,6 +5552,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class B> void A<B>::f() {
 	// B b; // A's B, not the template parameter
 	// }
+	@Test
 	public void test14_6_1s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5211,6 +5566,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class C> void N::B<C>::f(C) {
 	// C b; // C is the template parameter, not N::C
 	// }
+	@Test
 	public void test14_6_1s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5224,6 +5580,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// B b; // A's B
 	// a b; // error: A's a isn't a type name
 	// };
+	@Test
 	public void test14_6_1s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5236,6 +5593,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// pb->j++;
 	// }
 	// };
+	@Test
 	public void test14_6_2s2() throws Exception {
 		final String code = getAboveComment();
 		parse(code, ParserLanguage.CPP, true, 0);
@@ -5253,6 +5611,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class T> struct X : B<T> {
 	// A a; // a has type double
 	// };
+	@Test
 	public void test14_6_2s3() throws Exception {
 		final String content = getAboveComment();
 		IASTTranslationUnit tu = parse(content, ParserLanguage.CPP, true, 0);
@@ -5278,6 +5637,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// Y* p; // Y<T>
 	// };
 	// Y<A> ya;
+	@Test
 	public void test14_6_2s4() throws Exception {
 		final String content = getAboveComment();
 		parse(content, ParserLanguage.CPP, true, 0);
@@ -5302,6 +5662,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// void g(int); // not in scope at the point of the template
 	// // definition, not considered for the call g(1)
+	@Test
 	public void test14_6_3s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5321,6 +5682,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // in its namespace (global scope)
 	// b = gcd(3,4); // illformed; gcd is not visible
 	// }
+	@Test
 	public void test14_6_5s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5332,6 +5694,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class T> T X<T>::s = 0;
 	// X<int> aa;
 	// X<char*> bb;
+	@Test
 	public void test14_7s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5352,6 +5715,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// p->g(); //instantiation of class Z<char> required, and
 	// // instantiation of Z<char>::g() required
 	// }
+	@Test
 	public void test14_7_1s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5367,12 +5731,14 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // convert D<char>* to B<char>*
 	// delete ppp; // instantiation of D<double> required
 	// }
+	@Test
 	public void test14_7_1s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// template<class T> class X;
 	// X<char> ch; // error: definition of X required
+	@Test
 	public void test14_7_1s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5391,6 +5757,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// static int x;
 	// };
 	// template<> int B<>::x = 1; // specialize for T == int
+	@Test
 	public void test14_7s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5405,6 +5772,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(sr); //instantiation of S<int> allowed but not required
 	// // instantiation of S<float> allowed but not required
 	// };
+	@Test
 	public void test14_7_1s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5426,6 +5794,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int i = m.get("Nicholas");
 	// // ...
 	// }
+	@Test
 	public void test14_7_1s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5438,6 +5807,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(a, b); // default argument z = zdef(T()) instantiated
 	// f(a); //illformed; ydef is not declared
 	// }
+	@Test
 	public void test14_7_1s12() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5448,6 +5818,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // the implicit instantiation of X<T*> which requires
 	// // the implicit instantiation of X<T**> which ...
 	// };
+	@Test
 	public void test14_7_1s14() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5461,6 +5832,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class T> void f(T&) { }
 	// }
 	// template void N::f<int>(int&);
+	@Test
 	public void test14_7_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5475,6 +5847,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template class N::Y<char*>; // OK: explicit instantiation in namespace N
 	// template void N::Y<double>::mf(); // OK: explicit instantiation
 	// // in namespace N
+	@Test
 	public void test14_7_2s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5483,6 +5856,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class T> void sort(Array<T>& v);
 	// // instantiate sort(Array<int>&) - templateargument deduced
 	// template void sort<>(Array<int>&);
+	@Test
 	public void test14_7_2s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5490,6 +5864,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// char* p = 0;
 	// template<class T> T g(T = &p);
 	// template int g<int>(int); // OK even though &p isn't an int.
+	@Test
 	public void test14_7_2s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5499,6 +5874,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class T> class Array {  };
 	// template<class T> void sort(Array<T>& v) {  }
 	// template<> void sort<char*>(Array<char*>&) ;
+	@Test
 	public void test14_7_3s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5506,6 +5882,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<> class X<int> {  }; // error: X not a template
 	// template<class T> class X;
 	// template<> class X<char*> {  }; // OK: X is a template
+	@Test
 	public void test14_7_3s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5524,6 +5901,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // explicit specialization syntax not used for a member of
 	// // explicitly specialized class template specialization
 	// void A<int>::f(int) {  }
+	@Test
 	public void test14_7_3s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5538,6 +5916,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<> void sort<String>(Array<String>& v); // error: specialization
 	// // after use of primary template
 	// template<> void sort<>(Array<char*>& v); // OK: sort<char*> not yet used
+	@Test
 	public void test14_7_3s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5552,6 +5931,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// }
 	// template<> class N::Y<double> {  }; // OK: specialization
 	// // in same namespace
+	@Test
 	public void test14_7_3s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5561,6 +5941,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // explicit specialization for sort(Array<int>&)
 	// // with deduces templateargument of type int
 	// template<> void sort(Array<int>&);
+	@Test
 	public void test14_7_3s11() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5572,6 +5953,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// template<> template<> class A<int>::B<double> { };
 	// template<> template<> void A<char>::B<char>::mf() { };
+	@Test
 	public void test14_7_3s17() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5580,6 +5962,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<> class X<int>;
 	// X<int>* p; // OK: pointer to declared class X<int>
 	// X<int> x; // error: object of incomplete class X<int>
+	@Test
 	public void test14_7_3s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5589,6 +5972,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template <> void f(int*); // Ambiguous
 	// template <> void f<int>(int*); // OK
 	// template <> void f(int); // OK
+	@Test
 	public void test14_7_3s12() throws Exception {
 		// gcc does not report the explicit instantiation as ambiguous, so we accept it as well.
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
@@ -5598,6 +5982,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class T> inline T g(T) {  }
 	// template<> inline void f<>(int) {  } // OK: inline
 	// template<> int g<>(int) {  } // OK: not inline
+	@Test
 	public void test14_7_3s14() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5620,6 +6005,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void A<int>::g<char>(int,char); // X specified as char
 	// // member specialization even if defined in class definition
 	// template<> void A<int>::h(int) { }
+	@Test
 	public void test14_7_3s16() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5637,6 +6023,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class Y> template<>
 	// void A<Y>::B<double>::mf2() { }; // illformed; B<double> is specialized but
 	// // its enclosing class template A is not
+	@Test
 	public void test14_7_3s18() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5651,6 +6038,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(&a); //call f<int>(int*)
 	// f(&b); //call f<char*>(char**)
 	// }
+	@Test
 	public void test14_8s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5667,6 +6055,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int i = convert<int,double>(d); // int convert(double)
 	// char c = convert<char,double>(d); // char convert(double)
 	// }
+	@Test
 	public void test14_8_1s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5677,6 +6066,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int i = f<int>(5.6); // Y is deduced to be double
 	// int j = f(5.6); // illformed: X cannot be deduced
 	// }
+	@Test
 	public void test14_8_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5690,6 +6080,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // Z is deduced to be double
 	// f("aa",3.0); //error: X cannot be deduced
 	// }
+	@Test
 	public void test14_8_1s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5703,6 +6094,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// {
 	// f<Complex>(1); // OK, means f<Complex>(Complex(1))
 	// }
+	@Test
 	public void test14_8_1s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5723,6 +6115,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f<3>(b); //wellformed because C::f is visible; then
 	// // A::f is found by argument dependent lookup
 	// }
+	@Test
 	public void test14_8_1s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5737,6 +6130,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int i = convert<int>(d); // call convert<int,double>(double)
 	// int c = convert<char>(d); // call convert<char,double>(double)
 	// }
+	@Test
 	public void test14_8_2s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5757,6 +6151,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // #5: function type is h(int, const int*)
 	// h<const int>(1,0);
 	// }
+	@Test
 	public void test14_8_2s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5770,6 +6165,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		f<int>(); // f<int,double>(0,0)
 	//		f<int,char>(); // f<int,char>(0,0)
 	//	}
+	@Test
 	public void test14_8_2s5() throws Exception {
 		final String content = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(content, true);
@@ -5793,6 +6189,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	X f(Y, Y); // #2
 	//	X x1, x2;
 	//	X x3 = f(x1, x2); // deduction fails on #1 (cannot add X+X), calls #2
+	@Test
 	public void test14_8_2s8a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -5800,6 +6197,8 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template <class T> int f(T[5]);
 	// int I = f<int>(0);
 	// int j = f<void>(0); // invalid array
+	@Test
+	@Disabled("Known failing")
 	public void _test14_8_2s8b() throws Exception {
 		final String content = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(content, true);
@@ -5809,6 +6208,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 
 	// template <class T> int f(typename T::B*);
 	// int i = f<int>(0);
+	@Test
 	public void test14_8_2s8c() throws Exception {
 		final String content = getAboveComment();
 		IASTTranslationUnit tu = parse(content, ParserLanguage.CPP, true, 2);
@@ -5837,6 +6237,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		g<C>(0); // The N member of C is not a non-type
 	//		h<D>(0); // The TT member of D is not a template
 	//	}
+	@Test
 	public void test14_8_2s8d() throws Exception {
 		final String content = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(content, true);
@@ -5848,6 +6249,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 
 	// template <class T> int f(int T::*);
 	// int i = f<int>(0);
+	@Test
 	public void test14_8_2s8e() throws Exception {
 		final String code = getAboveComment();
 		parse(code, ParserLanguage.CPP, true, 2);
@@ -5859,6 +6261,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	template <class T> int f(S<T, T()>*);
 	//	struct X {};
 	//	int i0 = f<X>(0);
+	@Test
 	public void test14_8_2s8f() throws Exception {
 		final String code = getAboveComment();
 		parse(code, ParserLanguage.CPP, true, 2);
@@ -5868,6 +6271,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 
 	// template <class T, T*> int f(int);
 	// int i2 = f<int,1>(0); // can't conv 1 to int*
+	@Test
 	public void test14_8_2s8g() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 1);
 	}
@@ -5876,6 +6280,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template <signed char> int f(int);
 	// int i1 = f<1>(0); // ambiguous
 	// int i2 = f<1000>(0); // ambiguous
+	@Test
 	public void test14_8_2s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 2);
 	}
@@ -5890,6 +6295,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		f({1,"asdf"}); // error: T deduced to both int and const char*
 	//		g({1,2,3}); // error: no argument deduced for T
 	//	}
+	@Test
 	public void test14_8_2_1s1a() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -5908,6 +6314,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		f(x, y, z); // Types is deduced to int, float, const int
 	//		g(x, y, z); // T1 is deduced to int; Types is deduced to float, int
 	//	}
+	@Test
 	public void test14_8_2_1s1b() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -5926,6 +6333,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	int n2 = f(0); // calls f<int>(int&&)
 	//	int n3 = g(i); // error: would call g<int>(const int&&), which
 	//	               // would bind an rvalue reference to an lvalue
+	@Test
 	public void test14_8_2_1s3() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -5943,6 +6351,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	int g(int);
 	//	int g(char);
 	//	int i = f(g); // calls f(int (*)(int))
+	@Test
 	public void test14_8_2_1s7() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -5957,6 +6366,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	int g(int);
 	//	char g(char);
 	//	int i = f(1, g); // calls f(int, int (*)(int))
+	@Test
 	public void test14_8_2_1s8() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -5971,6 +6381,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	char g(char);
 	//	template <class T> T g(T);
 	//	int i = f(1, g); // calls f(int, int (*)(int))
+	@Test
 	public void test14_8_2_1s9() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -5986,6 +6397,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	void test(const int * const * const * p1) {
 	//     test(a); // T is deduced as int, not const int
 	//  }
+	@Test
 	public void test14_8_2_3s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -5995,6 +6407,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	void g() {
 	//		f<int>(1); // calls #1
 	//	}
+	@Test
 	public void test14_8_2_4s11() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6009,6 +6422,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	  g(Tuple<int, float&>()); // calls #3
 	//	  g(Tuple<int>()); // calls #3
 	// }
+	@Test
 	public void test14_8_2_4s12() throws Exception {
 		final String code = getAboveComment();
 		parse(code, ParserLanguage.CPP, true, 0);
@@ -6032,6 +6446,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//  void test() {
 	//	   g({1,2,3}); // error: no argument deduced for T
 	//  }
+	@Test
 	public void test14_8_2_5s5() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -6048,6 +6463,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(a,a); //OK: T is A
 	// f(b,b); //OK: T is B
 	// }
+	@Test
 	public void test14_8_2_5s7a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -6062,6 +6478,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		f(g2); //error: T could be char or int
 	//		f(g3); //error: U could be char or float
 	//	}
+	@Test
 	public void test14_8_2_5s7b() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -6078,6 +6495,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// {
 	// f(p); // f(const int *)
 	// }
+	@Test
 	public void test14_8_2_5s7c() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6093,6 +6511,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(d); //calls f(B<int>&)
 	// f(d2); //calls f(B<int>&)
 	// }
+	@Test
 	public void test14_8_2_5s7d() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6104,6 +6523,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		f(i); // calls f<int&>(int&), i.e., #1
 	//		f(0); // calls f<int>(int&&), i.e., #2
 	//	}
+	@Test
 	public void test14_8_2_5s10() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -6120,6 +6540,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(v); //error: argument for templateparameter
 	// //T cannot be deduced
 	// }
+	@Test
 	public void test14_8_2_5s14() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -6138,6 +6559,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f2<10>(v); //OK
 	// f3(v); //OK: i deduced to be 10
 	// }
+	@Test
 	public void test14_8_2_5s15() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -6163,6 +6585,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		g<0>(a1); // OK
 	//		f(a1, a2); // OK
 	//	}
+	@Test
 	public void test14_8_2_5s16a() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -6193,6 +6616,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		B<77> b;
 	//		deduce<77> (a.xm, 62, b.ym);
 	//	}
+	@Test
 	public void test14_8_2_5s16b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6210,6 +6634,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		B<1> b;
 	//		g(b); // OK: cv-qualifiers are ignored on template parameter types
 	//	}
+	@Test
 	public void test14_8_2_5s17() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -6232,6 +6657,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		f(&h); // OK: void h(char,int) is a unique match
 	//		f(&foo); // error: type deduction fails because foo is a template
 	//	}
+	@Test
 	public void test14_8_2_5s18() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -6248,6 +6674,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		f(); // error: cannot deduce T
 	//		f<int>(); // OK: call f<int>(5,7)
 	//	}
+	@Test
 	public void test14_8_2_5s19() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -6266,6 +6693,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		A<B> ab;
 	//		f(ab); //calls f(A<B>)
 	//	}
+	@Test
 	public void test14_8_2_4s20() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6283,6 +6711,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	Y<int&, float&, double&> y2; // uses partial specialization; T is int&, Types contains float, double
 	//	Y<int, float, double> y3; // uses primary template; Types contains int, float, double
 	//	int fv = f(g); // OK; Types contains int, float
+	@Test
 	public void test14_8_2_4s21() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6296,6 +6725,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//		f(1, 2); // calls #3; non-variadic template #3 is more
 	//		// specialized than the variadic templates #1 and #2
 	//	}
+	@Test
 	public void test14_8_2_5s22() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -6319,6 +6749,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// char m2 = max(c,d); // max(char a, char b)
 	// int m3 = max(a,c); // error: cannot generate max(int,char)
 	// }
+	@Test
 	public void test14_8_3s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -6331,6 +6762,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// char m2 = max(c,d); // max(char a, char b)
 	// int m3 = max(a,c); // resolved
 	// }
+	@Test
 	public void test14_8_3s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6343,6 +6775,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(bi); // f(bi)
 	// f(di); // f( (B<int>&)di )
 	// }
+	@Test
 	public void test14_8_3s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6356,6 +6789,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(i,c); //#2: f<int>(i,c);
 	// f(i,i); //#2: f<int>(i,char(i))
 	// }
+	@Test
 	public void test14_8_3s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6364,6 +6798,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void g() {
 	//    f("Annemarie"); // call of f<const char*>
 	// }
+	@Test
 	public void test14_8_3s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6380,6 +6815,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// } catch(...) { // handler 1
 	// }
 	// }
+	@Test
 	public void test15s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6402,6 +6838,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // handles exceptions thrown from the ctorinitializer
 	// // and from the constructor function body
 	// }
+	@Test
 	public void test15s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6426,6 +6863,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // handle exceptions of type Overflow here
 	// }
 	// }
+	@Test
 	public void test15_1s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6440,6 +6878,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // other handler
 	// }
 	// }
+	@Test
 	public void test15_1s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6459,6 +6898,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // ...
 	// }
 	// }
+	@Test
 	public void test15_3s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6466,11 +6906,13 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void f() throw(int); // OK
 	// void (*fp)() throw (int); // OK
 	// void g(void pfa() throw(int)); // OK
+	@Test
 	public void test15_4s1a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// typedef int (*pf)() throw(int); // illformed
+	@Test
 	public void test15_4s1b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6486,6 +6928,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	//	  f(a);
 	//	  g(a);
 	//	}
+	@Test
 	public void test15_4s1c() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6498,6 +6941,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void f(); // illformed
 	// void g() throw (int); // OK
 	// };
+	@Test
 	public void test15_4s3a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6510,6 +6954,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// pf1 = pf2; // OK: pf1 is less restrictive
 	// pf2 = pf1; // error: pf2 is more restrictive
 	// }
+	@Test
 	public void test15_4s3b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6525,6 +6970,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// if (n) throw Z(); // also OK
 	// throw W(); // will call unexpected()
 	// }
+	@Test
 	public void test15_4s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6534,6 +6980,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// {
 	// // f(); //OK
 	// }
+	@Test
 	public void test15_4s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -6553,6 +7000,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // Implicit declaration of D::D(const D&) throw();
 	// // Implicit declaration of D::~D() throw (X,Y);
 	// };
+	@Test
 	public void test15_4s13() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -6564,6 +7012,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// #else
 	// #define INCFILE "versN.h"
 	// #endif
+	@Test
 	public void test16_2s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6578,6 +7027,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// a = ((a + 32765) + b);
 	// a = (a + (b + 32765));
 	// }
+	@Test
 	public void test18_2_1_5s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6586,6 +7036,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// enum E { z = 16 };
 	// int b[X::z]; // OK
 	// };
+	@Test
 	public void test3_3_1s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6598,6 +7049,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// f(a);
 	// }
 	// };
+	@Test
 	public void test3_4_1s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6616,6 +7068,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// F f;
 	// f.A::a = 1; // OK, A::a is a member of F
 	// }
+	@Test
 	public void test3_4_5s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6626,6 +7079,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // may be statically initialized to 0.0 or
 	// // dynamically initialized to 1.0
 	// double d1 = fd(); // may be initialized statically to 1.0
+	@Test
 	public void test3_6_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6637,6 +7091,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// *pcc = &c;
 	// *pc = 'C'; //2: modifies a const object
 	// }
+	@Test
 	public void test4_4s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6649,6 +7104,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int S::* pm = &S::i; // pm refers to mutable member S::i
 	// cs.*pm = 88; // illformed: cs is a const object
 	// }
+	@Test
 	public void test5_5s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6670,6 +7126,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// g(); //okay: name g refers to the same entity
 	// h(); //error: name h found in two namespaces
 	// }
+	@Test
 	public void test7_3_4s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -6677,6 +7134,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int a;
 	// const int b = a;
 	// int c = b;
+	@Test
 	public void test8_5s14() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6690,6 +7148,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// struct D2 : D {
 	// void f();
 	// };
+	@Test
 	public void test10_3s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6706,6 +7165,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// B* bp = new D;
 	// delete bp; //1: uses D::operator delete(void*)
 	// }
+	@Test
 	public void test12_5s7a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -6724,6 +7184,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// B* bp = new D[i];
 	// delete[] bp; // undefined behavior
 	// }
+	@Test
 	public void test12_5s7b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -6739,6 +7200,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// //operator+ (a,a); // ERROR - global operator hidden by member
 	// a + a; // OK - calls global operator+
 	// }
+	@Test
 	public void test13_3_1_2s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6750,6 +7212,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// C<V> value;
 	// // ...
 	// };
+	@Test
 	public void test14_1s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6761,6 +7224,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// T t1 = i; // templateparameters T and i
 	// ::T t2 = ::i; // global namespace members T and i
 	// }
+	@Test
 	public void test14_1s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6772,6 +7236,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// X<&s.m> x4; // error: address of nonstatic member
 	// X<&s.s> x5; // error: &S::s must be used
 	// X<&S::s> x6; // OK: address of static member
+	@Test
 	public void test14_3_2s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6784,6 +7249,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// X<int,"Studebaker"> x1; // error: string literal as template argument
 	// char p[] = "Vivisectionist";
 	// X<int,p> x2; // OK
+	@Test
 	public void test14_3_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -6792,6 +7258,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// B<1> b2; // error: temporary would be required for template argument
 	// int c = 1;
 	// B<c> b1; // OK
+	@Test
 	public void test14_3_2s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -6810,6 +7277,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void f(int);
 	// template<void (*pf)(int)> struct A {  };
 	// A<&f> a; // selects f(int)
+	@Test
 	public void test14_3_2s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6827,11 +7295,13 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// ac.f('c'); //template
 	// ac.f<>(1); //template
 	// }
+	@Test
 	public void test14_5_2s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0); //should be 0
 	}
 
 	// template<class T1, class T2, int I> class A<T1, T2, I> { }; // error
+	@Test
 	public void test14_5_5s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -6845,6 +7315,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class T> template<class T2>
 	// struct A<T>::C::B<T2*> { };
 	// A<short>::C::B<int*> absip; // uses partial specialization
+	@Test
 	public void test14_5_5s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6858,6 +7329,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// }
 	// A<int,int*> a; // uses the partial specialization, which is found through
 	// // the using declaration which refers to the primary template
+	@Test
 	public void test14_5_5s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6865,6 +7337,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template<class T> void f();
 	// template<int I> void f(); // OK: overloads the first template
 	// // distinguishable with an explicit template argument list
+	@Test
 	public void test14_5_6_1s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6873,6 +7346,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template <int I, int J> A<I+J> f/*1*/(A<I>, A<J>); // #1
 	// template <int K, int L> A<K+L> f/*2*/(A<K>, A<L>); // same as #1
 	// template <int I, int J> A<I-J> f/*3*/(A<I>, A<J>); // different from #1
+	@Test
 	public void test14_5_6_1s5() throws Exception {
 		final String content = getAboveComment();
 		IASTTranslationUnit tu = parse(content, ParserLanguage.CPP, true, 0);
@@ -6887,6 +7361,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// template <int I> class A;
 	// template <int I, int J> void f/*1*/(A<I+J>); // #1
 	// template <int K, int L> void f/*2*/(A<K+L>); // same as #1
+	@Test
 	public void test14_5_6_1s6() throws Exception {
 		final String content = getAboveComment();
 		IASTTranslationUnit tu = parse(content, ParserLanguage.CPP, true, 0);
@@ -6900,12 +7375,14 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int f(int); // #2
 	// int k = f(1); // uses #2
 	// int l = f<>(1); // uses #1
+	@Test
 	public void test14_8_1s2b() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
 
 	// #define TABSIZE 100
 	// int table[TABSIZE];
+	@Test
 	public void test15_3_5s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6924,6 +7401,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int (&ra)[3] = a; // ra refers to the array a
 	// ra[1] = i; // modifies a[1]
 	// }
+	@Test
 	public void test8_5_3s1() throws Exception { // TODO raised bug 90648
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6936,6 +7414,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// this->A::operator=(s); // wellformed
 	// return *this;
 	// }
+	@Test
 	public void test12s1() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6957,6 +7436,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// // C/B/D/A sublattice is fully constructed
 	// { }
 	// };
+	@Test
 	public void test12_7s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6979,6 +7459,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// class D {
 	// typedef I I; // error, even though no reordering involved
 	// };
+	@Test
 	public void test3_3_6s5() throws Exception { // 90606
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -6993,6 +7474,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// void g() {
 	// (int (*)(int))&f; // cast expression as selector
 	// }
+	@Test
 	public void test13_4s5a() throws Exception { // bug 90674
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -7028,6 +7510,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// };
 	// int ef(D&);
 	// int ff(X&);
+	@Test
 	public void test11_3s2() throws Exception { //bug 92793
 		IASTTranslationUnit tu = parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 		IASTCompositeTypeSpecifier D = getCompositeType(tu, 2);
@@ -7041,6 +7524,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// int b = f(a);
 	// int c(b);
 	// }
+	@Test
 	public void test8_5s2() throws Exception { // 90641
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}
@@ -7053,6 +7537,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// new (int(*p)) int; // newplacement expression
 	// new (int(*[x])); // new typeid
 	// }
+	@Test
 	public void test8_2s3() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, false, 0);
 	}
@@ -7063,6 +7548,7 @@ public class AST2CPPSpecTest extends AST2SpecTestBase {
 	// {
 	// f<int()>(); // int() is a typeid:call the first f()
 	// }
+	@Test
 	public void test14_3s2() throws Exception {
 		parse(getAboveComment(), ParserLanguage.CPP, true, 0);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTestBase.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTestBase.java
@@ -18,12 +18,6 @@ import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.internal.core.parser.ParserException;
 
 public abstract class AST2CPPTestBase extends AST2TestBase {
-	public AST2CPPTestBase() {
-	}
-
-	public AST2CPPTestBase(String name) {
-		super(name);
-	}
 
 	protected IASTTranslationUnit parseAndCheckBindings(String code) throws Exception {
 		return parseAndCheckBindings(code, ScannerKind.STD);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPTests.java
@@ -25,7 +25,14 @@ import static org.eclipse.cdt.core.dom.ast.IASTExpression.ValueCategory.LVALUE;
 import static org.eclipse.cdt.core.dom.ast.IASTExpression.ValueCategory.XVALUE;
 import static org.eclipse.cdt.core.parser.ParserLanguage.CPP;
 import static org.eclipse.cdt.core.parser.tests.VisibilityAsserts.assertVisibility;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.StringReader;
@@ -170,21 +177,10 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.CPPSemantics;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.CPPVisitor;
 import org.eclipse.cdt.internal.core.index.IndexCPPSignatureUtil;
 import org.eclipse.cdt.internal.core.parser.ParserException;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class AST2CPPTests extends AST2CPPTestBase {
-
-	public AST2CPPTests() {
-	}
-
-	public AST2CPPTests(String name) {
-		super(name);
-	}
-
-	public static TestSuite suite() {
-		return suite(AST2CPPTests.class);
-	}
 
 	private void assertProblemBinding(int id, IBinding b) {
 		assertTrue(b instanceof IProblemBinding);
@@ -242,15 +238,15 @@ public class AST2CPPTests extends AST2CPPTestBase {
 				final String name = dtor.getName().toString();
 				switch (dtor.getRoleForName(dtor.getName())) {
 				case IASTNameOwner.r_declaration:
-					assertTrue("Unexpected decl " + name, i < declNames.length);
+					assertTrue(i < declNames.length, "Unexpected decl " + name);
 					assertEquals(declNames[i++], name);
 					break;
 				case IASTNameOwner.r_definition:
-					assertTrue("Unexpected decl " + name, j < defNames.length);
+					assertTrue(j < defNames.length, "Unexpected decl " + name);
 					assertEquals(defNames[j++], name);
 					break;
 				default:
-					assertTrue(name, false);
+					assertTrue(false, name);
 				}
 			}
 		}
@@ -261,8 +257,8 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	protected static void assertSameType(IType first, IType second) {
 		assertNotNull(first);
 		assertNotNull(second);
-		assertTrue("Expected types to be the same, but first was: '" + first.toString() + "' and second was: '" + second
-				+ "'", first.isSameType(second));
+		assertTrue(first.isSameType(second), "Expected types to be the same, but first was: '" + first.toString()
+				+ "' and second was: '" + second + "'");
 	}
 
 	private void checkUserDefinedLiteralIsType(String code, String type_name) throws Exception {
@@ -284,6 +280,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int (*zzz2) (char);
 	// int ((*zzz3)) (char);
 	// int (*(zzz4)) (char);
+	@Test
 	public void testBug40768() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -291,6 +288,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertNoProblemBindings(col);
 	}
 
+	@Test
 	public void testBug40422() throws Exception {
 		IASTTranslationUnit tu = parse("class A { int y; }; int A::* x = 0;", CPP);
 		NameCollector col = new NameCollector();
@@ -298,6 +296,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertNoProblemBindings(col);
 	}
 
+	@Test
 	public void testBug43241() throws Exception {
 		parseAndCheckBindings("int m(int); int (*pm)(int) = &m; int f(){} int f(int); int x = f((*pm)(5));");
 	}
@@ -308,6 +307,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int f(){}
 	// int f(int);
 	// int x = f((a.*pm)(5));
+	@Test
 	public void testBug43242() throws Exception {
 		parseAndCheckBindings(getAboveComment());
 	}
@@ -320,14 +320,17 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int f(){}
 	//	int f(int);
 	//	int x = f(a->*pm);
+	@Test
 	public void testBug43579() throws Exception {
 		parseAndCheckBindings();
 	}
 
+	@Test
 	public void testBug75189() throws Exception {
 		parseAndCheckBindings("struct A{};typedef int (*F) (A*);");
 	}
 
+	@Test
 	public void testBug75340() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings("void f(int i = 0, int * p = 0);");
 		IASTSimpleDeclaration sd = (IASTSimpleDeclaration) tu.getDeclarations()[0];
@@ -339,6 +342,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  if (first < 1 || last > 99)
 	//	    return false;
 	//	}
+	@Test
 	public void testBug75858() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -351,6 +355,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// type c;
 	// enum type2 {A, B};
 	// enum type2 d, e;
+	@Test
 	public void testBug77967() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -365,6 +370,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  p2 = &MyStruct.b;
 	//	  MyStruct.b = 1;
 	//	}
+	@Test
 	public void testBug78103() throws Exception {
 		parseAndCheckBindings(getAboveComment());
 	}
@@ -378,6 +384,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  A(int t);
 	//	};
 	//	A::A(int t) : B(t - 1) {}
+	@Test
 	public void testBug78883() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -388,10 +395,12 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  B();
 	//	  void foo();
 	//	};
+	@Test
 	public void testBug79540() throws Exception {
 		parseAndCheckBindings(getAboveComment());
 	}
 
+	@Test
 	public void testBug86282() throws Exception {
 		IASTTranslationUnit tu = parse("void foo() { int (* f[])() = new (int (*[10])());  }", CPP);
 		NameCollector col = new NameCollector();
@@ -412,6 +421,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//   for(int x = 0 ; x < 10; x++) {
 	//   }
 	// }
+	@Test
 	public void testBug95411() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector nameCol = new NameCollector();
@@ -419,6 +429,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertNoProblemBindings(nameCol);
 	}
 
+	@Test
 	public void testBug95424() throws Exception {
 		IASTTranslationUnit tu = parse("void f(){ traits_type::copy(__r->_M_refdata(), __buf, __i); }", CPP,
 				ScannerKind.GNU, true);
@@ -435,6 +446,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  CINIT(FILE, OBJECTPOINT, 1),
 	//	  CINIT(URL,  OBJECTPOINT, 2)
 	//	} CURLoption;
+	@Test
 	public void testBug102825() throws Exception {
 		parseAndCheckBindings(getAboveComment());
 	}
@@ -447,6 +459,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  WithTemplate <int, localConst> brokenInstance;
 	//	  return 0;
 	//	}
+	@Test
 	public void testBug103578() throws Exception {
 		parseAndCheckBindings(getAboveComment());
 	}
@@ -462,11 +475,13 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	struct A<T>::B {
 	//	  typedef typename A::type type;
 	//	};
+	@Test
 	public void testBug433556() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	// class A { } a;
+	@Test
 	public void testSimpleClass() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		IASTSimpleDeclaration decl = (IASTSimpleDeclaration) tu.getDeclarations()[0];
@@ -485,6 +500,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	// class A; class A {};
+	@Test
 	public void testClassForwardDecl() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -506,6 +522,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	// class A {};  A a;
+	@Test
 	public void testVariable() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -532,6 +549,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	// class A {  int f; };
+	@Test
 	public void testField() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -553,6 +571,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	// class A { int f(); };
+	@Test
 	public void testMethodDeclaration() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -575,6 +594,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	//  class A { void f();  };
 	//  void A::f() { }
+	@Test
 	public void testMethodDefinition() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -612,6 +632,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	// class A { void f(); int i;    };
 	// void A::f() { i; }
+	@Test
 	public void testMemberReference() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -663,6 +684,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class A { int i; };
 	// class B : public A { void f(); };
 	// void B::f() { i; }
+	@Test
 	public void testBasicInheritance() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -733,6 +755,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f(){
 	//    BC::a++; //ok
 	// }
+	@Test
 	public void testNamespaces() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -760,6 +783,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    A++;
 	//    class A a;
 	// }
+	@Test
 	public void testNameHiding() throws Exception {
 		String content = getAboveComment();
 		IASTTranslationUnit tu = parse(content, CPP);
@@ -792,6 +816,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    B b;
 	// }
 	// int B;
+	@Test
 	public void testBlockTraversal() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -818,6 +843,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    f(1);		//calls f(int);
 	//    f('b');
 	// }
+	@Test
 	public void testFunctionResolution() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -836,6 +862,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//     S myS;
 	//     myS.x = 5;
 	// }
+	@Test
 	public void testSimpleStruct() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -858,6 +885,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    struct A;
 	//    struct A * a;
 	// }
+	@Test
 	public void testStructureTags_a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -879,6 +907,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f(){
 	//    struct A * a;
 	// }
+	@Test
 	public void testStructureTags_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -901,6 +930,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f() {
 	//    a->i;
 	// }
+	@Test
 	public void testStructureDef() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -919,6 +949,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f(int x) {
 	//    struct x i;
 	// }
+	@Test
 	public void testStructureNamespace() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -933,6 +964,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f(int b){
 	//    b;
 	// }
+	@Test
 	public void testFunctionDef() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -954,6 +986,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    f();
 	// }
 	// void f(){ }
+	@Test
 	public void testSimpleFunctionCall() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -971,6 +1004,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//       i;
 	//    }
 	// }
+	@Test
 	public void testForLoop() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -985,6 +1019,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f(){
 	//    ((struct A *) 1)->x;
 	// }
+	@Test
 	public void testExpressionFieldReference() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -1005,6 +1040,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    if (*cp != red)
 	//       return;
 	// }
+	@Test
 	public void testEnumerations() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -1029,6 +1065,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertSame(pt.getType(), hue);
 	}
 
+	@Test
 	public void testPointerToFunction() throws Exception {
 		IASTTranslationUnit tu = parse("int (*pfi)();", CPP);
 		NameCollector collector = new NameCollector();
@@ -1056,6 +1093,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int * f(int i, char c);
 	// void (*g) (A *);
 	// void (* (*h)(A**)) (int);
+	@Test
 	public void testFunctionTypes() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -1121,6 +1159,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertTrue(h_ps[0] instanceof IBasicType);
 	}
 
+	@Test
 	public void testFnReturningPtrToFn() throws Exception {
 		IASTTranslationUnit tu = parse("void (* f(int))(){}", CPP);
 
@@ -1145,6 +1184,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    X::f();
 	//    X::g();
 	// }
+	@Test
 	public void testUsingDeclaration() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -1182,6 +1222,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  using A::f;
 	//	  f('c');
 	//	}
+	@Test
 	public void testUsingDeclaration_86368() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		IFunction f1 = bh.assertNonProblem("f(int)", 1);
@@ -1209,6 +1250,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void g(char []);
 	// void h(int(a)());
 	// void h(int (*) ());
+	@Test
 	public void testFunctionDeclarations() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -1233,6 +1275,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    B * b = new B();
 	//    b->x;
 	// }
+	@Test
 	public void testProblem_AmbiguousInParent() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -1250,6 +1293,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    A * a = new A();
 	//    a->x;
 	// }
+	@Test
 	public void testVirtualParentLookup() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector(true);
@@ -1279,6 +1323,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    A * a = new A();
 	//    a->x;
 	// }
+	@Test
 	public void testAmbiguousVirtualParentLookup() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector(true);
@@ -1310,6 +1355,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// namespace A {
 	//    void f() { x; }
 	// }
+	@Test
 	public void testExtendedNamespaces() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -1327,6 +1373,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	// class A { A(void);  A(const A &); };
+	@Test
 	public void testConstructors() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -1350,6 +1397,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	// class A {};
+	@Test
 	public void testImplicitConstructors() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -1385,6 +1433,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  };
 	//  typedef E F;
 	//  F::E() {}
+	@Test
 	public void testImplicitConstructors_360223() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPClassType c = bh.assertNonProblem("C", 0);
@@ -1407,6 +1456,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	template <typename T>
 	//	struct Bar<T, decltype(T())> { };
 	//	constexpr int v = Bar<Foo,Foo>::val;
+	@Test
 	public void testImplicitConstructors_1265() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector(true);
@@ -1431,6 +1481,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int test() {
 	//	  foo(1);
 	//	}
+	@Test
 	public void testInheritedConstructor() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -1449,6 +1500,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int test() {
 	//	  foo(1);
 	//	}
+	@Test
 	public void testInheritedConstructorFromTemplateInstance() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -1467,6 +1519,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int test() {
 	//	  foo(1);
 	//	}
+	@Test
 	public void testInheritedConstructorFromUnknownClass() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -1488,6 +1541,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(A<int> a) {
 	//	  foo(a);
 	//	}
+	@Test
 	public void testInheritedTemplateConstructor() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -1498,12 +1552,14 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		using base::base;
 	//		base waldo() const;
 	//	};
+	@Test
 	public void testInheritedConstructorShadowingBaseClassName_485383() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	// class A { ~A(); };
 	// class B { ~B(void); };
+	@Test
 	public void testExplicitDestructor_183160() throws Exception {
 		// class F { (~)F(); };
 		// class G { (~)G(void); };
@@ -1520,20 +1576,21 @@ public class AST2CPPTests extends AST2CPPTestBase {
 			int count = 0;
 			for (ICPPMethod method : methods)
 				count += method.getName().startsWith("~") ? 1 : 0;
-			assertEquals(line, 0, count);
+			assertEquals((long) 0, (long) count, line);
 
 			methods = A.getDeclaredMethods();
 			assertNotNull(methods);
 			count = 0;
 			for (ICPPMethod method : methods)
 				count += method.getName().startsWith("~") ? 1 : 0;
-			assertEquals(line, 1, count);
+			assertEquals((long) 1, (long) count, line);
 		}
 	}
 
 	// class C {};
 	// class D {D();};
 	// class E {E(void);};
+	@Test
 	public void testImplicitDestructor_183160() throws Exception {
 		BufferedReader br = new BufferedReader(new StringReader(getAboveComment()));
 		for (String line = br.readLine(); line != null; line = br.readLine()) {
@@ -1547,14 +1604,14 @@ public class AST2CPPTests extends AST2CPPTestBase {
 			int count = 0;
 			for (ICPPMethod method : methods)
 				count += method.getName().startsWith("~") ? 1 : 0;
-			assertEquals(line, 1, count);
+			assertEquals((long) 1, (long) count, line);
 
 			methods = A.getDeclaredMethods();
 			assertNotNull(methods);
 			count = 0;
 			for (ICPPMethod method : methods)
 				count += method.getName().startsWith("~") ? 1 : 0;
-			assertEquals(line, 0, count);
+			assertEquals((long) 0, (long) count, line);
 		}
 	}
 
@@ -1578,6 +1635,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  class R {public: R(int k=5, long k=4);};
 	//  class S {public: S(int k=5, int* ip= 0);};
 	//  class T {public: T(int k=5, int* ip= 0, T* t= 0);};
+	@Test
 	public void testExplicitDefaultConstructor_183160() throws Exception {
 		BufferedReader br = new BufferedReader(new StringReader(getAboveComment()));
 		for (String line = br.readLine(); line != null; line = br.readLine()) {
@@ -1596,6 +1654,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  class R {public: R(int k=5, long k);};
 	//  class S {public: S(int k=5, int* ip);};
 	//  class T {public: T(int k, int* ip= 0, T* t= 0);};
+	@Test
 	public void testExplicitNonDefaultConstructor_183160() throws Exception {
 		BufferedReader br = new BufferedReader(new StringReader(getAboveComment()));
 		for (String line = br.readLine(); line != null; line = br.readLine()) {
@@ -1618,6 +1677,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	class F {private: F(const F &, int j=2, int k=3);};
 	//	class G {protected: G(volatile G &, int i=4, int l=2);};
 	//	class H {H(const volatile H &, int i=1, long k=2) {}};
+	@Test
 	public void testExplicitCopyConstructor_183160() throws Exception {
 		BufferedReader br = new BufferedReader(new StringReader(getAboveComment()));
 		for (String line = br.readLine(); line != null; line = br.readLine()) {
@@ -1638,6 +1698,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	class K {protected: K(volatile K *, int i=4, int l=2);}; // K * rather than K  &
 	//	class L {L(const volatile L &, int i=1, long k=2, int* x) {}}; // param int* x has no initializer
 	//	class M {public: template <typename T> M(){}}; // same signature as implicit
+	@Test
 	public void testNotExplicitCopyConstructor_183160() throws Exception {
 		BufferedReader br = new BufferedReader(new StringReader(getAboveComment()));
 		for (String line = br.readLine(); line != null; line = br.readLine()) {
@@ -1657,6 +1718,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	class B {public: void operator=(B &, int); };  // compile error
 	//	class C {public: void operator=(C &c, int k=5) {} };  // compile error
 	//	class D {public: void operator=(const D &, const D &); };  // compile error
+	@Test
 	public void testNotExplicitCopyAssignmentOperator_183160() throws Exception {
 		BufferedReader br = new BufferedReader(new StringReader(getAboveComment()));
 		for (String line = br.readLine(); line != null; line = br.readLine()) {
@@ -1690,6 +1752,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	class B {protected: void operator=(const B &); };
 	//	class C {private: void operator=(volatile C &) {} };
 	//	class D {D& operator=(volatile const D &); };
+	@Test
 	public void testExplicitCopyAssignmentOperator_183160() throws Exception {
 		BufferedReader br = new BufferedReader(new StringReader(getAboveComment()));
 		for (String line = br.readLine(); line != null; line = br.readLine()) {
@@ -1725,6 +1788,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	A a = A(1);
+	@Test
 	public void testConstructorCall() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPConstructor ctor = bh.assertNonProblem("A(int x)", "A", ICPPConstructor.class);
@@ -1744,6 +1808,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  A a("hi", 5, 10);
 	//	}
+	@Test
 	public void testInvalidImplicitConstructorCall() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertImplicitName("a", 1, IProblemBinding.class);
@@ -1760,6 +1825,8 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  B b;
 	//	  A a = A(b);
 	//	}
+	@Test
+	@Disabled("Known failing")
 	public void _testConversionOperator() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPMethod oper = bh.assertNonProblem("operator A", "operator A", ICPPMethod.class);
@@ -1779,6 +1846,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  S s;
 	//	  waldo(s);  // ERROR
 	//	}
+	@Test
 	public void testOverloadedRefQualifiedConversionOperators_506728() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -1786,6 +1854,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// namespace A { int x; }
 	// namespace B = A;
 	// int f(){ B::x;  }
+	@Test
 	public void testNamespaceAlias() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1803,6 +1872,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertInstances(col, x, 3);
 	}
 
+	// @Test
 	// public void testBug84250() throws Exception {
 	// assertTrue(((IASTDeclarationStatement) ((IASTCompoundStatement)
 	// ((IASTFunctionDefinition) parse(
@@ -1815,6 +1885,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    int (*p) [2];
 	//    (&p)[0] = 1;
 	// }
+	@Test
 	public void testBug84250() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1834,6 +1905,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    int (*p) [2];
 	//    (&p)[0] = 1;
 	// }
+	@Test
 	public void testBug84250b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1849,6 +1921,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	// struct s { double i; } f(void);
 	// struct s f(void){}
+	@Test
 	public void testBug84266() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1862,6 +1935,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertSame(s_ref, s_decl);
 	}
 
+	@Test
 	public void testBug84266b() throws Exception {
 		IASTTranslationUnit tu = parse("struct s f(void);", CPP);
 		NameCollector col = new NameCollector();
@@ -1887,6 +1961,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    int x;
 	//    { int x = x; }
 	// }
+	@Test
 	public void testBug84228() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1913,6 +1988,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    A::n = 42;
 	//    A b;
 	// }
+	@Test
 	public void testBug84615() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1931,6 +2007,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertNotNull(prob);
 	}
 
+	@Test
 	public void testBug84371() throws Exception {
 		String code = "int x = ::ABC::DEF::ghi;";
 		IASTTranslationUnit tu = parse(code, CPP);
@@ -1953,6 +2030,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    AB::f(1);
 	//    AB::f(`c`);
 	// }
+	@Test
 	public void testBug84679() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.STD, false);
 		NameCollector col = new NameCollector();
@@ -1982,6 +2060,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    struct Node * node;
 	//    friend struct Glob;
 	// };
+	@Test
 	public void testBug84692() throws Exception {
 		// also tests bug 234042.
 		CPPASTNameBase.sAllowRecursionBindings = false;
@@ -2004,6 +2083,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// namespace A { using namespace B;  int a;  }
 	// namespace B { using namespace A; }
 	// void f() { B::a++;  }
+	@Test
 	public void testBug84686() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2028,6 +2108,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    }
 	//    return *this;
 	// }
+	@Test
 	public void testBug84705() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2055,6 +2136,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class A { void f(); void g() const; };
 	// void A::f(){ this; }
 	// void A::g() const { *this; }
+	@Test
 	public void testThis() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -2081,6 +2163,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertTrue(((IQualifierType) type).isConst());
 	}
 
+	@Test
 	public void testBug84710() throws Exception {
 		IASTTranslationUnit tu = parse("class T { T(); };", CPP);
 		NameCollector col = new NameCollector();
@@ -2098,6 +2181,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int main() {
 	//    f(parm);
 	// }
+	@Test
 	public void testArgumentDependantLookup() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2126,6 +2210,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int main() {
 	//    f(a);
 	// }
+	@Test
 	public void testArgumentDependantLookup_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2155,6 +2240,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    A::i; //i2
 	//    j;
 	// }
+	@Test
 	public void testBug84610() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2181,6 +2267,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    B* pb = new B();
 	//    pb->mutate();
 	// }
+	@Test
 	public void testBug84703() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2201,6 +2288,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f() {         ;
 	//    int S::* pm = &S::i;
 	// }
+	@Test
 	public void testBug84469() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2209,6 +2297,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertEquals(9, col.size());
 	}
 
+	@Test
 	public void testPointerToMemberType() throws Exception {
 		IASTTranslationUnit tu = parse("struct S; int S::* pm;", CPP);
 		NameCollector col = new NameCollector();
@@ -2232,6 +2321,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f() {
 	//    s->*pm = 1;
 	// }
+	@Test
 	public void testBug_PM_() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2251,6 +2341,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void foo() {
 	//    (s->*pm)()->i;
 	// }
+	@Test
 	public void testBug_PM_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2276,7 +2367,9 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertInstances(col, f, 3);
 	}
 
+	// @Test
 	// public void testFindTypeBinding_a() throws Exception {
+
 	// IASTTranslationUnit tu = parse(
 	// "int x = 5; int y(x);", CPP);
 	//
@@ -2298,6 +2391,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// assertTrue(binding instanceof ICPPClassType);
 	// }
 	//
+	// @Test
 	// public void testFindTypeBinding_b() throws Exception {
 	// IASTTranslationUnit tu = parse(
 	// "struct B; void f() { B * bp; }", CPP);
@@ -2321,6 +2415,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void g() {
 	// B * bp;  //1
 	// }
+	@Test
 	public void testBug85049() throws Exception {
 		IASTTranslationUnit t = parse(getAboveComment(), CPP);
 		IASTFunctionDefinition g = (IASTFunctionDefinition) t.getDeclarations()[1];
@@ -2335,6 +2430,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    int A::* pm = &A::i;
 	//    f(pm);
 	// }
+	@Test
 	public void testPMConversions() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2361,6 +2457,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void g() {
 	//    f(pm);
 	// }
+	@Test
 	public void testPMKoenig_a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2387,6 +2484,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    N::A * a;
 	//    f(a->*pm);
 	// }
+	@Test
 	public void testPMKoenig_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2413,6 +2511,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// };
 	// void set();
 	// class B{};
+	@Test
 	public void testFriend() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2436,6 +2535,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    friend B;
 	// };
 	// class B{};
+	@Test
 	public void testForwardDeclaredFriend_525645() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -2453,6 +2553,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    friend void set();
 	//    friend void Other::m();
 	// };
+	@Test
 	public void testFriend_275358() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -2473,6 +2574,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	// class A { friend class B; friend class B; };
 	// class B{};
+	@Test
 	public void testBug59149() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2494,6 +2596,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class B {
 	//    friend class A::N;
 	// };
+	@Test
 	public void testBug59302() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2515,6 +2618,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class A {
 	//    friend class B *helper();
 	// };
+	@Test
 	public void testBug75482() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2538,6 +2642,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void foo() {
 	//    pf = &f;
 	// }
+	@Test
 	public void testBug45763a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2560,6 +2665,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    g(&f);
 	//    (*pg)(&f);
 	// }
+	@Test
 	public void testBug45763b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2581,6 +2687,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void (* bar ()) (int) {
 	//    return &f;
 	// }
+	@Test
 	public void testBug45763c() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2600,6 +2707,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void foo () {
 	//    (void (*)(int)) &f;
 	// }
+	@Test
 	public void testBug45763d() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2617,6 +2725,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// extern int g;
 	// int g;
 	// void f() {  g = 1; }
+	@Test
 	public void testBug85824() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2638,6 +2747,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    int a4;
 	//    a;
 	// }
+	@Test
 	public void testPrefixLookup() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2669,6 +2779,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void test(){
 	//   v_;
 	// }
+	@Test
 	public void testAdditionalNamespaceLookup() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2689,6 +2800,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	// static void f();
 	// void f() {}
+	@Test
 	public void testIsStatic() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2707,7 +2819,8 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	// && __i == 2))
 	//	// return;
 	//	// }
-	//	public void testBug85310() throws Exception {
+	//	@Test
+	// public void testBug85310() throws Exception {
 	//		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 	//		IASTFunctionDefinition f = (IASTFunctionDefinition)
 	//		tu.getDeclarations()[0];
@@ -2725,6 +2838,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void g() {
 	//    B* pb = new (p) D1;
 	// }
+	@Test
 	public void testBug86267() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector(true);
@@ -2755,6 +2869,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    }
 	//    return *this;
 	// }
+	@Test
 	public void testBug86269() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2782,6 +2897,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    printf(p);
 	//    printf("abc");
 	// }
+	@Test
 	public void testBug86279() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2801,6 +2917,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void h() {
 	//    g(a);
 	// }
+	@Test
 	public void testBug86346() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2813,6 +2930,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertInstances(col, g, 2);
 	}
 
+	@Test
 	public void testBug86288() throws Exception {
 		String code = "int *foo(int *b) { return (int *)(b); }";
 		IASTTranslationUnit tu = parse(code, CPP);
@@ -2827,6 +2945,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// };
 	// int (B::*pb)() = &B::f;
 	// }
+	@Test
 	public void testBug84476() throws Exception {
 		String code = getAboveComment();
 		IASTFunctionDefinition foo = (IASTFunctionDefinition) parse(code, CPP).getDeclarations()[0];
@@ -2845,6 +2964,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    }
 	//    A(int) {}
 	// };
+	@Test
 	public void testBug86336() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPClassType clazz = bh.assertNonProblem("A {", "A", ICPPClassType.class);
@@ -2864,6 +2984,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void foo() {
 	//    int S::* pm = &S::i;
 	// }
+	@Test
 	public void testBug86306() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2889,6 +3010,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    using A::f<double>; // illformed
 	//    using A::X<int>; // illformed
 	// };
+	@Test
 	public void testBug86372() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2902,6 +3024,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//       a[i] = 1;
 	//    int j = i;
 	// }
+	@Test
 	public void testBug86319() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2925,6 +3048,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    p->x.i;
 	//    p->x.j;
 	// }
+	@Test
 	public void testBug86350() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2951,6 +3075,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//     i = 0;
 	//   }
 	// }
+	@Test
 	public void testBug84478() throws Exception {
 		IASTFunctionDefinition foo = (IASTFunctionDefinition) parse(getAboveComment(), CPP).getDeclarations()[0];
 		ICPPASTWhileStatement whileStatement = (ICPPASTWhileStatement) ((IASTCompoundStatement) foo.getBody())
@@ -2964,6 +3089,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  {   enum { x = x };  }
 	//	}
 	//	enum { RED };
+	@Test
 	public void testBug86353() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2997,6 +3123,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    typeid(d1) == typeid(d2);
 	//    typeid(D) == typeid(d2);
 	// }
+	@Test
 	public void testBug86274() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3018,6 +3145,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    point(1);
 	//    point();
 	// }
+	@Test
 	public void testBug86546() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3036,6 +3164,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//       void g() {  i++;  }
 	//    }
 	// }
+	@Test
 	public void testBug86358a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3056,6 +3185,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    namespace V {
 	//    }
 	// }
+	@Test
 	public void testBug86358b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3086,6 +3216,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    void f(int) { f('c'); }
 	//    void g(int) { g('c'); }
 	// };
+	@Test
 	public void test86371() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3118,6 +3249,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// namespace CWVLN = Company_with_veryblahblah;
 	// namespace CWVLN = Company_with_veryblahblah;
 	// namespace CWVLN = CWVLN;
+	@Test
 	public void testBug86369() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3159,6 +3291,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    void f(int);
 	// }
 	// using A::f;
+	@Test
 	public void testBug86470a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3198,6 +3331,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    using B::f;
 	//    f('c');
 	// }
+	@Test
 	public void testBug86470b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3217,6 +3351,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    g('a');
 	//    struct g gg;
 	// }
+	@Test
 	public void testBug86470c() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3251,6 +3386,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    x = 1;
 	//    struct x xx;
 	// }
+	@Test
 	public void testBug86470d() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3290,6 +3426,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    using A::f;
 	//    f(3.5);
 	// }
+	@Test
 	public void testBug86470e() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3320,6 +3457,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f(B* p) {
 	//    p->i = 1;
 	// }
+	@Test
 	public void testBug86678() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3340,6 +3478,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    printf("hello");
 	//    printf("a=%d b=%d", a, b);
 	// }
+	@Test
 	public void testBug86543() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3353,6 +3492,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    int m = (a > b) ? a : b;
 	//    return (m > c) ? m : c;
 	// }
+	@Test
 	public void testBug86554() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3377,6 +3517,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// struct X { static int g(); };
 	// struct Y : X { static int i ; };
 	// int Y::i = g();
+	@Test
 	public void testBug86621() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3414,6 +3555,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    y++;
 	//    g();
 	// }
+	@Test
 	public void testBug86649() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3446,6 +3588,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    int c;
 	//    C() : c(0) { }
 	// };
+	@Test
 	public void testBug86827() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3470,6 +3613,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//       int v2;
 	//    }
 	// }
+	@Test
 	public void testFind_a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3498,6 +3642,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// };
 	// void B::f() {
 	// }
+	@Test
 	public void testFind_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3530,6 +3675,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    void f(char);
 	//    using A::f;
 	// }
+	@Test
 	public void testFind_c() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3568,6 +3714,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    using namespace A;
 	//    using namespace C;
 	// }
+	@Test
 	public void testFind_d() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3596,6 +3743,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    B();
 	//    void bf();
 	// };
+	@Test
 	public void testFind_185408() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3629,6 +3777,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    int b;
 	//    void fb();
 	// };
+	@Test
 	public void testImplicitMethods() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3687,6 +3836,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertSame(result[9], A_implicit[3]);
 	}
 
+	@Test
 	public void testBug87424() throws Exception {
 		IASTTranslationUnit tu = parse("int * __restrict x;", CPP, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
@@ -3707,6 +3857,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertTrue(((ICPPPointerToMemberType) t).isRestrict());
 	}
 
+	@Test
 	public void testBug87705() throws Exception {
 		IASTTranslationUnit tu = parse("class A { friend class B::C; };", CPP, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
@@ -3718,6 +3869,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertEquals(C.getID(), IProblemBinding.SEMANTIC_NAME_NOT_FOUND);
 	}
 
+	@Test
 	public void testBug88459() throws Exception {
 		IASTTranslationUnit tu = parse("int f(); ", CPP);
 		NameCollector col = new NameCollector();
@@ -3727,6 +3879,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertFalse(f.isStatic());
 	}
 
+	@Test
 	public void testBug88501a() throws Exception {
 		IASTTranslationUnit tu = parse("void f(); void f(int); struct f;", CPP);
 		NameCollector col = new NameCollector();
@@ -3737,7 +3890,9 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertTrue(col.getName(3).resolveBinding() instanceof ICPPClassType);
 	}
 
+	// @Test
 	// public void testBug8342a() throws Exception {
+
 	// IASTTranslationUnit tu = parse("int a; int a;", CPP);
 	//
 	// NameCollector col = new NameCollector();
@@ -3747,6 +3902,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// IProblemBinding p = (IProblemBinding) col.getName(1).resolveBinding();
 	// assertEquals(p.getID(), IProblemBinding.SEMANTIC_INVALID_REDEFINITION);
 	// }
+	@Test
 	public void testBug8342b() throws Exception {
 		IASTTranslationUnit tu = parse("extern int a; extern char a;", CPP);
 		NameCollector col = new NameCollector();
@@ -3762,6 +3918,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f() {
 	//    B::i;
 	// }
+	@Test
 	public void testNamespaceAlias_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3792,6 +3949,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  MACRO;
 	//	}
+	@Test
 	public void testNamespaceAliasInMacroExpansion_506668() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -3800,6 +3958,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class B : public A {
 	//    B () : A() {}
 	// };
+	@Test
 	public void testBug89539() throws Exception {
 		String content = getAboveComment();
 		IASTTranslationUnit tu = parse(content, CPP);
@@ -3825,6 +3984,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    A * a;
 	// };
 	// class A;
+	@Test
 	public void testBug89851() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3836,6 +3996,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertTrue(col.getName(3).resolveBinding() instanceof ICPPClassType);
 	}
 
+	@Test
 	public void testBug89828() throws Exception {
 		IASTTranslationUnit tu = parse("class B * b; void f();  void f(int);", CPP);
 		NameCollector col = new NameCollector();
@@ -3862,6 +4023,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//       f(A::t1);
 	//    }
 	// };
+	@Test
 	public void testBug90039() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3877,6 +4039,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f(void) {
 	//    enum { one };
 	// }
+	@Test
 	public void testBug90039b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3893,6 +4056,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// operator int();
 	// char& operator[](unsigned int);
 	// };
+	@Test
 	public void testOperatorConversionNames() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3917,6 +4081,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// X::operator int() { }
 	// template <class A,B> class X<A,C> { operator int(); };
 	// template <class A,B> X<A,C>::operator int() { }
+	@Test
 	public void testBug36769B() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3959,6 +4124,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertNotNull(((ICPPASTConversionName) int4).getTypeId());
 	}
 
+	@Test
 	public void testBug88662() throws Exception {
 		IASTTranslationUnit tu = parse("int foo() {  return int();}", CPP);
 		IASTReturnStatement returnStatement = (IASTReturnStatement) ((IASTCompoundStatement) ((IASTFunctionDefinition) tu
@@ -3969,6 +4135,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertEquals(expression.getSimpleType(), ICPPASTSimpleTypeConstructorExpression.t_int);
 	}
 
+	@Test
 	public void testBug90498a() throws Exception {
 		IASTTranslationUnit tu = parse("typedef int INT;\ntypedef INT (FOO) (INT);", CPP);
 
@@ -3984,6 +4151,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertEquals(nested.getName().toString(), "FOO");
 	}
 
+	@Test
 	public void testBug90498b() throws Exception {
 		IASTTranslationUnit tu = parse("int (* foo) (int) (0);", CPP);
 
@@ -4007,6 +4175,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//     typeid(d1) == typeid(d2);
 	//     typeid(D) == typeid(d2);
 	// }
+	@Test
 	public void testBug866274() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		IASTFunctionDefinition foo = (IASTFunctionDefinition) tu.getDeclarations()[3];
@@ -4030,6 +4199,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		}
 	}
 
+	@Test
 	public void testTypedefFunction() throws Exception {
 		IASTTranslationUnit tu = parse("typedef int foo (int);", CPP);
 		NameCollector col = new NameCollector();
@@ -4046,6 +4216,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	typedef A B;
 	//
 	//	B a = B(1);
+	@Test
 	public void testTypedefConstructorCall() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPConstructor ctor = bh.assertNonProblem("A(int x)", "A", ICPPConstructor.class);
@@ -4062,6 +4233,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void foo(){
 	//    f((1, 2));
 	// }
+	@Test
 	public void testBug90616() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4072,6 +4244,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertSame(f1, f2);
 	}
 
+	@Test
 	public void testBug90603() throws Exception {
 		IASTTranslationUnit tu = parse("class X { void f(){} };", CPP);
 		NameCollector col = new NameCollector();
@@ -4095,6 +4268,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class X {   };
 	// X x;
 	// class X {   };
+	@Test
 	public void testBug90662() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4153,6 +4327,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    const C& operator <(const C&);
 	//    const C& operator>(const C&);
 	// };
+	@Test
 	public void testOperatorNames() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4206,6 +4381,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// struct C {
 	//    auto operator<=>(const C&);
 	// };
+	@Test
 	public void testThreeWayComparisonOperatorName() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.STDCPP20);
 		NameCollector col = new NameCollector();
@@ -4228,6 +4404,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// static constexpr auto greater01 = greater(0, 1);
 	// static constexpr auto greater00 = greater(0, 0);
 	// static constexpr auto greater10 = greater(1, 0);
+	@Test
 	public void testThreeWayComparisonSimpleCase() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper(CPP, ScannerKind.STDCPP20);
 		helper.assertVariableValue("less01", 1);
@@ -4252,6 +4429,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// };
 	//
 	// constexpr auto value = V1 | V2;
+	@Test
 	public void testBinaryOperatorOverloadTemplate() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper(CPP);
 		helper.assertVariableValue("value", 42);
@@ -4265,6 +4443,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    typedef char I;
 	//    typedef I I;
 	// };
+	@Test
 	public void testBug90623() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4298,6 +4477,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// typedef int I;
 	// void f11(I i);
 	// void main(){ f a; }
+	@Test
 	public void testBug90623b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4317,6 +4497,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// };
 	// Y y;
 	// X* x = new X(y);
+	@Test
 	public void testBug90654a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector(true);
@@ -4333,6 +4514,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int f(int);
 	// int f(float);
 	// int x = f(a);
+	@Test
 	public void testBug90654b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4351,6 +4533,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    this->A::operator=(s);
 	//    return *this;
 	// }
+	@Test
 	public void testBug90653() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4372,6 +4555,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void foo() {
 	//    f("test");
 	// }
+	@Test
 	public void testBug86618() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4386,6 +4570,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void foo () {
 	//    f(g) ;
 	// }
+	@Test
 	public void testBug45129() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4411,6 +4596,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//   ABC::DEF * var;
 	//   ABC::GHI * value;
 	// }
+	@Test
 	public void testAmbiguousStatements() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		IASTDeclaration[] declarations = tu.getDeclarations();
@@ -4425,6 +4611,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    union { int a; char* p; };
 	//    a = 1;
 	// }
+	@Test
 	public void testBug86639() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4439,6 +4626,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    int aa1, aa2;
 	//    a;
 	// }
+	@Test
 	public void testBug80940() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4463,6 +4651,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    const Ex * e;
 	//    e->d();
 	// }
+	@Test
 	public void testBug77024() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4490,6 +4679,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    Point() : xCoord(0) {}
 	//    int xCoord;
 	// };
+	@Test
 	public void testBug91773() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4500,6 +4690,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertSame(x, x2);
 	}
 
+	@Test
 	public void testBug90648() throws ParserException {
 		IASTTranslationUnit tu = parse("int f() { int (&ra)[3] = a; }", CPP);
 		IASTFunctionDefinition f = (IASTFunctionDefinition) tu.getDeclarations()[0];
@@ -4513,6 +4704,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertTrue(declarators[0] instanceof IASTArrayDeclarator);
 	}
 
+	@Test
 	public void testBug92980() throws Exception {
 		String code = "struct A { A(); A(const A&) throw(1); ~A() throw(X); };";
 		parse(code, CPP, ScannerKind.GNU, false);
@@ -4520,6 +4712,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	// class Dummy { int v(); int d; };
 	// void Dummy::v(int){ d++; }
+	@Test
 	public void testBug92882() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4538,6 +4731,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    f(3);
 	//    f();
 	// }
+	@Test
 	public void testBug86547() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4547,6 +4741,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertInstances(col, f1, 5);
 	}
 
+	@Test
 	public void testBug90647() throws Exception {
 		parse("char msg[] = \"Syntax error on line %s\\n\";", CPP);
 	}
@@ -4564,6 +4759,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int k;
 	// k = sum;
 	// }
+	@Test
 	public void testBug82766() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4577,6 +4773,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//     char *c;
 	//     l |= ((unsigned long)(*((c)++)))<<24;
 	// }
+	@Test
 	public void testBug77385() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4584,6 +4781,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertNoProblemBindings(col);
 	}
 
+	@Test
 	public void testBug83997() throws Exception {
 		IASTTranslationUnit tu = parse("namespace { int x; }", CPP);
 		NameCollector col = new NameCollector();
@@ -4591,6 +4789,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertNoProblemBindings(col);
 	}
 
+	@Test
 	public void testBug85786() throws Exception {
 		IASTTranslationUnit tu = parse("void f(int); void foo () { void * p = &f; ((void (*) (int)) p) (1); }",
 				ParserLanguage.C);
@@ -4604,6 +4803,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    static int arr[ n ];
 	// };
 	// int C::arr[n];
+	@Test
 	public void testBug90610() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4629,6 +4829,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int X::y = 1;
 	// int (*g(int))(int);
 	// int (*pf)(int);
+	@Test
 	public void testDeclDefn() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4655,6 +4856,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int f(int);
 	// int (&rfi)(int) = f;
 	// int (&rfd)(double) = f;
+	@Test
 	public void testBug95200() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4667,6 +4869,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertSame(col.getName(9).resolveBinding(), f1);
 	}
 
+	@Test
 	public void testBug95425() throws Exception {
 		IASTTranslationUnit tu = parse("class A { A(); };", CPP);
 		NameCollector col = new NameCollector();
@@ -4696,6 +4899,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    char x[100];
 	//    f(x);
 	// }
+	@Test
 	public void testBug95461() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4710,6 +4914,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//   A * b = 0;
 	//   A & c = 0;
 	// }
+	@Test
 	public void testAmbiguity() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		IASTSimpleDeclaration A = (IASTSimpleDeclaration) tu.getDeclarations()[0];
@@ -4738,6 +4943,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// F f;
 	// f.A::a = 1;
 	// }
+	@Test
 	public void testBug84696() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4761,6 +4967,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  int a;
 	//	};
 	//	int X:: * pmi = &X::a;
+	@Test
 	public void testBasicPointerToMember() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		assertEquals(tu.getDeclarations().length, 2);
@@ -4779,6 +4986,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void foo() {
 	//	    (waldo()->*true).meow();  // Method 'meow' could not be resolved
 	//	}
+	@Test
 	public void testOverloadedPointerToMemberOperator_488611() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4788,6 +4996,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void foo(D* dp) {
 	//	  B* bp = dynamic_cast<B*>(dp);
 	//	}
+	@Test
 	public void testBug84466() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		ICPPASTCastExpression dynamic_cast = (ICPPASTCastExpression) ((IASTEqualsInitializer) ((IASTSimpleDeclaration) ((IASTDeclarationStatement) ((IASTCompoundStatement) ((IASTFunctionDefinition) tu
@@ -4797,6 +5006,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertEquals(dynamic_cast.getOperator(), ICPPASTCastExpression.op_dynamic_cast);
 	}
 
+	@Test
 	public void testBug88338_CPP() throws Exception {
 		IASTTranslationUnit tu = parse("struct A; struct A* a;", CPP);
 		NameCollector col = new NameCollector();
@@ -4815,6 +5025,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertFalse(col.getName(0).isReference());
 	}
 
+	@Test
 	public void testPointerToFunction_CPP() throws Exception {
 		IASTTranslationUnit tu = parse("int (*pfi)();", CPP);
 		assertEquals(tu.getDeclarations().length, 1);
@@ -4831,6 +5042,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  X a[10];
 	//	  a[0].bar;
 	//	}
+	@Test
 	public void testBug95484() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4844,6 +5056,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void f(const char * const * argv){
 	//	  strcmp(*argv);
 	//	}
+	@Test
 	public void testBug95419() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4861,6 +5074,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  public: Sub(Other *);
 	//	};
 	//	Sub::Sub(Other * b) : Base(b) {}
+	@Test
 	public void testBug95673() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 
@@ -4875,6 +5089,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  mem(x, "FUNC");
 	//	  mem(x + offset, "FUNC2");
 	//	}
+	@Test
 	public void testBug95768() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4892,6 +5107,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int Foo::import(){
 	//    trace(this);
 	// }
+	@Test
 	public void testBug95741() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4908,6 +5124,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// RTCharacter::operator char(void)const {
 	//    return value;
 	// }
+	@Test
 	public void testBug95692() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4922,6 +5139,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    str(0);
 	//    str(00);  str(0x0);
 	// }
+	@Test
 	public void testBug95734() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4939,6 +5157,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    str(1.2);
 	//    str(ONE);  str(p);
 	// }
+	@Test
 	public void testBug95734b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -4954,6 +5173,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// char * value;
 	// ::operator delete(value);
 	// }
+	@Test
 	public void testBug95786() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -4971,6 +5191,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// catch (...)
 	// {
 	// }
+	@Test
 	public void testBug86868() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		assertEquals(tu.getDeclarations().length, 1);
@@ -4979,6 +5200,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f(int t){
 	// int s (t);
 	// }
+	@Test
 	public void testBug94779() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		IASTDeclarationStatement ds = (IASTDeclarationStatement) ((IASTCompoundStatement) ((IASTFunctionDefinition) tu
@@ -4989,6 +5211,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	// int t= 0;
 	// int s (t);
+	@Test
 	public void testBug211756() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		IASTSimpleDeclaration sd = (IASTSimpleDeclaration) (tu.getDeclarations()[1]);
@@ -5003,6 +5226,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    ci->state;
 	//    (ci - 1)->state;
 	// }
+	@Test
 	public void testBug95714() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5015,6 +5239,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	// float _Complex x;
 	// double _Complex y;
+	@Test
 	public void testBug95757() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		IASTDeclaration[] decls = tu.getDeclarations();
@@ -5034,6 +5259,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f(){
 	//    A::i++;
 	// }
+	@Test
 	public void testTypedefQualified() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5051,6 +5277,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  int b(f());
 	//	  return a+b;
 	//  }
+	@Test
 	public void testBug86849() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5063,6 +5290,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f(A * a) {
 	//    copy(a);
 	// }
+	@Test
 	public void testBug96655() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5072,6 +5300,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertSame(copy, col.getName(7).resolveBinding());
 	}
 
+	@Test
 	public void testBug96678() throws Exception {
 		parse("int x; // comment \r\n", CPP, ScannerKind.STD, true);
 	}
@@ -5081,6 +5310,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f() {
 	//    copy(new A());
 	// }
+	@Test
 	public void testNewExpressionType() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5093,6 +5323,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class A {
 	//    A(int i = 0);
 	// };
+	@Test
 	public void testDefaultConstructor() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5116,6 +5347,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    b->foo;
 	//    b[0].foo;
 	// }
+	@Test
 	public void testBug91707() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5133,6 +5365,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    class C {};
 	// };
 	// class A::B{};
+	@Test
 	public void testBug92425() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5152,6 +5385,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    struct F {} f;
 	//    void f(int a) {}
 	// }
+	@Test
 	public void testBug92425b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5167,12 +5401,14 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	// A< B< C< D< E< F< G< H<int> > > > > > > > a;
 	// int A::B<int>::* b;
+	@Test
 	public void testBug98704() throws Exception {
 		parse(getAboveComment(), CPP);
 	}
 
 	// void f();
 	// void f(void) {}
+	@Test
 	public void testBug_AIOOBE() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5187,6 +5423,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f(const int);
 	// void f(int);
 	// void g() { f(1); }
+	@Test
 	public void testRankingQualificationConversions_a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5198,6 +5435,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f(const volatile int);
 	// void f(const int);
 	// void g() { f(1); }
+	@Test
 	public void testRankingQualificationConversions_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5225,6 +5463,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		i(&ca); // i(const int *)
 	//		i(&a);  // i(int * const &)
 	//	}
+	@Test
 	public void testRankingQualificationConversions_c() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -5270,6 +5509,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//       void A::f(){}
 	//    }
 	// }
+	@Test
 	public void testBug98818() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5297,6 +5537,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    A a;
 	//    a.B.i; a.C.j;
 	// }
+	@Test
 	public void testAnonymousStructures() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -5308,6 +5549,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertSame(j, col.getName(5).resolveBinding());
 	}
 
+	@Test
 	public void testBug99262() throws Exception {
 		parse("void foo() {void *f; f=__null;}", CPP, ScannerKind.GNU, true);
 	}
@@ -5317,11 +5559,13 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f2() {
 	//   f1(__null);
 	// }
+	@Test
 	public void testBug240567() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertNonProblem("f1(__null", 2, ICPPFunction.class);
 	}
 
+	@Test
 	public void testBug100408() throws Exception {
 		IASTTranslationUnit tu = parse("int foo() { int x=1; (x)*3; }", CPP);
 		NameCollector col = new NameCollector();
@@ -5329,6 +5573,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertNoProblemBindings(col);
 	}
 
+	@Test
 	public void testBug84478c() throws Exception {
 		IASTTranslationUnit tu = parse("void foo() { switch(int x = 4) { case 4: x++; break; default: break;} }", CPP);
 		NameCollector col = new NameCollector();
@@ -5337,6 +5582,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertSame(col.getName(1).resolveBinding(), col.getName(2).resolveBinding());
 	}
 
+	@Test
 	public void testBug84478d() throws Exception {
 		IASTTranslationUnit tu = parse("void foo() { for(int i = 0; int j = 0; ++i) {} }", CPP);
 		NameCollector col = new NameCollector();
@@ -5353,6 +5599,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//       a++; b++;
 	//    }
 	// }
+	@Test
 	public void testBug84478b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -5377,6 +5624,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void f(char** p) {
 	//    free(p);
 	// }
+	@Test
 	public void testBug100415() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -5397,6 +5645,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//       friend class X;
 	//    };
 	// }
+	@Test
 	public void testBug86688() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -5412,6 +5661,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    int m::f();
 	// };
 	// int m::f(){}
+	@Test
 	public void testBug100403() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -5431,6 +5681,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    friend void A::f1(AT);
 	//    friend void A::f2(BT);
 	// };
+	@Test
 	public void testBug90609() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -5454,6 +5705,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//       e->blah;
 	//    }
 	// }
+	@Test
 	public void testBug103281() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -5466,6 +5718,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertSame(blah, col.getName(6).resolveBinding());
 	}
 
+	@Test
 	public void testBug78800() throws Exception {
 		parseAndCheckBindings(
 				"class Matrix {  public: Matrix & operator *(Matrix &); }; Matrix rotate, translate; Matrix transform = rotate * translate;");
@@ -5478,6 +5731,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void X::foo() {
 	//    i;
 	// }
+	@Test
 	public void test10_2s3b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -5495,6 +5749,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int f() {
 	// int x = 4;  while(x < 10) blah: ++x;
 	// }
+	@Test
 	public void testBug1043290() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment());
 		IASTFunctionDefinition fd = (IASTFunctionDefinition) tu.getDeclarations()[0];
@@ -5511,6 +5766,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// do { ++i; } while(i < 10);
 	// return 0;
 	// }
+	@Test
 	public void testBug104800() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment());
 		IASTFunctionDefinition f = (IASTFunctionDefinition) tu.getDeclarations()[0];
@@ -5518,6 +5774,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertEquals(body.getStatements().length, 3);
 	}
 
+	@Test
 	public void testBug107150() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#define FUNC_PROTOTYPE_PARAMS(list)    list\r\n");
@@ -5551,6 +5808,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int FooClass::foo() {
 	// return 0;
 	// }
+	@Test
 	public void testBug108202() throws Exception {
 		parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 	}
@@ -5561,6 +5819,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// 	static int MyClass::static_field;
 	// };
 	// int MyClass::static_field;
+	@Test
 	public void testBug174791() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
@@ -5599,6 +5858,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// }
 	// void nsSplit::a() {
 	// }
+	@Test
 	public void testBug180979() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
@@ -5615,6 +5875,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// #define _GLIBCXX_BEGIN_NAMESPACE(X) namespace X _GLIBCXX_VISIBILITY(default) {
 	// _GLIBCXX_BEGIN_NAMESPACE(std)
 	// } // end the namespace
+	@Test
 	public void testBug195701() throws Exception {
 		parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 	}
@@ -5626,6 +5887,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    double operator*(double);
 	//    using A::operator*;
 	// };
+	@Test
 	public void testBug178059() throws Exception {
 		parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 	}
@@ -5633,6 +5895,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void foo (void *p) throw () ;
 	// void bar (void *p) __attribute__ ((__nonnull__(1)));
 	// void zot (void *p) throw () __attribute__ ((__nonnull__(1)));
+	@Test
 	public void testBug179712() throws Exception {
 		parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 	}
@@ -5667,6 +5930,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		problem4(ptm);
 	//		problem5(ptm);
 	//	}
+	@Test
 	public void testBug214335() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 
@@ -5696,6 +5960,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	}
 	//	outer::foo x;
 	//	outer::inner::foo y;
+	@Test
 	public void testAttributeInUsingDirective_351228() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -5721,6 +5986,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		fs();
 	//		fs(1);
 	//	}
+	@Test
 	public void testReferencesOfUsingDecls() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
@@ -5803,6 +6069,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void O::I::f() {
 	//    a=0;
 	// }
+	@Test
 	public void testUsingDirectiveWithNestedClass_209582() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 
@@ -5822,6 +6089,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    Test foo2 (bar, pBar);
 	//    Test foo3 (&bar);
 	// }
+	@Test
 	public void testCastAmbiguity_211756() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 
@@ -5836,6 +6104,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	 if (relayIndex < 0 || relayIndex > numRelays)
 	//	    return 0;
 	// }
+	@Test
 	public void testTemplateIDAmbiguity_104706() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 
@@ -5859,6 +6128,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    (base::has_trivial_copy<value_type>::value &&
 	//	    base::has_trivial_destructor<value_type>::value)>
 	//	    realloc_ok;
+	@Test
 	public void testTemplateIDAmbiguity_228118() throws Exception {
 		parse(getAboveComment(), CPP);
 	}
@@ -5874,6 +6144,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    func(qualified);
 	//    func(unqualified);
 	// }
+	@Test
 	public void testScopeOfUsingDelegates_219424() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 
@@ -5889,6 +6160,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void Test::member1(){
 	//    member2();
 	// }
+	@Test
 	public void testQualifiedMemberDeclaration_222026() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -5937,6 +6209,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void Test::member1(){
 	//    member2();
 	// }
+	@Test
 	public void testQualifiedMemberDeclarationInNamespace_222026() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -5979,6 +6252,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	// namespace ns { typedef int ns::TINT; } // illegal, still no CCE is expected.
+	@Test
 	public void testQualifiedTypedefs_222093() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		IBinding td = bh.assertProblem("TINT", 4);
@@ -5991,11 +6265,13 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//   if (a > b) {
 	//   }
 	// }
+	@Test
 	public void testResettingTemplateIdScopesStack_223777() throws Exception {
 		parseAndCheckBindings(getAboveComment());
 	}
 
 	// long x= 10L;
+	@Test
 	public void testLongLiteral_225534() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		IASTDeclarator decltor = ((IASTSimpleDeclaration) tu.getDeclarations()[0]).getDeclarators()[0];
@@ -6011,6 +6287,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// short      sh(0);
 	// long       l(0L);
 	// long long  ll(0LL);
+	@Test
 	public void testInitializeUnsigned_245070() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -6063,6 +6340,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		foo/*k1*/(11.1L);
 	//		foo/*k2*/(11.1E1L);
 	//	}
+	@Test
 	public void testLiteralsViaOverloads_225534() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		char[] cs = { 'a', 'b', 'e', 'f', 'g', 'h', 'i', 'j', 'k' };
@@ -6070,7 +6348,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 			for (int i = 1; i < (c < 'i' ? 4 : 3); i++) {
 				ICPPFunction def = ba.assertNonProblem("foo/*_" + c + "*/", 3, ICPPFunction.class);
 				ICPPFunction ref = ba.assertNonProblem("foo/*" + c + "" + i + "*/", 3, ICPPFunction.class);
-				assertSame("function ref: " + c + "" + i, def, ref);
+				assertSame(def, ref, "function ref: " + c + "" + i);
 			}
 		}
 	}
@@ -6096,6 +6374,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		SecondLevelProxy p2;
 	//		p2->doA();
 	//	}
+	@Test
 	public void testRecursiveUserDefinedFieldAccess_205964() throws Exception {
 		parseAndCheckBindings(getAboveComment());
 	}
@@ -6107,6 +6386,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// using ns::A;
 	//
 	// class B: public A {};
+	@Test
 	public void testBug235196() throws Exception {
 		parseAndCheckBindings(getAboveComment());
 	}
@@ -6123,6 +6403,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// X::~X() {}
 	// X::operator int() {}
 	// X::xtint(a); // 2
+	@Test
 	public void testEmptyDeclSpecifier() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("X {", 1, ICPPClassType.class);
@@ -6158,6 +6439,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  new (T[f][f]);
 	//    new (p) (T[f][f]);
 	// };
+	@Test
 	public void testNewPlacement() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment());
 		IASTFunctionDefinition fdef = getDeclaration(tu, 3);
@@ -6185,6 +6467,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//   void test() {}
 	//   +
 	// }
+	@Test
 	public void testTrailingSyntaxErrorInNamespace() throws Exception {
 		final String comment = getAboveComment();
 		IASTTranslationUnit tu = parse(comment, CPP, ScannerKind.STD, false);
@@ -6198,6 +6481,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//   void test() {}
 	//   +
 	// }
+	@Test
 	public void testTrailingSyntaxErrorInLinkageSpec() throws Exception {
 		final String comment = getAboveComment();
 		IASTTranslationUnit tu = parse(comment, CPP, ScannerKind.STD, false);
@@ -6209,6 +6493,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	// class C;
 	// void func(void (C::*m)(int) const);
+	@Test
 	public void test233889_a() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPFunction func = bh.assertNonProblem("func(", 4, ICPPFunction.class);
@@ -6231,6 +6516,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		 func(&C::m1);
 	//		 func(&C::m2);
 	//	 }
+	@Test
 	public void testBug233889_b() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPFunction fn1 = bh.assertNonProblem("func(&C::m1", 4, ICPPFunction.class);
@@ -6252,6 +6538,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		void member3() volatile { foo(this);/*3*/ }
 	//		void member4() const volatile { foo(this);/*4*/ }
 	//	};
+	@Test
 	public void testThisType() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ICPPFunction pt1 = ba.assertNonProblem("foo(this);/*1*/", 3, ICPPFunction.class);
@@ -6284,6 +6571,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//      A* a2= new A();
 	//      a2->foo();/*2*/
 	//	}
+	@Test
 	public void testMemberAccessOperator_a() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertProblem("foo();/*1*/", 3);
@@ -6307,6 +6595,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		B* b2= new B();
 	//		b2->foo();/*2*/
 	//	}
+	@Test
 	public void testMemberAccessOperator_b() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ICPPMethod m1 = ba.assertNonProblem("foo();/*1*/", 3, ICPPMethod.class);
@@ -6323,6 +6612,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	   C c;
 	//	   c->foo();/**/ // refers to A::foo
 	//	}
+	@Test
 	public void testMemberAccessOperator_c() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("foo();/**/", 3);
@@ -6336,6 +6626,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	   C c;
 	//	   c->foo();/**/ // expect problem - foo is not in B
 	//	}
+	@Test
 	public void testMemberAccessOperator_d() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertProblem("foo();/**/", 3);
@@ -6352,6 +6643,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	   C2 c;
 	//	   c->foo();/**/ // refers to A::foo
 	//	}
+	@Test
 	public void testMemberAccessOperator_e() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("foo();/**/", 3);
@@ -6363,6 +6655,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		typeid(int).name();
 	//		typeid(s).name();
 	//	}
+	@Test
 	public void testTypeid_209578() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP);
 	}
@@ -6380,6 +6673,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  f3(r);
 	//	  f4(s);
 	//	}
+	@Test
 	public void testArrayToPointerConversion() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("f1(p)", 2, ICPPFunction.class);
@@ -6400,6 +6694,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		test(y);
 	//		test(z);
 	//	}
+	@Test
 	public void testArrayToPtrConversionForTypedefs_239931() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP);
 	}
@@ -6414,6 +6709,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  test2(x);
 	//	  test3(x);
 	//	}
+	@Test
 	public void testAdjustmentOfParameterTypes_239975() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP);
 	}
@@ -6428,11 +6724,13 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  ptr2mem= reinterpret_cast<void (A::*)(char)>(&A::m);
 	//	  ptr2mem= (void (A::*)(int))(0);
 	//	}
+	@Test
 	public void testTypeIdForPtrToMember_242197() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP);
 	}
 
 	// void restrict();
+	@Test
 	public void testRestrictIsNoCPPKeyword_228826() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, CPP, ScannerKind.STD);
@@ -6442,6 +6740,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void test1();
 	// void test2() throw ();
 	// void test3() throw (int);
+	@Test
 	public void testEmptyExceptionSpecification_86943() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), CPP);
 
@@ -6469,6 +6768,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		} catch (const char &ex) {
 	//		}
 	//	}
+	@Test
 	public void testScopeOfCatchHandler_209579() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP);
 	}
@@ -6480,6 +6780,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  func(x);
 	//	  func(y);
 	//	}
+	@Test
 	public void testOverloadedFunction_248774() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPFunction func1 = helper.assertNonProblem("func(x)", 4, ICPPFunction.class);
@@ -6499,6 +6800,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  func(x[0]);
 	//	  func(y[0]);
 	//	}
+	@Test
 	public void testOverloadedOperator_248803() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPFunction func1 = helper.assertNonProblem("func(x[0])", 4, ICPPFunction.class);
@@ -6524,6 +6826,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class C5 : C1 {
 	//    void m();//5
 	// };
+	@Test
 	public void testOverridden_248846() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPMethod m0 = helper.assertNonProblem("m();//0", 1, ICPPMethod.class);
@@ -6586,6 +6889,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  void test(A* p) {
 	//    p.a; // should not resolve
 	//  }
+	@Test
 	public void testPointerMemberAccess_245068() throws Exception {
 		final String comment = getAboveComment();
 		final boolean[] isCpps = { false, true };
@@ -6599,6 +6903,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  template<typename T> class CT {};
 	//  }
 	//  using ns::CT<int>;
+	@Test
 	public void testTemplateIdInUsingDecl_251199() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP);
 	}
@@ -6610,6 +6915,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	struct B {
 	//	  operator ns::A(); // problems on operator ns and on A
 	//	};
+	@Test
 	public void testNamespaceQualifiedOperator_256840() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -6622,6 +6928,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(int p) {
 	//	  f(p);
 	//	}
+	@Test
 	public void testFunctionExtraArgument() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertProblem("f(p)", 1);
@@ -6632,6 +6939,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(int* p) {
 	//	  f(p);
 	//	}
+	@Test
 	public void testVariadicFunction_2500582() throws Exception {
 		final String comment = getAboveComment();
 		final boolean[] isCpps = { false, true };
@@ -6650,6 +6958,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  // Should resolve to f(Incomplete*) since 0 can be converted to Incomplete*
 	//    f(0);
 	//	}
+	@Test
 	public void testVariadicFunction_2500583() throws Exception {
 		final String comment = getAboveComment();
 		final boolean[] isCpps = { false, true };
@@ -6672,6 +6981,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//      c(i,i)= 0;
 	//    	c(i) = 0;
 	//    }
+	@Test
 	public void testFunctionCallOnLHS_252695() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code, CPP, ScannerKind.GNU);
@@ -6688,6 +6998,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    class B;
 	//    template <int E> class B;
 	//    template <int E> class B {};
+	@Test
 	public void testInvalidClassRedeclaration_254961() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.GNU, false);
@@ -6706,6 +7017,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    template <template<typename> class T> class B {};
 	//    template <typename T> class B;
 	//    template <typename T> class B {};
+	@Test
 	public void testInvalidClassRedeclaration_364226() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.GNU, false);
@@ -6723,6 +7035,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    };
 	//    void Foo::foo(void) {
 	//    }
+	@Test
 	public void testVoidParamInDefinition_257376() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP);
 	}
@@ -6740,6 +7053,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    	ns::C* cptr= 0;
 	//    	C c= C(cptr);
 	//    }
+	@Test
 	public void testNoKoenigForConstructors() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP);
 	}
@@ -6751,6 +7065,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    void test() {
 	//      donothing();
 	//    }
+	@Test
 	public void testVoidViaTypedef_258694() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP);
 	}
@@ -6765,6 +7080,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    static int& x = y; // y is not defined
 	//    int y;
 	//	};
+	@Test
 	public void testScopeOfClassMember_259460() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("B b", 1, ICPPClassType.class);
@@ -6784,6 +7100,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//      RED, GREEN
 	//    };
 	//  };
+	@Test
 	public void testScopeOfClassMember_259648() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("GREEN)", 5, IEnumerator.class);
@@ -6802,6 +7119,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// 	  func(*a);
 	// 	  func(*b);
 	// 	}
+	@Test
 	public void testSmartPointerReference_259680() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ICPPFunction f1 = ba.assertNonProblem("func(*a)", 4, ICPPFunction.class);
@@ -6819,6 +7137,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	        (c == c.a && (c<c.a || (c == c.a && (c<c.a || (c == c.a && (c<c.a
 	//	        ))))))))))))))))))))))))))))));
 	//	}
+	@Test
 	public void testNestedTemplateIDAmbiguity_259501() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -6843,6 +7162,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    (p1 / p2).a; //4
 	//    (p1 % p2).a; //5
 	//  }
+	@Test
 	public void testOverloadedBinaryOperator_259927a() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("a; //1", 1, ICPPField.class);
@@ -6872,6 +7192,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    (b % b).a; //5
 	//    (b + i).a; //6
 	//  }
+	@Test
 	public void testOverloadedBinaryOperator_259927b() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("a; //1", 1, ICPPField.class);
@@ -6895,6 +7216,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    (p1++).x; //1
 	//    (++p1).x; //2
 	// }
+	@Test
 	public void testOverloadedUnaryOperator_259927c() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("x; //1", 1, ICPPField.class);
@@ -6912,6 +7234,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    (p1++).x; //1
 	//    (++p1).x; //2
 	// }
+	@Test
 	public void testOverloadedUnaryOperator_259927d() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("x; //1", 1, ICPPField.class);
@@ -6942,6 +7265,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	(!b).xx; // 5
 	//	(~b).xx; // 6
 	// }
+	@Test
 	public void testOverloadedUnaryOperator_259927e() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		for (int i = 1; i <= 6; i++)
@@ -6973,6 +7297,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	(!b).xx; // 5
 	//	(~b).xx; // 6
 	//}
+	@Test
 	public void testOverloadedUnaryOperator_259927f() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		for (int i = 1; i <= 6; i++)
@@ -6992,6 +7317,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	 typedef int S1 (int(T));  // resolve this ambiguity first
 	//	 typedef int S2 (int(t));  // resolve this ambiguity first
 	// };
+	@Test
 	public void testOrderOfAmbiguityResolution_259373() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ICPPVariable a = ba.assertNonProblem("a;", 1);
@@ -7020,6 +7346,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    g(1);
 	//	  }
 	//	}
+	@Test
 	public void testFriendFunctionResolution_86368() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		IFunction f1 = bh.assertNonProblem("f(int)", 1);
@@ -7050,6 +7377,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//
 	//	template <typename U>
 	//	int func(int i) { return i; }
+	@Test
 	public void testFriendFunction_438114() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPFunction f1 = bh.assertNonProblemOnFirstIdentifier("func(int i);");
@@ -7085,6 +7413,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//   ca.bar();/*7*/
 	//   a.bar();/*8*/
 	// }
+	@Test
 	public void testMemberFunctionDisambiguationByCVness_238409() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -7138,6 +7467,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    void blabla2() {
 	//    	test2(e1);
 	//    }
+	@Test
 	public void testOverloadResolution_262191() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -7152,6 +7482,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    void* h;
 	//    select (int (h) + 1);
 	//  }
+	@Test
 	public void testSimpleTypeConstructorExpressions() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -7165,6 +7496,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  f(a());
 	//	}
+	@Test
 	public void testBug263152a() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertProblem("f(a())", 1);
@@ -7181,6 +7513,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(B p) {
 	//	  p.m(a());
 	//	}
+	@Test
 	public void testBug263152b() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("m(a())", 1, ICPPMethod.class);
@@ -7192,6 +7525,8 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    a = 0;
 	//	  }
 	//	};
+	@Test
+	@Disabled("Known failing")
 	public void _testInstanceMemberInStaticMethod_263154() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertProblem("a =", 1);
@@ -7210,6 +7545,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		for (;A* a = 0;) {a= 0;}
 	//		for (;B* b;) {b= 0;}
 	//	}
+	@Test
 	public void testAmbiguityResolutionInCondition_263158() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper ba = new AST2AssertionHelper(code, true);
@@ -7224,6 +7560,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(void* ptr) {
 	//		delete (type)(ptr);
 	//	}
+	@Test
 	public void testAmbiguityResolutionInDeleteExpression_428922() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper ba = new AST2AssertionHelper(code, true);
@@ -7245,6 +7582,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  f(r);
 	//	  f(s);
 	//	}
+	@Test
 	public void testPointerToNonPointerConversion_263159() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertProblem("f(p)", 1);
@@ -7262,6 +7600,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  fip(0);
 	//	  fia(0);
 	//	}
+	@Test
 	public void testNonPointerToPointerConversion_263707() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertProblem("fip(1)", 3);
@@ -7278,6 +7617,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	   reset(new cl());
 	//     reset(new cl[1]);
 	//	}
+	@Test
 	public void testTypeOfNewExpression_264163() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -7292,6 +7632,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		range<char*> ir(0);
 	//		onRange(ir);
 	//	}
+	@Test
 	public void testConstructorTemplateInImplicitConversion_264314() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper ba = new AST2AssertionHelper(code, true);
@@ -7312,6 +7653,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  template<typename T> class CT {};
 	//  CT<pcpi> ct1;
 	//  CT<pcpi2> ct2;
+	@Test
 	public void testConstTypedef_264474() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper ba = new AST2AssertionHelper(code, true);
@@ -7359,6 +7701,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		mpr(&X::cm);    // cm is const
 	//		mprc(&X::m);    // m is not const
 	//	}
+	@Test
 	public void testMemberPtrs_264479() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper ba = new AST2AssertionHelper(code, true);
@@ -7384,6 +7727,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(int* p) {
 	//	  f(!p);
 	//	}
+	@Test
 	public void testTypeOfNotExpression_265779() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("f(!p)", 1);
@@ -7408,6 +7752,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(B<int>& p) {
 	//	  p.waldo();
 	//	}
+	@Test
 	public void testDependentEnumeration_446711a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7434,6 +7779,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(B<int>& p) {
 	//	  p.waldo();
 	//	}
+	@Test
 	public void testDependentEnumeration_446711b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7460,6 +7806,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(B<int>& p) {
 	//	  p.waldo();
 	//	}
+	@Test
 	public void testDependentEnumeration_446711c() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7486,6 +7833,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(B<int, 0>& p) {
 	//	  p.waldo();
 	//	}
+	@Test
 	public void testDependentEnumeration_446711d() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7512,6 +7860,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(B<long, 0>& p) {
 	//	  p.waldo();
 	//	}
+	@Test
 	public void testDependentEnumeration_446711e() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertProblemOnFirstIdentifier(".waldo()");
@@ -7528,6 +7877,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  temp = new ::S*;
 	//	  temp = new (::S*);
 	//	}
+	@Test
 	public void testNewPointerOfClass_267168() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7536,6 +7886,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  void f2(const char *(n[])) {
 	//    if (n && 1){}
 	//  }
+	@Test
 	public void testPointerToArrayWithDefaultVal_267184() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper ba = new AST2AssertionHelper(code, true);
@@ -7555,6 +7906,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  virtual void pv() = 0;
 	//	  void (*ptrToFunc) ()= 0;
 	//	};
+	@Test
 	public void testPureVirtualVsInitDeclarator_267184() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code, CPP);
@@ -7587,6 +7939,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//			a.operator S *();
 	//		}
 	//	}
+	@Test
 	public void testLookupScopeForConversionNames_267221() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -7600,6 +7953,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int func() {
 	//		bar((A){foo()});
 	//	}
+	@Test
 	public void testBug268714() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -7611,6 +7965,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	   int ** x;
 	//	   f(x);
 	//	}
+	@Test
 	public void testRankingOfQualificationConversion_269321() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -7632,6 +7987,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    (1 + x).a; //2
 	//	    (x + 1.0).b; //3
 	//	}
+	@Test
 	public void testOverloadResolutionForOperators_266211() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("a; //1", 1, ICPPField.class);
@@ -7652,6 +8008,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    (x + x).a; //1
 	//	    (x + 1.0).a; //2
 	//	}
+	@Test
 	public void testOverloadResolutionForOperators_268534() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("a; //1", 1, ICPPField.class);
@@ -7666,6 +8023,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		C* c= 0;
 	//		test(c);
 	//	}
+	@Test
 	public void testInvalidUserDefinedConversion_269729() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertProblem("test(c)", 4);
@@ -7682,6 +8040,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		foo('a');
 	//		foo(L'a');
 	//	}
+	@Test
 	public void testWideCharacterLiteralTypes_270892() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -7697,6 +8056,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// auto u8 = u8"";
 	// auto u = u"";
 	// auto U = U"";
+	@Test
 	public void testStringLiteralPrefixTypes_526724() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -7730,6 +8090,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	using ns::A;
 	//	struct A;
 	//	A a;
+	@Test
 	public void testForwardDeclarationAfterUsing_271236() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertNonProblem("A a;", 1, ICPPClassType.class);
@@ -7737,6 +8098,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	//	template <class T> class Moo;
 	//	bool getFile(Moo <class Foo> & res);
+	@Test
 	public void testScopeOfClassFwdDecl_270831() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ICPPClassType t = ba.assertNonProblem("Foo", 3, ICPPClassType.class);
@@ -7758,6 +8120,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	   test(d1); // test(C c) has to be selected
 	//	   test(d2); // test(C c) has to be selected
 	//	}
+	@Test
 	public void testDerivedToBaseConversion_269318() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper ba = new AST2AssertionHelper(code, true);
@@ -7781,6 +8144,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	} a;
 	//
 	//	int i = bar(a(1));
+	@Test
 	public void testCallToObjectOfClassType_267389() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -7791,6 +8155,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    C(T);  // ctor
 	//    C(s);  // instance s;
 	// };
+	@Test
 	public void testDeclarationAmbiguity_269953() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code, CPP);
@@ -7812,6 +8177,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	typedef C3 T3;
 	//	T3::C3(int) {
 	//	}
+	@Test
 	public void testCtorWithTypedef_269953() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7823,6 +8189,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//	typedef Compare<int> MY_COMPARE;
 	//	template<> MY_COMPARE::Compare() {}
+	@Test
 	public void testTemplateCTorWithTypedef_269953() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7852,6 +8219,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		d.base(); // Parser log reports ambiguity on 'base'
 	//		return 0;
 	//	}
+	@Test
 	public void testHiddenVirtualBase_282993() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7863,6 +8231,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  C c;
 	//	  c()()()()()()()()()()()()()();
 	//	}
+	@Test
 	public void testNestedOverloadedFunctionCalls_283324() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code, CPP);
@@ -7873,7 +8242,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		assertInstance(t, ICPPClassType.class);
 		assertTrue(stmt.getExpression().isLValue());
 		final long time = System.currentTimeMillis() - now;
-		assertTrue("Lasted " + time + "ms", time < 5000);
+		assertTrue(time < 5000, "Lasted " + time + "ms");
 	}
 
 	//	class A {
@@ -7883,6 +8252,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(A a) {
 	//	  m(a);
 	//	}
+	@Test
 	public void testInlineFriendFunction_284690() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7900,6 +8270,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  f(u1);
 	//	  f(l1);
 	//	}
+	@Test
 	public void testEnumToIntConversion_285368() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ICPPFunction f1 = ba.assertNonProblem("f(i1)", 1, ICPPFunction.class);
@@ -7931,6 +8302,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  f(i3);
 	//	}
+	@Test
 	public void testCastInEnumeratorValue_446380() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		IEnumerator i2 = ba.assertNonProblem("i2", IEnumerator.class);
@@ -7949,6 +8321,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	//	typedef enum enum_name enum_name;
+	@Test
 	public void testTypedefRecursion_285457() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertProblem("enum_name", 9);
@@ -7958,6 +8331,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  enum MyEnum {};
 	//	  MyStruct(MyEnum value) {}
 	//	};
+	@Test
 	public void testEnumRedefinitionInStruct_385144() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7968,6 +8342,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    x a;
 	//	  }
 	//	};
+	@Test
 	public void testLookupFromInlineFriend_284690() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7985,6 +8360,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void  PropertyValueList::hello() {
 	//	  XInterface temp;
 	//	}
+	@Test
 	public void testTypeLookupWithMultipleInheritance_286213() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8002,6 +8378,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//			return ContainerOf<RobotPart>::numParts;
 	//		}
 	//	};
+	@Test
 	public void testInheritanceFromMultipleInstancesOfSameTemplate_383502() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8017,6 +8394,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		static const int v8= 1;
 	//	};
 	//	const int X::v7= 1;
+	@Test
 	public void testVariableDefVsDecl_286259() throws Exception {
 		String[] declNames = { "v3" };
 		String[] defNames = { "v1", "v2", "v4", "v5", "X::v7" };
@@ -8034,6 +8412,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		static const int v2= 1;
 	//	};
 	//	const int X::v2;
+	@Test
 	public void testVariableDefVsDecl_292635() throws Exception {
 		String[] declNames = { "v1" };
 		String[] defNames = { "X::v2" };
@@ -8051,6 +8430,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    struct T;
 	//	    struct T* m2;
 	//	};
+	@Test
 	public void testStructOwner_290693() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -8076,6 +8456,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    return ~0;
 	//	}
+	@Test
 	public void testNonUserdefinedOperator_291409b() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code, CPP);
@@ -8093,6 +8474,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	inline void Test::t() {
 	//	   t<1>();
 	//	}
+	@Test
 	public void testMethodTemplateWithSameName_292051() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -8117,6 +8499,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		C c= *new C();
 	//		foo(c);
 	//	}
+	@Test
 	public void testUserDefinedConversion_222444a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8144,6 +8527,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		x2(f);
 	//		x3(f);
 	//	}
+	@Test
 	public void testUserDefinedConversion_222444b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8164,6 +8548,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		foo(c);
 	//      foo(cc);
 	//	}
+	@Test
 	public void testUserDefinedConversion_222444c() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -8180,6 +8565,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int main() {
 	//		return B == 23;
 	//	}
+	@Test
 	public void testInvalidOverload_291409() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code, CPP);
@@ -8196,6 +8582,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		int* ptr;
 	//		f(ptr);
 	//	}
+	@Test
 	public void testParameterAdjustment_293538() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -8213,6 +8600,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//
 	//	ns::A::A() : CT<B>(1) {
 	//	}
+	@Test
 	public void testLookupInConstructorChainInitializer_293566() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -8231,6 +8619,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		f(ns::e1 | ns::e2);  // the operator| needs to be looked up in the
 	//	                             // associated namespace.
 	//	}
+	@Test
 	public void testAssociatedScopesForOverloadedOperators_293589() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8242,6 +8631,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//   friend F friendFunction;
 	//   template<typename T> F methodTemplate;
 	// };
+	@Test
 	public void testFunctionDeclViaTypedef_86495() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -8278,6 +8668,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    xx(&a);
 	//	  f("");
 	//	}
+	@Test
 	public void testCVQualifiersWithArrays_293982() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8292,6 +8683,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  f(a); func(a);
 	//	  f(b); func(b);
 	//	}
+	@Test
 	public void testArrayTypeSizeFromInitializer_294144() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8302,6 +8694,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		}
 	//		template<typename T> struct C {};
 	//	};
+	@Test
 	public void testLookupInClassScopeForTemplateIDs_294904() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8315,6 +8708,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  func(A::array);
 	//	}
+	@Test
 	public void testCompleteArrayTypeWithIncompleteDeclaration_294144() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8323,6 +8717,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		int x,y;
 	//		return y < x ? -1 : y > x ? 1 : 0;
 	//	}
+	@Test
 	public void testSyntax1_295064() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8332,6 +8727,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		CT(TInt);
 	//	};
 	//	template <typename T> inline CT<T>::CT(TInt) {}
+	@Test
 	public void testSyntax2_295064() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8349,6 +8745,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		};
 	//		static_assert(sizeof(VMPage) == 1, "bla");
 	//	}
+	@Test
 	public void testStaticAssertions_294730() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8387,6 +8784,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    foo(source_const_ref());        // #1
 	//	    foo(source_const_rvalue_ref()); // #1
 	//	}
+	@Test
 	public void testRValueReference_294730() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -8427,6 +8825,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	const LRI&& r3 = i;     // r3 has the type int&
 	//	RRI& r4 = i;            // r4 has the type int&
 	//	RRI&& r5 = i;           // r5 has the type int&&
+	@Test
 	public void testRValueReferenceTypedefs_294730() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -8474,6 +8873,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  drref(2);  // rcd3 refers to temporary with value 2.0
 	//	  cdref(cvd); // error: type qualifiers dropped
 	// }
+	@Test
 	public void testDirectBinding_294730() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -8499,6 +8899,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(int) {
 	//		test(s());
 	//	}
+	@Test
 	public void testSpecialRuleForImplicitObjectType_294730() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -8555,6 +8956,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    sink3(z7);
 
 	// }
+	@Test
 	public void testInitOfClassObjectsByRValues_294730() throws Exception {
 		final CharSequence[] contents = getContents(3);
 		final String code = contents[0].toString();
@@ -8581,6 +8983,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		check(c+1);
 	//		check(c+a);
 	//	}
+	@Test
 	public void testADLForOperators_296906() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -8597,6 +9000,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		f(a, '1');  // calls ns::f(ns::A, char)
 	//		f(a, 1);  // calls ns::f(ns::A, char)
 	//	}
+	@Test
 	public void testADL_299101() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -8624,6 +9028,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	__typeof(a->x) t7();   // type is const double
 	//	__typeof((a->x)) t8(); // type is const double
 
+	@Test
 	public void testDecltype_294730() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -8657,12 +9062,14 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		decltype(w)::type i;
 	//		int x = decltype(w)::value;
 	//	}
+	@Test
 	public void testDecltypeInNameQualifier_380751() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	struct Base {};
 	//	struct Derived : decltype(Base()) {};
+	@Test
 	public void testDecltypeInBaseSpecifier_438348() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPClassType base = helper.assertNonProblem("struct Base", "Base");
@@ -8683,6 +9090,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    decltype(bar<const lambda_type>()(S())) v;
 	//	    v.waldo();
 	//	}
+	@Test
 	public void testDecltypeWithConstantLambda_397494() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8695,12 +9103,14 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    f([this] (int x) {});
 	//	  }
 	//	};
+	@Test
 	public void testLambdaWithCapture() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	int foo = 0;
 	//	auto bar = [foo] { return foo; };
+	@Test
 	public void testLambdaWithCapture_446225() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPVariable foo1 = bh.assertNonProblemOnFirstIdentifier("foo =", ICPPVariable.class);
@@ -8728,6 +9138,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  int p;
 	//	  waldo({[p](int arg) { return true; }});
 	//	}
+	@Test
 	public void testLambdaWithCaptureInInitializerList_488265() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8759,6 +9170,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	S::S(int a) : f{a} {}		// Member initializer
+	@Test
 	public void testInitSyntax_302412() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8797,6 +9209,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		fs({1.0,2.0,3.0});
 	//      fs({});
 	//	}
+	@Test
 	public void testListInitialization_302412a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8820,6 +9233,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		A a{ 1.0,2.0 }; // OK, uses #1
 	//		g({ "foo", "bar" }); // OK, uses #3
 	//	}
+	@Test
 	public void testListInitialization_302412b() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -8870,6 +9284,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//      X x1;
 	//      x({x1});  // OK, lvalue reference to x1
 	//	}
+	@Test
 	public void testListInitialization_302412c() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -8894,6 +9309,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		f({'a', 'b'}); // OK: f(A(int,double)) user-defined conversion
 	//		f({1.0});      // narrowing not detected by cdt.
 	//	}
+	@Test
 	public void testListInitialization_302412d() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -8914,6 +9330,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		h({1.0}); // error: narrowing
 	//		h({ }); // OK: identity conversion
 	//	}
+	@Test
 	public void testListInitialization_302412e() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -8950,6 +9367,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		fH(1);      // no conversion from int to H
 	//		fH({1});    // H(G(1))
 	//	}
+	@Test
 	public void testListInitialization_302412f() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertProblem("f({1,1})", 1);
@@ -8978,6 +9396,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		waldo({short(1)});
 	//		waldo({1, 2});
 	//	}
+	@Test
 	public void testListInitialization_439477a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8989,6 +9408,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		waldo({1, 2, 3});     // should resolve to waldo(int const (&)[3])
 	//		waldo({1, 2, 3, 4});  // should not resolve
 	//	}
+	@Test
 	public void testListInitialization_439477b() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -9024,6 +9444,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	A<B> waldo({{0}, {0}});
+	@Test
 	public void testListInitialization_458679() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -9040,6 +9461,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo({""});
 	//	}
+	@Test
 	public void testListInitialization_491842() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9055,6 +9477,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  A{1};
 	//	  A{1, 2};
 	//	}
+	@Test
 	public void testListInitializer_495227() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper ah = getAssertionHelper();
@@ -9089,6 +9512,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    foo({3, 4.0, 'c'});  // 'foo' is ambiguous
 	//	}
+	@Test
 	public void testAggregateInitialization_487555() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9111,6 +9535,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		g1({a});
 	//		g2({s});
 	//	}
+	@Test
 	public void testListInitializationOfClass() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -9129,6 +9554,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		const str b = {"test", 4}; // ERROR, #2 fails, #1 is skipped explicit conversion
 	//		return str{p, i}; // OK, uses #1 to initialize, explicit constructor is considered too
 	//	}
+	@Test
 	public void testListInitializationWithExplicitConstructor() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector(true);
@@ -9159,6 +9585,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		const str b = {"test", 4}; // OK, #2 fails, uses #1 to initialize
 	//		return str{p, i}; // OK, uses #1 to initialize
 	//	}
+	@Test
 	public void testListInitializationOfClassTypeId() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -9177,6 +9604,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	auto t = new auto({1.0});
 	//	auto x;  // Error - missing initializer.
 	//	auto y = { 1.0, 5 };  // Error - inconsistent types in the array initializer.
+	@Test
 	public void testAutoType_289542() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -9210,6 +9638,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  for (auto a : a) {}
 	//	}
+	@Test
 	public void testAutoType_305970() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPVariable x = bh.assertNonProblem("x =", 1, ICPPVariable.class);
@@ -9222,6 +9651,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	// struct A { auto a = 1; };         // Auto-typed non-static fields are not allowed.
 	// struct B { static auto b = 1; };  // Auto-typed static fields are ok.
+	@Test
 	public void testAutoType_305987() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -9233,6 +9663,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	// auto fpif1(int)->int(*)(int)
 	// auto fpif2(int)->int(*)(int) {}
+	@Test
 	public void testNewFunctionDeclaratorSyntax_305972() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -9250,6 +9681,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// enum EUnscoped1 {b1};
 	// enum EUnscoped2 : long {b2};
 	// enum EUnscoped3 : int;
+	@Test
 	public void testScopedEnums_305975a() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -9305,6 +9737,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	enum F y1 = a; // OK
 	//	enum E1 : int; // OK: E1 is un-scoped, underlying type is int
 	//	enum class F1; // OK: F1 is scoped, underlying type is int
+	@Test
 	public void testScopedEnums_305975b() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -9313,6 +9746,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	enum class E x2 = E::a; //  illegal (elaborated type specifier)
 	//	enum class F y2 = a; // illegal
 	//	enum E; // illegal
+	@Test
 	public void testScopedEnums_305975c() throws Exception {
 		String code = getAboveComment();
 		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.GNU, false);
@@ -9333,6 +9767,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		fint(Col::red); // error: no conversion to int
 	//		fbool(Col::red); // error: no Col to bool conversion
 	//	}
+	@Test
 	public void testScopedEnums_305975d() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -9364,6 +9799,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		i = p->f(X::xr); // OK
 	//		i = p->f(p->xl); // OK
 	//	}
+	@Test
 	public void testScopedEnums_305975e() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9378,6 +9814,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		xdir d; // error: xdir not in scope
 	//		xl;     // error: not in scope
 	//	}
+	@Test
 	public void testScopedEnums_305975f() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -9392,6 +9829,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	enum class Y {e1, e2= f(e1)+2, e3};
 	//	enum A {e1, e2= e1+2, e3};
 	//	enum B {e1, e2= f(e1)+2, e3};
+	@Test
 	public void testScopedEnums_305975g() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -9405,6 +9843,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	enum S::waldo1 : int {
 	//		someConstant = 1508
 	//	};
+	@Test
 	public void testForwardDeclaringEnumAtClassScope_475894() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9417,6 +9856,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  f(sizeof(S::m));
 	//	//  f(sizeof(S::m + 1)); // Error not detected by CDT: reference to non-static member in subexpression
 	//	}
+	@Test
 	public void testSizeofOfNonstaticMember_305979() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9431,11 +9871,13 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  B<sizeof(one) == 1> b;
 	//	  b.waldo();
 	//	}
+	@Test
 	public void testSizeofReference_397342() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	constexpr int waldo = sizeof("cat\b\\\n");
+	@Test
 	public void testSizeofStringLiteralWithEscapeCharacters_459279() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPVariable waldo = helper.assertNonProblem("waldo");
@@ -9449,6 +9891,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  A& b;
 	//	};
 	//	A* p;
+	@Test
 	public void testSizeofStructWithReferenceField_397342() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		IASTName nameB = bh.findName("B");
@@ -9461,6 +9904,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	//	struct waldo {};
+	@Test
 	public void testSizeofEmptyStruct_457770() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		IASTName nameWaldo = bh.findName("waldo");
@@ -9479,6 +9923,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  B<alignof(one) == 1> b;
 	//	  b.waldo();
 	//	}
+	@Test
 	public void testAlignof_451082() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9491,6 +9936,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		f(c16);
 	//		f(c32);
 	//	}
+	@Test
 	public void testNewCharacterTypes_305976() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -9506,6 +9952,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    void (11);
 	//	    return 42;
 	//	}
+	@Test
 	public void testCastToVoid_309155() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9513,6 +9960,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test() {
 	//	    void *libHandle (0);
 	//	}
+	@Test
 	public void testCtorInitializerForVoidPtr_314113() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9529,6 +9977,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    C c;
 	//	    f(c+1);   // converts c to a char and calls operator+(int, int)
 	//	}
+	@Test
 	public void testBuiltinOperators_294543a() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -9547,6 +9996,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		A a;
 	//		f(a= 1);   // A cannot be converted to long& here
 	//	}
+	@Test
 	public void testBuiltinOperators_294543b() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -9564,6 +10014,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		int i;
 	//		f(i = a);   // A converts to long&, builtin assignment to i used, f(long) called
 	//	}
+	@Test
 	public void testBuiltinOperators_294543c() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), true);
 
@@ -9596,6 +10047,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    f(a = 2); // OK, uses const assignment overload, calls f(A)
 	//	    g(a = 3); // OK, uses const assignment overload, converts to int, calls g(long)
 	//	}
+	@Test
 	public void testBuiltinOperators_294543d() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), true);
 
@@ -9638,6 +10090,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//      Y* m();//2
 	//      Y* m(Y*);//3
 	//	};
+	@Test
 	public void testOverrideSimpleCovariance_321617() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPMethod m0 = helper.assertNonProblem("m();//0", 1, ICPPMethod.class);
@@ -9690,6 +10143,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		c.f();
 	//		c.C::f();
 	//	}
+	@Test
 	public void testResolutionToFinalOverrider_86654() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -9708,6 +10162,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	X::X() = default;
 	//	int f(int) = delete;
 	//	auto g() -> int = delete;
+	@Test
 	public void testDefaultedAndDeletedFunctions_305978() throws Exception {
 		String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code);
@@ -9737,6 +10192,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	//	const int b=12;
 	//	void f(int a= b) = delete ;
+	@Test
 	public void testDefaultedAndDeletedFunctions_305978b() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -9778,6 +10234,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		g(a);
 	//		gb(a);
 	//	}
+	@Test
 	public void testInlineNamespace_305980a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9791,6 +10248,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		ns::m::a;
 	//		ns::a;
 	//	}
+	@Test
 	public void testInlineNamespace_305980b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9812,6 +10270,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		::f(1);
 	//      ::g(1);
 	//	}
+	@Test
 	public void testInlineNamespace_305980c() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -9833,6 +10292,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    }
 	// }
 	// void ns::f() {}
+	@Test
 	public void testInlineNamespace_305980d() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -9864,6 +10324,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//        [](int p) -> char {};
 	//	    }
 	//	};
+	@Test
 	public void testLambdaExpression_316307a() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -9877,6 +10338,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	        return abs(a) < abs(b);
 	//	  });
 	//	}
+	@Test
 	public void testLambdaExpression_316307b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9889,6 +10351,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		void waldo();
 	//		function f = [this](){ waldo(); };
 	//	};
+	@Test
 	public void testLambdaInDefaultMemberInitializer_494182() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9897,6 +10360,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//
 	//	void f(const MyType& val);
 	//	void g(MyType& val);
+	@Test
 	public void testTypeString_323596() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -9921,6 +10385,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		}
 	//		container cnt;
 	//	};
+	@Test
 	public void testConstMember_323599() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -9941,6 +10406,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  fint(pe + pe); // problem
 	//	  fint(p + p);   // converted to boolean and then int.
 	//	};
+	@Test
 	public void testExplicitConversionOperators() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -9958,6 +10424,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		D d;
 	//		C c (d);
 	//	}
+	@Test
 	public void testExplicitOperatorInDirectInit() throws Exception {
 		String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code);
@@ -9976,6 +10443,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		f("abc");
 	//		g("abc");
 	//	}
+	@Test
 	public void testRankingOfDeprecatedConversionOnStringLiteral() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -10002,6 +10470,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//     a+a;					// xvalue
 	//     ar;					// rvalue
 	//  }
+	@Test
 	public void testXValueCategories() throws Exception {
 		String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code);
@@ -10040,6 +10509,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  int k = g(f1()); // calls g(const int&&)
 	//	  int l = g(f2()); // calls g(const int&&)
 	//	}
+	@Test
 	public void testRankingOfReferenceBindings_a() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		IFunction g1 = bh.assertNonProblemOnFirstIdentifier("g(const int&)");
@@ -10070,6 +10540,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  A().p();//5      // calls A::p()&&
 	//	  a.p();//6        // calls A::p()&
 	//  }
+	@Test
 	public void testRankingOfReferenceBindings_b() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPMethod s1 = bh.assertNonProblem("operator<<(int)", 10);
@@ -10104,6 +10575,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	S s1 = { 1.0, 2.0, 3.0 };            // invoke #1
 	//	S s2 = { 1, 2, 3 };                  // invoke #2
 	//	S s3 = { };                          // invoke #3
+	@Test
 	public void testEmptyInitializerList_324096() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -10134,6 +10606,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    waldo({1, 2});
 	//	}
+	@Test
 	public void testIntToBoolConversionInInitList_521543() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10148,6 +10621,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//        int i;
 	//    }
 	//    int j = A::i;
+	@Test
 	public void testInlineNamespaceLookup_324096() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10161,6 +10635,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		C c;
 	//		f(true ? c : 1); // calls f(int), not f(C);
 	//	}
+	@Test
 	public void testConditionalOperator_324853a() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		IBinding f = bh.assertNonProblem("f(int);", 1);
@@ -10176,6 +10651,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  f(0 ? p : ""); // uses f(const char*);
 	//    g(0 ? p : ""); // converts "" to char*
 	//	}
+	@Test
 	public void testConditionalOperator_324853b() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		IBinding fc = bh.assertNonProblem("f(const char*);", 1);
@@ -10197,6 +10673,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	C c3 ({1,2});         // C(C(int, int)) // copy ctor is elided
 	//	C c4 ={1,2};          // C(C(int, int)) // copy ctor is elided
 	//	C c5 {1,2};           // C(int, int)
+	@Test
 	public void testCtorForAutomaticVariables_156668() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -10229,6 +10706,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  int number = 5;
 	//	  g(&number);
 	//	}
+	@Test
 	public void testTopLevelRestrictQualifier_327328() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -10249,6 +10727,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  f(&rnumber); // calls f(int* __restrict* a)
 	//	  f(&number); // calls f(int** a)
 	//	}
+	@Test
 	public void testOverloadingWithRestrictQualifier_327328() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -10266,6 +10745,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//	typedef const S T;
 	//	T::C c;
+	@Test
 	public void testCVQualifiedClassName_328063() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10275,6 +10755,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		for (int& x : array)
 	//			x *= 2;
 	//	}
+	@Test
 	public void testRangeBasedForLoop_327223() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10293,6 +10774,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test(D& c) {
 	//		  func(c.get()); // error.
 	//	}
+	@Test
 	public void testOverrideUsingDeclaredMethod_328802() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10308,6 +10790,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  int y;
 	//	};
 	//	}
+	@Test
 	public void testOwner() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPNamespace ns = bh.assertNonProblemOnFirstIdentifier("ns");
@@ -10326,11 +10809,13 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		A(int a = f());
 	//		static int f();
 	//	};
+	@Test
 	public void testFwdLookupForDefaultArgument() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//  auto f2 ();		// missing late return type.
+	@Test
 	public void testBug332114a() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		IBinding b = bh.assertNonProblem("f2", 0);
@@ -10341,6 +10826,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	enum E: short;
 	//	enum E: short;
 	//	enum E: short {e1, e2};
+	@Test
 	public void testBug332114b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10353,6 +10839,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    for (auto& s : array)
 	//	        s.f();  // ERROR HERE
 	//	}
+	@Test
 	public void testAutoTypeInRangeBasedFor_332883a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10370,6 +10857,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    for (auto s : range)
 	//	        s.f();  // ERROR HERE
 	//	}
+	@Test
 	public void testAutoTypeInRangeBasedFor_332883b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10397,6 +10885,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    for (const auto& r : p)
 	//	        r.x;
 	//	}
+	@Test
 	public void testAutoTypeInRangeBasedFor_332883c() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10413,6 +10902,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//			e.f();
 	//	    }
 	//	}
+	@Test
 	public void testAutoTypeInRangeBasedFor_359653() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10430,6 +10920,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    for (auto x : C());  // ERROR: Symbol 'begin' could not be resolved
 	//	}
+	@Test
 	public void testRangedBasedFor_538517() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -10439,6 +10930,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    int a, b;
 	//	    B(T) : a(0), b(0) {}
 	//	};
+	@Test
 	public void testMemberInitializer_333200() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10447,6 +10939,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	template <typename T, typename U> auto add(T t, U u) -> decltype(t + u) {
 	//	    return t + u;
 	//	}
+	@Test
 	public void testResolutionInTrailingReturnType_333256() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10457,6 +10950,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	struct Derived : Base {
 	//		virtual auto waldo() -> bool override;
 	//	};
+	@Test
 	public void testOverrideSpecifierAfterTrailingReturnType_489876() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10469,6 +10963,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//
 	//	auto (*z1)() -> auto(*)() -> int(*)();
 	//	int (*(*(*z2)())())();
+	@Test
 	public void testTrailingReturnTypeInFunctionPointer() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 
@@ -10492,6 +10987,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    CHAINER c;
 	//	    test((c,0,1));
 	//	}
+	@Test
 	public void testOverloadedCommaOpWithConstClassRef_334955() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10509,6 +11005,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  os<char> ss;
 	//	  (ss << "").ok;
 	//	}
+	@Test
 	public void testOverloadedOperatorWithInheritanceDistance_335387() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10533,12 +11030,14 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void waldo(Bitmap& icon) {
 	//	    icon.IsOk();  // ERROR: "Method 'IsOk' could not be resolved"
 	//	}
+	@Test
 	public void testBaseComputationWhileTypeIsIncomplete_498393() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	// namespace ns {int a;}
 	// using ns::a;
+	@Test
 	public void testPropertyOfUsingDeclaration() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		ICPPASTUsingDeclaration udecl = getDeclaration(tu, 1);
@@ -10556,6 +11055,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		S s[1];
 	//		s->foo();
 	//	}
+	@Test
 	public void testMemberAccessForArray_347298() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10570,6 +11070,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		Y y2 = y;
 	//      X x = y2;
 	//	}
+	@Test
 	public void testReferenceToCopyConstructor() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		ICPPASTFunctionDefinition fdef = getDeclaration(tu, 2);
@@ -10605,6 +11106,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void xx() {
 	//		MyCallback x= MyCallback(&Foo::Method); // Invalid overload of 'Foo::Method'
 	//	}
+	@Test
 	public void testTypedefAsClassNameWithFunctionPtrArgument_350345() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10622,6 +11124,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void f2(int (x), int y=x) {
 	//		x= 1;
 	//	}
+	@Test
 	public void testAmbiguityResolution_354599() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10643,6 +11146,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  C c;
 	//	  c.method(b);
 	//	}
+	@Test
 	public void testAmbiguityResolution_356268() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10650,6 +11154,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void (g)(char);
 	//	void (g)(int); //1
 	//	void (g)(int); //2
+	@Test
 	public void testFunctionRedeclarations() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		IFunction g1 = bh.assertNonProblem("g)(char)", 1);
@@ -10665,12 +11170,14 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		int r = 12;
 	//		return r;
 	//	}
+	@Test
 	public void testVariableDeclarationInIfStatement() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	class A : A {
 	//	};
+	@Test
 	public void testRecursiveClassInheritance_357256() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPClassType c = bh.assertNonProblem("A", 1);
@@ -10685,6 +11192,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//	template<> struct CT2<Tdef> {  // Accessed before ambiguity is resolved
 	//	};
+	@Test
 	public void testAmbiguityResolution_359364() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10705,6 +11213,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	template<>
 	//	struct B<int> {
 	//	};
+	@Test
 	public void testAmbiguityResolution_427854() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10716,6 +11225,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		T();
 	//		~T();
 	//	};
+	@Test
 	public void testErrorForDestructorWithWrongName_367590() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.STD, false);
 		IASTCompositeTypeSpecifier S;
@@ -10745,6 +11255,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		f(i64);
 	//		f(word);
 	//	}
+	@Test
 	public void testModeAttribute_330635() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		String[] calls = { "f(i8)", "f(i16)", "f(i32)", "f(i64)", "f(word)" };
@@ -10754,18 +11265,19 @@ public class AST2CPPTests extends AST2CPPTestBase {
 		}
 		for (int i = 0; i < functions.length - 1; i++) {
 			for (int j = 0; j < i; j++) {
-				assertNotSame(calls[i] + " and " + calls[j] + " resolve to the same function", functions[i],
-						functions[j]);
+				assertNotSame(functions[i], functions[j],
+						calls[i] + " and " + calls[j] + " resolve to the same function");
 			}
 		}
-		assertSame(calls[calls.length - 1] + " and " + calls[calls.length - 2] + " resolve to different functions",
-				functions[calls.length - 1], functions[calls.length - 2]);
+		assertSame(functions[calls.length - 1], functions[calls.length - 2],
+				calls[calls.length - 1] + " and " + calls[calls.length - 2] + " resolve to different functions");
 	}
 
 	//	void f(int x) try {
 	//	} catch(...) {
 	//		(void)x;
 	//	}
+	@Test
 	public void testParentScopeOfCatchHandler_376246() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10775,6 +11287,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    void doSomething() throw(MyException);
 	//	};
 	//	void MyClass::doSomething() throw (MyException) {}
+	@Test
 	public void testScopeOfExceptionSpecification_377457() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10814,6 +11327,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		h( nullptr ); // deduces T = nullptr_t
 	//		h( (float*) nullptr ); // deduces T = float*
 	//	}
+	@Test
 	public void testNullptr_327298a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10832,6 +11346,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void testtemplates() {
 	//		g( nullptr ); // error
 	//	}
+	@Test
 	public void testNullptr_327298b() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		bh.assertProblem("checkNullPtr(1)", 12);
@@ -10845,6 +11360,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		f( nullptr ); // calls f( char* )
 	//		f( 0 ); // calls f( int )
 	//	}
+	@Test
 	public void testNullptr_327298c() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
@@ -10855,6 +11371,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	// void foo(struct S s);
+	@Test
 	public void testParameterForwardDeclaration_379511() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPClassType struct = bh.assertNonProblem("S", 1, ICPPClassType.class);
@@ -10867,6 +11384,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// struct S {
 	//     friend F;
 	// };
+	@Test
 	public void testFriendClass() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10876,6 +11394,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// struct S {
 	//     friend T;
 	// };
+	@Test
 	public void testFriendTypedef() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10884,6 +11403,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// struct T {
 	//     friend P;
 	// };
+	@Test
 	public void testFriendTemplateParameter() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10897,6 +11417,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    friend foo::foo();
 	//	    friend foo::~foo();
 	//	};
+	@Test
 	public void testFriendConstructorDestructor_400940() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10911,6 +11432,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void foo() {
 	//	    Waldo c;  // error here
 	//	}
+	@Test
 	public void testFriendClassLookup_512932() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10919,6 +11441,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//     virtual void mFuncDecl() final;
 	//     virtual void mFuncDef() final {}
 	// };
+	@Test
 	public void testFinalFunction() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -10949,6 +11472,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//     void mFuncDecl() override;
 	//     void mFuncDef() override {}
 	// };
+	@Test
 	public void testOverrideFunction() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -10979,6 +11503,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//     void mFuncDecl() final override;
 	//     void mFuncDef() final override {}
 	// };
+	@Test
 	public void testOverrideFinalFunction() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -11011,6 +11536,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// };
 	// struct S final : public Base {
 	// };
+	@Test
 	public void testFinalClass() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -11042,6 +11568,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// 	   S s;
 	// 	   s.foo(1);
 	// }
+	@Test
 	public void testFinalTemplateMethod() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -11058,6 +11585,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//     final = 4;
 	//     override = 2;
 	// }
+	@Test
 	public void testFinalAndOverrideVariables() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11068,12 +11596,14 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// void foo(struct S final) {
 	//     final.i = 23;
 	// }
+	@Test
 	public void testFinalParameter() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	struct S __final {};
 	//	struct T { void foo() __final; };
+	@Test
 	public void testFinalGccExtension_442457() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPClassType s = bh.assertNonProblem("S");
@@ -11091,6 +11621,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	struct U {
 	//		static const bool value = __is_trivially_constructible(S, Args...);
 	//	};
+	@Test
 	public void testParsingOfGcc5TypeTraitIntrinsics_485713() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
 	}
@@ -11103,6 +11634,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	bool operator==(S1 a, int r );
 	//	static const int x = sizeof(CT<i>((TD * (CT<sizeof(s1 == 1)>::*)) 0));
 	//	template<int I> bool operator==(S1 a, const CT<I>& r);
+	@Test
 	public void testOrderInAmbiguityResolution_390759() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11118,6 +11650,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    bar(N::A);
 	//	}
+	@Test
 	public void testADLForFunctionObject_388287() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11145,6 +11678,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		foo(outer::waldo{});
 	//		foo(outer::E{});
 	//	}
+	@Test
 	public void testADL_485710() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11157,6 +11691,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	struct S {};
 	//	const bool b = __is_base_of(S, int);
 	//	typedef A<b>::type T;
+	@Test
 	public void testIsBaseOf_395019() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -11195,6 +11730,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	using Waldo = B<T>;
 	//
 	//	Waldo<A> c;
+	@Test
 	public void testIsBaseOf_446094() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -11261,6 +11797,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//      fint({vbool});
 	//      fint({vchar});
 	//  }
+	@Test
 	public void testNarrowingConversionsInListInitialization_389782() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -11297,6 +11834,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo({1});
 	//	}
+	@Test
 	public void testNarrowingConversionInListInitialization_491748() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11334,6 +11872,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	std::string fine2(int i) {
 	//		return i ? "a" : "b";
 	//	}
+	@Test
 	public void testThrowExpressionInConditional_396663() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -11347,6 +11886,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    foo(true ? new A() : new B());
 	//	}
+	@Test
 	public void testBasePointerConverstionInConditional_462705() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11358,6 +11898,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    waldo(false ? s : 0);
 	//	}
+	@Test
 	public void testTypedefOfPointerInConditional_481078() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11372,6 +11913,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	struct base {};
 	//	struct derived : base {};
 	//	typedef enable_if<__is_base_of(base, derived)>::type T;
+	@Test
 	public void testIsBaseOf_399353() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -11380,6 +11922,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	struct derived : base {};
 	//	typedef derived derived2;
 	//	const bool value = __is_base_of(base, derived2);
+	@Test
 	public void testIsBaseOf_409100() throws Exception {
 		BindingAssertionHelper b = getAssertionHelper();
 		IVariable var = b.assertNonProblem("value");
@@ -11391,6 +11934,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    class Inner {};
 	//  };
 	//  }
+	@Test
 	public void testNestedClassScopeInlineDefinition_401661() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -11409,6 +11953,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  };
 	//  }
 	//  class NS::Enclosing::Inner{};
+	@Test
 	public void testNestedClassScopeSeparateDefinition_401661() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -11424,6 +11969,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  namespace NS {
 	//  class Inner {};
 	//  }
+	@Test
 	public void testClassScopeInlineDefinition_401661() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -11440,6 +11986,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  class Inner;
 	//  }
 	//  class NS::Inner{};
+	@Test
 	public void testClassScopeSeparateDefinition_401661() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -11468,6 +12015,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//    void privateMemberFunction();
 	//    class privateNestedClass {};
 	//  };
+	@Test
 	public void testMemberAccessibilities() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 
@@ -11508,6 +12056,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		__sync_val_compare_and_swap(&i, 1, 2);
 	//		__sync_synchronize();
 	//	}
+	@Test
 	public void testGNUSyncBuiltins_389578() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -11517,6 +12066,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		__sync_bool_compare_and_swap(&p, p, p);
 	//		__sync_fetch_and_add(&p, p, 2);
 	//	}
+	@Test
 	public void testGNUSyncBuiltinsOnVoidPtr_533822() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -11530,6 +12080,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  int __int128_t;
 	//	  int __uint128_t;
 	//	}
+	@Test
 	public void testGCCIntBuiltins_444577() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -11558,6 +12109,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	typedef underlying_type<e_int>::type int_type;
 	//	typedef underlying_type<e_ulong>::type ulong_type;
 	//	typedef underlying_type<e_long>::type loong_type;
+	@Test
 	public void testUnderlyingTypeBuiltin_411196() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -11578,6 +12130,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//	enum class E : short {};
 	//	using target = underlying_type<E>::type;
+	@Test
 	public void testUnderlyingType_548954() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		assertSameType((ITypedef) helper.assertNonProblem("target"), CPPBasicType.SHORT);
@@ -11596,6 +12149,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  bar(2);
 	//	}
+	@Test
 	public void testUnderlyingType_540909() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
 	}
@@ -11609,6 +12163,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void foo() {
 	//	  bar('a'); // Invalid arguments 'Candidates are: void bar(@120932903)'
 	//	}
+	@Test
 	public void testUnderlyingType_568625() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
 	}
@@ -11621,6 +12176,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		intFunc(__builtin_expect(i, 0));
 	//		ptrFunc(__builtin_return_address(4));
 	//	}
+	@Test
 	public void testGCCBuiltins_512932a() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -11634,6 +12190,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		intFunc(__builtin_expect(pI, (int*)0));
 	//		ptrFunc(__builtin_expect(i, 0));
 	//	}
+	@Test
 	public void testGCCBuiltins_512932b() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertProblem("__builtin_assume_aligned", "__builtin_assume_aligned");
@@ -11655,6 +12212,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//     }
 	//   }
 	// }
+	@Test
 	public void testQualifiedNameLookup() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 
@@ -11701,6 +12259,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//			test(*a);
 	//		}
 	//	};
+	@Test
 	public void testBuiltInOperator_423396() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11714,6 +12273,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//			test(*a);
 	//		}
 	//	};
+	@Test
 	public void testBuiltInOperatorFunctionType_423396() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11723,6 +12283,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void foo() {
 	//	    waldo(__FUNCTION__);
 	//	}
+	@Test
 	public void testTypeOfBuiltinSymbol_512932() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11735,6 +12296,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  S s;
 	//	  tint(s.S);
 	//	}
+	@Test
 	public void testFieldWithSameNameAsClass_326750() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11744,11 +12306,13 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    waldo([](){});
 	//	}
+	@Test
 	public void testConversionFromLambdaToFunctionPointer_424765() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	void bar(void *a1, void *a2) __attribute__((nonnull(1, 2)));
+	@Test
 	public void testGCCAttributeSequence_416430() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		IASTDeclaration[] declarations = tu.getDeclarations();
@@ -11782,11 +12346,13 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    struct MyStruct::Inner in;
 	//	    in.waldo;
 	//	}
+	@Test
 	public void testFieldAndNestedTypeWithSameName_425033() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	void f(double (&(x)));
+	@Test
 	public void testParenthesizedReferenceArgument_424898() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11798,6 +12364,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	}
 	//
 	//	constexpr int waldo = naive_fibonacci(5);
+	@Test
 	public void testConditionalExpressionFolding_429891() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IVariable waldo = helper.assertNonProblem("waldo");
@@ -11811,6 +12378,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	}
 	//
 	//	constexpr int waldo = naive_fibonacci(50);
+	@Test
 	public void testConstexprEvaluationLimit_429891() throws Exception {
 		// Here we're just checking that the computation of the initial
 		// value finishes (with a null result) in a reasonable time.
@@ -11825,6 +12393,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		return a;
 	//	}
 	//	constexpr int waldo = foo();
+	@Test
 	public void testNameLookupInDefaultArgument_432701() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IVariable waldo = helper.assertNonProblem("waldo");
@@ -11838,6 +12407,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		S1(42);
 	//		s2(43);
 	//	}
+	@Test
 	public void testICPPASTFunctionCallExpression_getOverload_441701() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -11851,6 +12421,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	//  void f(int &&a);
+	@Test
 	public void testRValueReferenceSignature_427856() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		IASTSimpleDeclaration sd = (IASTSimpleDeclaration) tu.getDeclarations()[0];
@@ -11863,12 +12434,14 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		int waldo = 42;
 	//		find(waldo);
 	//	}
+	@Test
 	public void testRValueReferenceBindingToTemporary_470943() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	constexpr int waldo1 = 42;
 	//	constexpr auto waldo2 = 43;
+	@Test
 	public void testConstexprVariableIsConst_451091() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPVariable waldo1 = helper.assertNonProblem("waldo1");
@@ -11879,6 +12452,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	//	constexpr int* waldo;
+	@Test
 	public void testConstexprPointerVariable_541670() throws Exception {
 		getAssertionHelper().assertVariableType("waldo", CommonCPPTypes.constPointerToInt);
 	}
@@ -11886,6 +12460,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	constexpr int waldo1();
 	//	constexpr int (*waldo2())(int);
 	//	struct S { constexpr int waldo3(); };
+	@Test
 	public void testTypeOfConstexprFunction_451090() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPFunction waldo1 = helper.assertNonProblem("waldo1");
@@ -11900,12 +12475,14 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	//	void waldo() noexcept;
+	@Test
 	public void testASTCopyForNoexceptDefault_bug456207() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	template <typename> struct waldo { waldo(int); };
 	//	auto x = static_cast<waldo<int>>(0);
+	@Test
 	public void testTemplateIdInsideCastOperator_460080() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11928,17 +12505,20 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	struct Y {
 	//		alignas(N...) char x;
 	//	};
+	@Test
 	public void testAlignas_451082() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	struct alignas(16) Node {};
 	//	enum alignas(8) E { E1, E2 };
+	@Test
 	public void testAlignas_475739() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	__attribute__((section(".example"))) alignas(4) static int waldo;
+	@Test
 	public void testAlignasAfterAttribute_538615() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
 	}
@@ -11946,6 +12526,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int var1 alignas(16);
 	// int var2 __attribute__((section(".example"))) alignas(16);
 	// int var3 alignas(16) __attribute__((section(".example")));
+	@Test
 	public void testAlignaAsAfterDeclarator() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
 	}
@@ -11958,6 +12539,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int operator "" _F(const char32_t* s, unsigned int sz) { return sz; }
 	// int operator "" _G(char c) { return (int)c; }
 	// constexpr double operator "" _km_to_miles(long double km) { return km * 0.6213; }
+	@Test
 	public void testSimpleUserDefinedLiteralOperators() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11994,6 +12576,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//			01_suff,
 	//			1ULL << 34,
 	//	};
+	@Test
 	public void testIntegerUserDefinedLiterals() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12007,6 +12590,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		0x01p3XX,
 	//		1._X
 	//	};
+	@Test
 	public void testDoublesUserDefinedLiterals() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12015,6 +12599,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// char c2 = '0'suff;
 	// char* c3 = "Hello"_suff;
 	// char* c4 = "Hello"suff;
+	@Test
 	public void testCharStringUserDefinedLiterals() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12022,6 +12607,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(unsigned long long i) { return Ret(); }
 	// auto test = 123_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes1() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12029,6 +12615,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(long double i) { return Ret(); }
 	// auto test = 12.3_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes2() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12036,6 +12623,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char* s) { return Ret(); }
 	// auto test = 123_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes1a() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12043,6 +12631,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char* s) { return Ret(); }
 	// auto test = 12.3_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes2a() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12051,6 +12640,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// Ret operator "" _X(unsigned long long d) { return Ret(); }
 	// bool operator "" _X(const char* s) { return false; }
 	// auto test = 123_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes1b() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12059,6 +12649,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// Ret operator "" _X(long double d) { return Ret(); }
 	// bool operator "" _X(const char* s) { return false; }
 	// auto test = 12.3_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes2b() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12066,6 +12657,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 	// auto test = "123"_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes3() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12073,6 +12665,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const wchar_t* s, unsigned sz) { return Ret(); }
 	// auto test = L"123"_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes3a() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12080,6 +12673,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char16_t* s, unsigned sz) { return Ret(); }
 	// auto test = u"123"_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes3b() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12087,6 +12681,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char32_t* s, unsigned sz) { return Ret(); }
 	// auto test = U"123"_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes3c() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12094,6 +12689,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// template<char... Chars> Ret operator "" _X() { return Ret(); }
 	// auto test = 123_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes4a() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12101,6 +12697,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// template<char... Chars> Ret operator "" _X() { return Ret(); }
 	// auto test = 123.123_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes4b() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12108,6 +12705,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 	// auto test = "123" "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation1a() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12115,6 +12713,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 	// auto test = "123"_X "123";
+	@Test
 	public void testUserDefinedLiteralConcatenation1b() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12122,6 +12721,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 	// auto test = u8"123" "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation2a() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12129,6 +12729,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 	// auto test = u8"123"_X "123";
+	@Test
 	public void testUserDefinedLiteralConcatenation2b() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12136,6 +12737,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 	// auto test = "123" u8"123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation2c() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12143,6 +12745,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 	// auto test = "123"_X u8"123";
+	@Test
 	public void testUserDefinedLiteralConcatenation2d() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12150,6 +12753,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const wchar_t* s, unsigned sz) { return Ret(); }
 	// auto test = L"123" "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation3a() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12157,6 +12761,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const wchar_t* s, unsigned sz) { return Ret(); }
 	// auto test = L"123"_X "123";
+	@Test
 	public void testUserDefinedLiteralConcatenation3b() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12164,6 +12769,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const wchar_t* s, unsigned sz) { return Ret(); }
 	// auto test = "123" L"123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation3c() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12171,6 +12777,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const wchar_t* s, unsigned sz) { return Ret(); }
 	// auto test = "123"_X L"123";
+	@Test
 	public void testUserDefinedLiteralConcatenation3d() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12178,6 +12785,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char16_t* s, unsigned sz) { return Ret(); }
 	// auto test = u"123" "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation4a() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12185,6 +12793,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char16_t* s, unsigned sz) { return Ret(); }
 	// auto test = u"123"_X "123";
+	@Test
 	public void testUserDefinedLiteralConcatenation4b() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12192,6 +12801,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char16_t* s, unsigned sz) { return Ret(); }
 	// auto test = "123" u"123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation4c() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12199,6 +12809,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char16_t* s, unsigned sz) { return Ret(); }
 	// auto test = "123"_X u"123";
+	@Test
 	public void testUserDefinedLiteralConcatenation4d() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12206,6 +12817,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char32_t* s, unsigned sz) { return Ret(); }
 	// auto test = U"123" "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation5a() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12213,6 +12825,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char32_t* s, unsigned sz) { return Ret(); }
 	// auto test = U"123"_X "123";
+	@Test
 	public void testUserDefinedLiteralConcatenation5b() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12220,6 +12833,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char32_t* s, unsigned sz) { return Ret(); }
 	// auto test = "123" U"123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation5c() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12227,6 +12841,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char32_t* s, unsigned sz) { return Ret(); }
 	// auto test = "123"_X U"123";
+	@Test
 	public void testUserDefinedLiteralConcatenation5d() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12234,6 +12849,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(const char32_t* s, unsigned sz) { return Ret(); }
 	// auto test = "123"_X U"123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation6() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12241,6 +12857,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(char const * const s, unsigned long sz) { return Ret(); }
 	// auto test = "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation_528196_1a() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12248,6 +12865,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(char const * volatile s, unsigned long sz) { return Ret(); }
 	// auto test = "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation_528196_1b() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12255,6 +12873,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(char const * const volatile s, unsigned long sz) { return Ret(); }
 	// auto test = "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation_528196_1c() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12262,6 +12881,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(char const * s, unsigned long const sz) { return Ret(); }
 	// auto test = "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation_528196_2a() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12269,6 +12889,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(char const * s, unsigned long volatile sz) { return Ret(); }
 	// auto test = "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation_528196_2b() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12276,6 +12897,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(char const * s, unsigned long const volatile sz) { return Ret(); }
 	// auto test = "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation_528196_2c() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12283,6 +12905,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(unsigned long long const) { return Ret(); }
 	// auto test = 10_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation_528196_3a() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12290,6 +12913,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(unsigned long long volatile) { return Ret(); }
 	// auto test = 10_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation_528196_3b() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12297,6 +12921,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(unsigned long long const volatile) { return Ret(); }
 	// auto test = 10_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation_528196_3c() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12304,6 +12929,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(char const) { return Ret(); }
 	// auto test = 'a'_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation_528196_4a() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12311,6 +12937,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(char volatile) { return Ret(); }
 	// auto test = 'a'_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation_528196_4b() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12318,6 +12945,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// class Ret {};
 	// Ret operator "" _X(char const volatile) { return Ret(); }
 	// auto test = 'a'_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation_528196_4c() throws Exception {
 		checkUserDefinedLiteralIsRet(getAboveComment());
 	}
@@ -12326,6 +12954,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 	// Ret operator "" _Y(const char* s, unsigned sz) { return Ret(); }
 	// auto test = "123"_X "123"_Y;
+	@Test
 	public void testUserDefinedLiteralBadConcatenation1() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, false);
 
@@ -12342,16 +12971,19 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//   return basic_string { str, len };
 	// }
 	// auto waldo = "Waldo"s;
+	@Test
 	public void testStringLiterals() throws Exception {
 		checkUserDefinedLiteralIsType(getAboveComment(), "basic_string");
 	}
 
 	// auto waldo = 1i + 1;
+	@Test
 	public void testComplexNumbersCompilerSupport1() throws Exception {
 		checkUserDefinedLiteralIsType(getAboveComment(), "_Complex int");
 	}
 
 	// auto waldo = 1j + 1;
+	@Test
 	public void testComplexNumbersCompilerSupport2() throws Exception {
 		checkUserDefinedLiteralIsType(getAboveComment(), "_Complex int");
 	}
@@ -12364,6 +12996,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//   return complex { 0, imag };
 	// }
 	// auto waldo = 1i + 1;
+	@Test
 	public void testComplexNumbersOverriddenCompilerSupport() throws Exception {
 		checkUserDefinedLiteralIsType(getAboveComment(), "complex");
 	}
@@ -12376,6 +13009,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//   return complex { 0, imag };
 	// }
 	// auto waldo = 1.0if + 1;
+	@Test
 	public void testComplexFloatNumbersOverriddenCompilerSupport() throws Exception {
 		checkUserDefinedLiteralIsType(getAboveComment(), "complex");
 	}
@@ -12383,6 +13017,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// // Test name lacking a space
 	// int operator ""X(const char* s) { return 0; }
 	// int operator ""_X(const char* s) { return 0; }
+	@Test
 	public void testUserDefinedLiteralNoWhiteSpace1() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12407,6 +13042,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// auto e4 = u"1" _X "2";
 	// auto e5 = U"1" _X "2";
 	// auto d5 = U"1" _X;
+	@Test
 	public void testUserDefinedLiteralNoWhiteSpace2() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, false);
 		IASTDeclaration[] decls = tu.getDeclarations();
@@ -12423,6 +13059,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// template<char... Chars> RetA operator "" _X() { return RetA(); }
 	// RetB operator "" _X(unsigned long long i) { return RetB(); }
 	// auto a = 123_X;
+	@Test
 	public void testUserDefinedLiteralResolution1() throws Exception {
 		checkUserDefinedLiteralIsType(getAboveComment(), "RetB");
 	}
@@ -12432,6 +13069,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// template<char... Chars> RetA operator "" _X() { return RetA(); }
 	// RetB operator "" _X(long double i) { return RetB(); }
 	// auto a = 123.123_X;
+	@Test
 	public void testUserDefinedLiteralResolution2() throws Exception {
 		checkUserDefinedLiteralIsType(getAboveComment(), "RetB");
 	}
@@ -12441,6 +13079,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// template<char... Chars> RetA operator "" _X() { return RetA(); }
 	// RetB operator "" _X(const char * c) { return RetB(); }
 	// auto test = 123_X;
+	@Test
 	public void testUserDefinedLiteralResolution3() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPVariable test = bh.assertNonProblemOnFirstIdentifier("test");
@@ -12456,6 +13095,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    using namespace N;
 	//	    setColor("#ffffff"_color);  // ERROR
 	//	}
+	@Test
 	public void testUserDefinedLiteralInNamespace_510665() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12464,6 +13104,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	double waldo2 = 09.268;
 	//	double waldo3 = 02e2;
 	//	double waldo4 = 09e2;
+	@Test
 	public void testFloatLiteralWithLeadingZero_498434() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -12471,6 +13112,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	char foo() {
 	//		return '*';
 	//	}
+	@Test
 	public void testRegression_484618() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -12488,6 +13130,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	#else
 	//		0;
 	//	#endif
+	@Test
 	public void testHasFeature_442325() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("lambdas_supported", 1);
@@ -12509,6 +13152,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  int c[6] = { [4] = 29, [2] = 15 };
 	//	  int d[6] = { [2 ... 4] = 29 };
 	//	}
+	@Test
 	public void testDesignatedInitializers() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		//		ICPPASTDesignatedInitializer d1 = bh.assertNode(".a = 10");
@@ -12562,6 +13206,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	struct F : D, virtual E {
 	//		F() {}
 	//	};
+	@Test
 	public void testImplicitlyCalledBaseConstructor_393717() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -12599,6 +13244,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int main() {
 	//		a(A{3, 4});
 	//	}
+	@Test
 	public void testImplicitConstructorNameInTypeConstructorExpression_447431() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPConstructor ctor = helper.assertNonProblem("A(int, int)", "A");
@@ -12617,6 +13263,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    using Waldo = Waldo<int>;
 	//	    auto size = sizeof(Waldo::x);
 	//	}
+	@Test
 	public void testShadowingAliasDeclaration_484200() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12628,6 +13275,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    return Zero == 0; // "Symbol 'Zero' could not be resolved"
 	//	  }
 	//	};
+	@Test
 	public void testAnonymousEnumInAliasDeclaration_502016() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12639,6 +13287,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    enum class E { A };
 	//	    void bar(E);
 	//	};
+	@Test
 	public void testEnumDeclaredLaterInClass_491747() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12648,6 +13297,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    return 5;
 	//	}
 	//	constexpr int waldo = A + A;
+	@Test
 	public void testOverloadedOperatorWithEnumArgument_506672() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 5);
@@ -12657,6 +13307,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    static S waldo;
 	//	};
 	//	void foo(const S& = S());
+	@Test
 	public void testValueRepresentationOfClassWithStaticMemberOfOwnType_490475() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPFunction foo = helper.assertNonProblem("foo");
@@ -12668,6 +13319,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		S waldo;  // invalid
 	//	};
 	//	void foo(const S& = S());
+	@Test
 	public void testClassDirectlyAggregatingItself_490475() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPFunction foo = helper.assertNonProblem("foo");
@@ -12683,6 +13335,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		S waldo;
 	//	};
 	//	void foo(const T& = T());
+	@Test
 	public void testClassIndirectlyAggregatingItself_490475() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPFunction foo = helper.assertNonProblem("foo");
@@ -12709,6 +13362,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	decltype(auto) const m = 42; // Error - decltype(auto) does not allow type specifiers. Bug 527553
 	//	decltype(auto) volatile n = 42; // Error - decltype(auto) does not allow type specifiers. Bug 527553
 	//	decltype(auto) const volatile o = 42; // Error - decltype(auto) does not allow type specifiers. Bug 527553
+	@Test
 	public void testDecltypeAutoVariableTypes_482225() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -12765,6 +13419,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		return 23.0;
 	//	}
 	//	auto a = foo();
+	@Test
 	public void testDecltypeAutoTrailingReturnTypeConst_527553() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -12777,6 +13432,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		return 23.0;
 	//	}
 	//  auto a = foo();
+	@Test
 	public void testDecltypeAutoTrailingReturnTypeVolatile_527553() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -12789,6 +13445,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		return 23.0;
 	//	}
 	//	decltype(auto) a = foo();
+	@Test
 	public void testDecltypeAutoTrailingReturnTypeConstDecltype_527553() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -12800,6 +13457,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	auto foo() -> decltype(auto) {
 	//		return 23.0;
 	//	}
+	@Test
 	public void testDecltypeAutoTrailingReturnType_482225() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12807,6 +13465,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	decltype(auto) foo() {
 	//		return 23.0;
 	//	}
+	@Test
 	public void testDecltypeAutoReturnType_482225() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12819,11 +13478,13 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    Waldo w;
 	//	    auto i1 = w, i2 = i1.foo();  // Error on 'foo'
 	//	}
+	@Test
 	public void testAutoWithTwoDeclarators_522066() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	constexpr int waldo = (sizeof(double) % 16);
+	@Test
 	public void testSizeofDouble_506170() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 8);
@@ -12838,6 +13499,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		bc || bc;
 	//		!bc;
 	//	}
+	@Test
 	public void testContextualBooleanConversion_506972() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		IASTDeclaration explicitBooleanContextsFunction = tu.getDeclarations()[1];
@@ -12872,11 +13534,13 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    el0 __attribute__((deprecated)),
 	//	    el1,
 	//	};
+	@Test
 	public void testEnumeratorAttribute_514821() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
 	}
 
 	//	void foo([[maybe_unused]] int a);
+	@Test
 	public void testCxx11AttributeBeforeParameterDeclaration_530729() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12891,6 +13555,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    char name[sizeof(CType().m_Array)];
 	//	    foo(name);
 	//	}
+	@Test
 	public void testSizeofArrayField_512932() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12911,6 +13576,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//
 	//TestNameSpace::TestNameSpace() {
 	//}
+	@Test
 	public void testUsingDirectiveNamespaceWithPreviousFunctionName_517402() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12929,6 +13595,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//namespace ns12 = ns2;
 	//ns12::TestNameSpace::TestNameSpace() {
 	//}
+	@Test
 	public void testNamespaceAliasNamespaceWithPreviousFunctionName_517402() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12936,6 +13603,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	class C {};
 	//	typedef C D;
 	//	constexpr bool waldo = __is_class(D);
+	@Test
 	public void testIsClassBuiltinOnTypedef_522509() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 1);
@@ -12943,6 +13611,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	//	struct A {};
 	//	struct A* b = (1 == 1) ? new struct A : new struct A;
+	@Test
 	public void test_ElabTypeSpecInNewExprInConditional_526134() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -12953,6 +13622,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	constexpr bool waldo3 = __is_trivially_constructible(S, const S&);
 	//	constexpr bool waldo4 = __is_trivially_constructible(S, int);
 	//	constexpr bool waldo5 = __is_trivially_constructible(S, const S&, float);
+	@Test
 	public void testIsTriviallyConstructible_528072() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo1", 1);
@@ -12969,12 +13639,14 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	constexpr bool waldo = __is_constructible(pair<const int>, pair<int, int>&&);
+	@Test
 	public void testIsConstructible_539052() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 1);
 	}
 
 	//	constexpr bool waldo = unsigned(-1) < unsigned(0);
+	@Test
 	public void testNegativeCastToUnsigned_544509() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 0);
@@ -12989,6 +13661,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	constexpr short short_from_negative_long = -((1L << 32) + 1);
 	//	constexpr unsigned int uint_from_negative_long = -((1L << 32) + 1);
 	//	constexpr unsigned short ushort_from_negative_long = -((1L << 32) + 1);
+	@Test
 	public void testIntegerImplicitConversions() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -13009,6 +13682,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	constexpr bool bool_from_int_expr = int(0x100000001L) < 2;
 	//	constexpr bool bool_from_short_expr = short(0x100010001L) < 2;
 	//	constexpr int int_from_cast_to_int = (int)((1L << 32) + 1);
+	@Test
 	public void testIntegerTrunctatingConversions() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("bool_from_int_positive", 1);
@@ -13027,6 +13701,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	constexpr unsigned int uint_from_uint_literal_negation = -(1U);
 	//	constexpr unsigned int uint_from_uint_cast_negation = -(1U);
 	//	constexpr unsigned short ushort_from_ushort_cast_negation = -((unsigned short)1);
+	@Test
 	public void testUnsignedIntegerUnaryMinus() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -13051,6 +13726,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int main() {
 	//  	x::y::bar();
 	//	}
+	@Test
 	public void testNestedNamespaceDefinition_490359() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -13062,6 +13738,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	auto v_a = 1'123'456ul;
 	//	auto v_b = 1'123'456ull;
 	//	auto v_c = 0xAABB'CCDDll;
+	@Test
 	public void testLiteralDecimalSeparators_519062() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("l_a", 804);
@@ -13078,6 +13755,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	extern void *List[];
 	//	void *List[] = { 0 };
 	//	unsigned int ListSize = sizeof(List)/sizeof(List[0]);
+	@Test
 	public void testMultipleExternDecls_534098() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IVariable var = helper.assertNonProblem("ListSize");
@@ -13087,6 +13765,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	//static_assert(true);
+	@Test
 	public void testStaticAssertWithoutMessage_534808() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -13098,6 +13777,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	auto myFunA() -> struct MyStruct {
 	//	    return {5};
 	//	};
+	@Test
 	public void testElabSpecInTrailingReturn_535777() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -13114,6 +13794,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		type a4{1,2,3};
 	//		type a5 = {1,2,3};
 	//	}
+	@Test
 	public void testInitListConstructor_542448() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertImplicitName("a0", 2, CPPConstructor.class);
@@ -13134,6 +13815,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		type a1{1,2}; // ok
 	//		type a2 = {1,2}; // error: using explict ctor
 	//	}
+	@Test
 	public void testInitListConstructorWithExplicit_542448() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertImplicitName("a0", 2, CPPConstructor.class);
@@ -13148,6 +13830,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// int main() {
 	//     type a0 = {1,2};
 	// }
+	@Test
 	public void testInitListConstructorWithExplicit2_542448() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		// ill-formed, because overload resolution
@@ -13166,6 +13849,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	A a{1, 3, 5, 6};
+	@Test
 	public void testInitListConstRef_549035() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -13181,6 +13865,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  type{1, 2};
 	//	  type(other_type());
 	//	}
+	@Test
 	public void testCtorWithWrongArguments_543913() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertImplicitName("type(1, 2)", 4, IProblemBinding.class);
@@ -13201,6 +13886,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    foo({1});
 	//	    foo({{1}});
 	//	}
+	@Test
 	public void testBraceElisionForAggregateInit0_SimpleValid_543038() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -13218,6 +13904,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    foo({1,2});
 	//	    foo({{1,2}});
 	//	}
+	@Test
 	public void testBraceElisionForAggregateInit1_SimpleTooManyInitializers_543038() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertImplicitName("array{{1,2}}", 5, IProblemBinding.class);
@@ -13251,6 +13938,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		level1{1,2}; // ERROR: calling level1 constructor, not aggregate init of level0
 	//		foo({{{1,2,3}}}); // ERROR: not aggregate init
 	//	}
+	@Test
 	public void testBraceElisionForAggregateInit2_WithNonAggregate_543038() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertNonProblem("foo({level1{{1,2}}})", 3);
@@ -13272,6 +13960,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    foo({1,2,3,1,2,3}); // eliding all levels
 	//	    foo({{1,2,3},{1,2,3}}); // ERROR eliding outer-most is not allowed
 	//	}
+	@Test
 	public void testBraceElisionForAggregateInit3_543038() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertNonProblem("foo({{{1,2,3},{1,2,3}}});", 3);
@@ -13295,6 +13984,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		foo({type{1},type{2}});
 	//		foo({type{1}}); // ERROR: type is not default constructible
 	//	}
+	@Test
 	public void testBraceElisionForAggregateInit4_nonDefaultConstructible_543038() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertNonProblem("foo({type{1},type{2}});", 3);
@@ -13312,6 +14002,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	      foo({{1,2,3,{1,2,3}}}); // ok: data[1] is initialized without elision, data[0] with elision
 	//	      foo({{1,2,{1,2,3}}}); // ERROR: trying to initialize data[0][2] with {1,2,3}
 	//	}
+	@Test
 	public void testBraceElisionForAggregateInit5_partlyEliding_543038() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertNonProblem("foo({{{1,2,3},1,2,3}});", 3);
@@ -13335,6 +14026,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int main() {
 	//		foo({1});
 	//	}
+	@Test
 	public void testBraceElisionForAggregateInit6_typedef_543038() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -13348,6 +14040,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		auto s1 = S1 { };
 	//		return S2 { s1 };
 	//	}
+	@Test
 	public void testBraceElisionForAggregateInit7_545957() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -13356,6 +14049,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//      int a;
 	//  };
 	//  type b{sizeof(type)};
+	@Test
 	public void testAggregateInitNoNarrowingConversionInConstContext_545756() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -13368,6 +14062,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	struct B {
 	//	    A a{sizeof(T)};
 	//	};
+	@Test
 	public void testAggregateInitNoNarrowingConversionInDependentConstContext_545756() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -13377,6 +14072,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  };
 	//  const unsigned long v = 1;
 	//  type b{v};
+	@Test
 	public void testAggregateInitNoNarrowingConversionInConstContext2_545756() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -13386,6 +14082,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  };
 	//  unsigned long v = 1;
 	//  type b{v};
+	@Test
 	public void testAggregateInitNarrowingConversion_545756() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertImplicitName("b{v};", 1, IProblemBinding.class);
@@ -13397,6 +14094,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	type foo{"s"};
+	@Test
 	public void testCharArrayInitFromStringLiteral_545756() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -13406,6 +14104,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	type foo{"big"};
+	@Test
 	public void testCharArrayInitFromTooLargeStringLiteral_545756() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertImplicitName("foo", 3, IProblemBinding.class);
@@ -13416,6 +14115,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	type foo{L"s"};
+	@Test
 	public void testCharArrayInitFromWrongTypeStringLiteral_545756() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertImplicitName("foo", 3, IProblemBinding.class);
@@ -13426,6 +14126,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	type foo{"s"};
+	@Test
 	public void testUnknownSizeCharArrayInitFromStringLiteral_545756() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertImplicitName("foo", 3, IProblemBinding.class);
@@ -13443,6 +14144,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	        Time time = t.get();
 	//	   }
 	//	};
+	@Test
 	public void testCopyInitializationFromDependentType_546843() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -13460,6 +14162,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	        Time time{t.get()};
 	//	   }
 	//	};
+	@Test
 	public void testListInitializationFromDependentType_546843() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -13483,6 +14186,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	constexpr bool fptr_is_not_noexcept = noexcept(fptr());
 	//	constexpr bool fptr_noexcept_is_noexcept = noexcept(fptr_noexcept());
 	//  constexpr bool throw_is_not_noexcept = noexcept(throw fun_noexcept());
+	@Test
 	public void testNoexceptOperatorFunctions_545021() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -13507,6 +14211,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  constexpr bool not_noexcept_conditional = noexcept(noexcept_condition() ? fun() : fun_noexcept());
 	//  constexpr bool is_noexcept_conditional = noexcept(noexcept_condition() ? fun_noexcept() : fun_noexcept());
 	//  constexpr bool condition_not_noexcept = noexcept(condition() ? fun_noexcept() : fun_noexcept());
+	@Test
 	public void testNoexceptOperatorOperators_545021() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -13524,6 +14229,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//
 	//  constexpr bool aggregate_init_is_noexcept = noexcept(aggregate{1});
 	//  constexpr bool aggregate_access_is_noexcept = noexcept(agg.a);
+	@Test
 	public void testNoexceptOperatorAggregate_545021() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -13539,6 +14245,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  constexpr bool ctor_is_noexcept = noexcept(myclass{});
 	//  constexpr bool ctor_is_not_noexcept = noexcept(myclass{1});
 	//  constexpr bool constexpr_ctor_is_noexcept = noexcept(myclass{1, 1});
+	@Test
 	public void testNoexceptOperatorConstructors_545021() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -13567,6 +14274,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	constexpr bool noexcept_conversion = noexcept(static_cast<int>(t));
 	//	constexpr bool not_noexcept_conversion = noexcept(static_cast<int*>(t));
 	//	constexpr bool conversion_from_constructor = noexcept(static_cast<int*>(type{}));
+	@Test
 	public void testNoexceptOperatorType_545021() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -13590,6 +14298,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//
 	//	constexpr bool funt_is_not_noexcept = noexcept(funt(1));
 	//	constexpr bool funt_noexcept_is_noexcept = noexcept(funt_noexcept(1));
+	@Test
 	public void testNoexceptOperatorFunctionTemplates_545021() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -13611,6 +14320,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  constexpr bool unaryop_is_not_noexcept = noexcept(!t1);
 	//  constexpr bool noexcept_binaryop_is_noexcept = noexcept(t2 = 1);
 	//  constexpr bool noexcept_unaryop_is_noexcept = noexcept(!t2);
+	@Test
 	public void testNoexceptOperatorOverloadedOperators_545021() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -13624,6 +14334,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	void fun_taking_funptr(void(*ptr)()) noexcept;
 	//
 	//	constexpr bool is_noexcept = noexcept(fun_taking_funptr(fun));
+	@Test
 	public void testNoexceptOperatorNoncalledFunctionPtr_545021() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -13632,6 +14343,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 
 	//	void fun() throw();
 	//	constexpr bool is_noexcept = noexcept(fun());
+	@Test
 	public void testNoexceptOperatorEmptyThrow_545021() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -13643,6 +14355,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  auto closure = [](int i) {return i;};
 	//  constexpr bool is_not_noexcept = noexcept(closure());
 	//  constexpr bool conversion_is_noexcept = noexcept(static_cast<int (*)(int)>(closure));
+	@Test
 	public void testNoexceptOperatorLambda_545021() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -13656,6 +14369,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//
 	//	  constexpr bool is_noexcept = noexcept(foo<true>());
 	//	  constexpr bool is_not_noexcept = noexcept(foo<false>());
+	@Test
 	public void testNoexceptOperatorDependentNoexcept_545021() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -13666,6 +14380,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	  struct S { int mem; };
 	//	  S foo();  // could throw
 	//	  constexpr bool is_not_noexcept = noexcept(foo().mem);  // should be false
+	@Test
 	public void testNoexceptOperatorOwnerEval_545021() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -13676,6 +14391,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	    B a;
 	//	};
 	//	B t{1};
+	@Test
 	public void testSelfAggregation_546805() throws Exception {
 		// Note that ideally we would report an error already on the declaration of B as
 		// the class is aggregating itself. Today, we only report an error because of a
@@ -13692,6 +14408,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		A a;
 	//	};
 	//	B t{1};
+	@Test
 	public void testIndirectSelfAggregation_546805() throws Exception {
 		// See comment in previous test
 		BindingAssertionHelper bh = getAssertionHelper();
@@ -13708,6 +14425,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	auto a = A{1, 2};
+	@Test
 	public void testClassFromInitList_549036() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -13715,6 +14433,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	int a = 42, b = 42;
 	//	float c = 3.14, d = 3.14;
 	//	char e[] = "waldo", f[] = "waldo";
+	@Test
 	public void testLiteralExpressionEquivalence_551689() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPASTExpression a = helper.assertNode("a = 42", "42");
@@ -13734,6 +14453,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// };
 	// struct [[nodiscard]] S : public Base {
 	// };
+	@Test
 	public void testNoDiscardClass_Bug534420() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -13765,6 +14485,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//Foo<double> var1;
 	//Foo<int*> var2;
 	//Foo<int> var3;
+	@Test
 	public void testNoDiscardTemplateSpecialization_Bug534420() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -13810,6 +14531,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//Foo<double> var1;
 	//Foo<int*> var2;
 	//Foo<int> var3;
+	@Test
 	public void testFinalTemplateSpecialization_Bug561631() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -13849,6 +14571,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	// enum fruit { apple, banana };
 	// enum hue col;
 	// enum fruit f;
+	@Test
 	public void testEnumerations_Bug534420() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -13869,6 +14592,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//
 	//	template <>
 	//	void waldo(const IntPtr&) {}
+	@Test
 	public void testExplicitSpecPointerType_562697() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -13939,6 +14663,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		Test<TemplateArgs<int, bool>::Value>::false_val;
 	//		Test<TemplateArgs<int, int>::Value>::true_val;
 	//	}
+	@Test
 	public void testIsSame() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -13970,6 +14695,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//		function(true ? 0 : 0); // 12
 	//		functionPtr(true ? 0 : 0); // 13
 	//	}
+	@Test
 	public void testNullPointerConstantConversion_573764() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector collector = new NameCollector();
@@ -14020,6 +14746,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//
 	//	constexpr auto test_32 = calculate<signed long, unsigned int>(1, 2);
 	//	constexpr auto test_64 = calculate<signed long long, unsigned long>(1, 2);
+	@Test
 	public void testArithmeticConversionIssue_265() throws Exception {
 		// Depending on size of integer types above it may happen that the rank of unsigned type operand
 		// is less than rank of signed type operand, and both types are of same size.
@@ -14034,6 +14761,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	//  constexpr auto shiftdouble = (1. << 1);
+	@Test
 	public void testArithmeticEvaluationWithDoubleShiftOp() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IVariable shiftdouble = helper.assertNonProblem("shiftdouble = ", 11);
@@ -14042,6 +14770,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	}
 
 	//  constexpr auto shiftdouble = (1. <<= 1);
+	@Test
 	public void testArithmeticEvaluationWithDoubleShiftAssignOp() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IVariable shiftdouble = helper.assertNonProblem("shiftdouble = ", 11);
@@ -14053,12 +14782,14 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//  constexpr double zero = 0.;
 	//  constexpr double x = 1., y = 1.;
 	//  constexpr int shiftpack = ((x > zero) << Horizontal) | ((y > zero) << Vertical);
+	@Test
 	public void testArithmeticEvaluationOfRelationalOps() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("shiftpack", 3);
 	}
 
 	// constexpr auto true_value = __builtin_is_constant_evaluated();
+	@Test
 	public void testBuiltinIsConstantEvaluated() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("true_value", 1);
@@ -14078,6 +14809,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//			decl_function, // reference site marker
 	//			decl_simple, // reference site marker
 	//	};
+	@Test
 	public void testSimpleDeclarationOfFunction() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -14181,6 +14913,7 @@ public class AST2CPPTests extends AST2CPPTestBase {
 	//	/* 65 */ true == __is_trivially_assignable(E&, E&),
 	//	};
 	//
+	@Test
 	public void testIsAssignable() throws Exception {
 		//parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU /* use GNU extensions */);
 		BindingAssertionHelper helper = getAssertionHelper(CPP, ScannerKind.GNU /* use GNU extensions */);
@@ -14197,6 +14930,6 @@ public class AST2CPPTests extends AST2CPPTestBase {
 			}
 		}
 
-		assertEquals("Failed evaluations", 0, failures);
+		assertEquals((long) 0, (long) failures, "Failed evaluations");
 	}
 }

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CSpecTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CSpecTest.java
@@ -16,23 +16,18 @@ package org.eclipse.cdt.core.parser.tests.ast2;
 
 import org.eclipse.cdt.core.dom.ast.IASTExpression;
 import org.eclipse.cdt.core.parser.ParserLanguage;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author dsteffle
  */
 public class AST2CSpecTest extends AST2SpecTestBase {
 
-	public AST2CSpecTest() {
-	}
-
-	public AST2CSpecTest(String name) {
-		super(name);
-	}
-
 	// /* Start Example(C 4-6) */
 	// #ifdef _ _STDC_IEC_559_ _ // FE_UPWARD defined
 	// fesetround(FE_UPWARD);
 	// #endif
+	@Test
 	public void test4s6() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
@@ -40,6 +35,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// /* Start Example(C 5.1.1.3-2) */
 	// char i;
 	// int i;
+	@Test
 	public void test5_1_1_3s2() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
@@ -49,6 +45,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// char c1, c2;
 	// c1 = c1 + c2;
 	// }
+	@Test
 	public void test5_1_2_3s10() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -59,6 +56,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// double d;
 	// f1 = f2 * d;
 	// }
+	@Test
 	public void test5_1_2_3s11() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -70,6 +68,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// d1 = f = 1;
 	// d2 = (float) 1;
 	// }
+	@Test
 	public void test5_1_2_3s12() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -82,6 +81,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// z = x + x * y; // not equivalent toz = x * (1.0 + y);
 	// y = x / 5.0; // not equivalent toy = x * 0.2;
 	// }
+	@Test
 	public void test5_1_2_3s13() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -95,6 +95,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// a = ((a + 32765) + b);
 	// a = (a + (b + 32765));
 	// }
+	@Test
 	public void test5_1_2_3s14() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -107,12 +108,14 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// sum = sum * 10 - '0' + (*p++ = getchar());
 	// sum = (((sum * 10) - '0') + ((*(p++)) = (getchar())));
 	// }
+	@Test
 	public void test5_1_2_3s15() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
 
 	// /* Start Example(C 6.2.5-28) */
 	// struct tag (* a[5])(float);
+	@Test
 	public void test6_2_5s28() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
@@ -121,6 +124,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// int f(int (*)(), double (*)[3]);
 	// int f(int (*)(char *), double (*)[]);
 	// int f(int (*)(char *), double (*)[3]);
+	@Test
 	public void test6_2_7s5() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -129,6 +133,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// char x='\023';
 	// char y='\0';
 	// char z='\x13';
+	@Test
 	public void test6_4_4_4s12() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -142,6 +147,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// int foo() {
 	// int x=(*pf[f1()]) (f2(), f3() + f4());
 	// }
+	@Test
 	public void test6_5_2_2s12() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -159,6 +165,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// vs.i; // volatile int
 	// vs.ci; // volatile const int
 	// }
+	@Test
 	public void test6_5_2_3s7() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -185,6 +192,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// if (sin(u.nf.doublenode) == 0.0)
 	// return 0;
 	// }
+	@Test
 	public void test6_5_2_3s8a() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -206,12 +214,14 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// } u;
 	// return f(&u.s1, &u.s2);
 	// }
+	@Test
 	public void test6_5_2_3s8b() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
 
 	// /* Start Example(C 6.5.2.5-9) */
 	// int *p = (int []){2, 4};
+	@Test
 	public void test6_5_2_5s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -222,6 +232,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// int *p;
 	// p = (int [2]){*p};
 	// }
+	@Test
 	public void test6_5_2_5s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -233,6 +244,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// drawline(&(struct point){.x=1, .y=1},
 	// &(struct point){.x=3, .y=4});
 	// }
+	@Test
 	public void test6_5_2_5s11() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, false, 0);
 	}
@@ -241,6 +253,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// int f() {
 	// (const float []){1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6};
 	// }
+	@Test
 	public void test6_5_2_5s12() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -251,6 +264,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// (char []){"/tmp/fileXXXXXX"};
 	// (const char []){"/tmp/fileXXXXXX"};
 	// }
+	@Test
 	public void test6_5_2_5s13() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -259,6 +273,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// int f() {
 	// (const char []){"abc"} == "abc";
 	// }
+	@Test
 	public void test6_5_2_5s14() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -269,6 +284,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// struct int_list endless_zeros = {0, &endless_zeros};
 	// eval(endless_zeros);
 	// }
+	@Test
 	public void test6_5_2_5s15() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
@@ -284,6 +300,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// if (j < 2) goto again;
 	// return p == q && q->i == 1;
 	// }
+	@Test
 	public void test6_5_2_5s16() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -291,6 +308,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// /* Start Example(C 6.5.3.4-5) */
 	// extern void *alloc(size_t);
 	// double *dp = alloc(sizeof *dp);
+	@Test
 	public void test6_5_3_4s5() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
@@ -300,6 +318,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// int array[5];
 	// int x = sizeof array / sizeof array[0];
 	// }
+	@Test
 	public void test6_5_3_4s6() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -313,6 +332,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// (*p)[2] = 99; // a[1][2] == 99
 	// n = p - a; // n == 1
 	// }
+	@Test
 	public void test6_5_6s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -333,6 +353,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	//		cond ? ip : c_ip;
 	//		cond ? vp : ip;
 	//	}
+	@Test
 	public void test6_5_15s8() throws Exception {
 		BindingAssertionHelper helper = new AST2AssertionHelper(getAboveComment(), ParserLanguage.C);
 		IASTExpression c1 = helper.assertNode("cond ? c_vp : c_ip");
@@ -356,6 +377,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// long l;
 	// l = (c = i);
 	// }
+	@Test
 	public void test6_5_16_1s5() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -369,6 +391,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// *cpp = &c; // valid
 	// *p = 0; // valid
 	// }
+	@Test
 	public void test6_5_16_1s6() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -383,6 +406,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// offsetof(struct s, d);
 	// offsetof(struct ss, d);
 	// }
+	@Test
 	public void test6_7_2_1s17() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
@@ -394,6 +418,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// s1 = malloc(sizeof (struct s) + 64);
 	// s2 = malloc(sizeof (struct s) + 46);
 	// }
+	@Test
 	public void test6_7_2_1s18a() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
@@ -401,6 +426,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// /* Start Example(C 6.7.2.1-18b) */
 	// struct { int n; double d[8]; } *s1;
 	// struct { int n; double d[5]; } *s2;
+	@Test
 	public void test6_7_2_1s18b() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -414,6 +440,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// if (*cp != burgundy)
 	// return 0;
 	// }
+	@Test
 	public void test6_7_2_2s5() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -424,6 +451,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// struct tnode *left, *right;
 	// };
 	// struct tnode s, *sp;
+	@Test
 	public void test6_7_2_3s9() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -435,6 +463,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// TNODE *left, *right;
 	// };
 	// TNODE s, *sp;
+	@Test
 	public void test6_7_2_3s10() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -443,12 +472,14 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// struct s2;
 	// struct s1 { struct s2 *s2p; }; // D1
 	// struct s2 { struct s1 *s1p; }; // D2
+	@Test
 	public void test6_7_2_3s11() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
 
 	// /* Start Example(C 6.7.3-10) */
 	// extern const volatile int real_time_clock;
+	@Test
 	public void test6_7_3s10() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -468,6 +499,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// pci = &cs.mem; // valid
 	// pi = a[0]; // invalid: a[0] has type ''const int *''
 	// }
+	@Test
 	public void test6_7_3s11() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -476,6 +508,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// int * restrict a;
 	// int * restrict b;
 	// extern int c[];
+	@Test
 	public void test6_7_3_1s7() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -486,6 +519,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// while (n-- > 0)
 	// *p++ = *q++;
 	// }
+	@Test
 	public void test6_7_3_1s8() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -502,6 +536,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// f(50, d + 50, d); // valid
 	// f(50, d + 1, d); // undefined behavior
 	// }
+	@Test
 	public void test6_7_3_1s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -513,6 +548,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// for (i = 0; i < n; i++)
 	// p[i] = q[i] + r[i];
 	// }
+	@Test
 	public void test6_7_3_1s10() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -530,6 +566,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// p2 = q2; // undefined behavior
 	// }
 	// }
+	@Test
 	public void test6_7_3_1s11() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -543,6 +580,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// t.v = malloc(n * sizeof (float));
 	// return t;
 	// }
+	@Test
 	public void test6_7_3_1s12() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, false, 0);
 	}
@@ -561,6 +599,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// {
 	// return is_fahr ? cels(temp) : fahr(temp);
 	// }
+	@Test
 	public void test6_7_4s7() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -570,12 +609,14 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// int *const constant_ptr1;
 	// typedef int *int_ptr;
 	// const int_ptr constant_ptr2;
+	@Test
 	public void test6_7_5_1s4() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
 
 	// /* Start Example(C 6.7.5.2-7) */
 	// float fa[11], *afp[17];
+	@Test
 	public void test6_7_5_2s7() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -583,6 +624,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// /* Start Example(C 6.7.5.2-8) */
 	// extern int *x;
 	// extern int y[];
+	@Test
 	public void test6_7_5_2s8() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -600,6 +642,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// r = c; // compatible, but defined behavior only if
 	// // n == 6 andm == n+1
 	// }
+	@Test
 	public void test6_7_5_2s9() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -624,24 +667,28 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// extern int (*r)[m]; // invalid: r has linkage and points to VLA
 	// static int (*q)[m] = &B; // valid: q is a static block pointer to VLA
 	// }
+	@Test
 	public void test6_7_5_2s10() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
 
 	// /* Start Example(C 6.7.5.3-16) */
 	// int f(void), *fip(), (*pfi)();
+	@Test
 	public void test6_7_5_3s16() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
 
 	// /* Start Example(C 6.7.5.3-18) */
 	// int (*apfi[3])(int *x, int *y);
+	@Test
 	public void test6_7_5_3s18() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
 
 	// /* Start Example(C 6.7.5.3-19) */
 	// int (*fpfi(int (*)(long), int))(int, ...);
+	@Test
 	public void test6_7_5_3s19() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -663,6 +710,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// // a is a pointer to a VLA with n*m+300 elements
 	// a[i][j] += x;
 	// }
+	@Test
 	public void test6_7_5_3s20() throws Exception {
 		String code = getAboveComment();
 		// no valid c++ code
@@ -678,6 +726,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// void f2(double a[restrict][5]);
 	// void f3(double a[restrict 3][5]);
 	// void f4(double a[restrict static 3][5]);
+	@Test
 	public void test6_7_5_3s21() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -689,6 +738,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// extern KLICKSP *metricp;
 	// range x;
 	// range z, *zp;
+	@Test
 	public void test6_7_7s4() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -696,6 +746,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// /* Start Example(C 6.7.7-5) */
 	// typedef struct s1 { int x; } t1, *tp1;
 	// typedef struct s2 { int x; } t2, *tp2;
+	@Test
 	public void test6_7_7s5() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -705,6 +756,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// void (*signal(int, void (*)(int)))(int);
 	// fv *signal(int, fv *);
 	// pfv signal(int, pfv);
+	@Test
 	public void test6_7_7s7() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -719,6 +771,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// for (int i = 1; i < n; i++)
 	// a[i-1] = b[i];
 	// }
+	@Test
 	public void test6_7_7s8() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -726,12 +779,14 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// /* Start Example(C 6.7.8-24) */
 	// int i = 3.5;
 	// complex c = 5 + 3 * I;
+	@Test
 	public void test6_7_8s24() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
 
 	// /* Start Example(C 6.7.8-25) */
 	// int x[] = { 1, 3, 5 };
+	@Test
 	public void test6_7_8s25() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -742,6 +797,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// { 2, 4, 6 },
 	// { 3, 5, 7 },
 	// };
+	@Test
 	public void test6_7_8s26a() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -750,6 +806,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// int y[4][3] = {
 	// 1, 3, 5, 2, 4, 6, 3, 5, 7
 	// };
+	@Test
 	public void test6_7_8s26b() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -758,12 +815,14 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// int z[4][3] = {
 	// { 1 }, { 2 }, { 3 }, { 4 }
 	// };
+	@Test
 	public void test6_7_8s27() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
 
 	// /* Start Example(C 6.7.8-28) */
 	// struct { int a[3], b; } w[] = { { 1 }, 2 };
+	@Test
 	public void test6_7_8s28() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -791,6 +850,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// { 6 },
 	// }
 	// };
+	@Test
 	public void test6_7_8s29() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -799,6 +859,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// typedef int A[]; // OK - declared with block scope
 	// A a1 = { 1, 2 }, b1 = { 3, 4, 5 };
 	// int a2[] = { 1, 2 }, b2[] = { 3, 4, 5 };
+	@Test
 	public void test6_7_8s31() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -810,6 +871,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// t2[] = { 'a', 'b', 'c' };
 	// char *p = "abc";
 	// }
+	@Test
 	public void test6_7_8s32() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -820,12 +882,14 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// [member_two] = "member two",
 	// [member_one] = "member one",
 	// };
+	@Test
 	public void test6_7_8s33() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
 
 	// /* Start Example(C 6.7.8-34) */
 	// div_t answer = { .quot = 2, .rem = -1 };
+	@Test
 	public void test6_7_8s34() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 1); // div_t (correctly) cannot be resolved
 	}
@@ -833,6 +897,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// /* Start Example(C 6.7.8-35) */
 	// struct { int a[3], b; } w[] =
 	// { [0].a = {1}, [1].a[0] = 2 };
+	@Test
 	public void test6_7_8s35() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -842,12 +907,14 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// int a[MAX] = {
 	// 1, 3, 5, 7, 9, [MAX-5] = 8, 6, 4, 2, 0
 	// };
+	@Test
 	public void test6_7_8s36() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
 
 	// /* Start Example(C 6.7.8-38) */
 	// union { int any_member; } u = { .any_member = 42 };
+	@Test
 	public void test6_7_8s38() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -857,6 +924,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// int f() {
 	// (void)p(0);
 	// }
+	@Test
 	public void test6_8_3s4() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -867,6 +935,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// while (*s++ != '\0')
 	// ;
 	// }
+	@Test
 	public void test6_8_3s5() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -883,6 +952,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// end_loop1: ;
 	// }
 	// }
+	@Test
 	public void test6_8_3s6() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -900,6 +970,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// f(i+1);
 	// }
 	// }
+	@Test
 	public void test6_8_4s7() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -918,6 +989,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// // handle other operations
 	// }
 	// }
+	@Test
 	public void test6_8_6_1s3() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -937,6 +1009,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// }
 	// goto lab4; // invalid: going INTO scope of VLA.
 	// }
+	@Test
 	public void test6_8_6_1s4() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
@@ -960,6 +1033,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// int foo() {
 	// g.u2.f3 = f();
 	// }
+	@Test
 	public void test6_8_6_4s4() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}
@@ -969,6 +1043,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// {
 	// return a > b ? a : b;
 	// }
+	@Test
 	public void test6_9_1s13() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -979,6 +1054,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// (*funcp)();
 	// funcp();
 	// }
+	@Test
 	public void test6_9_1s14() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -999,6 +1075,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// extern int i3; // refers to pre vious, whose linkage is external
 	// extern int i4; // refers to pre vious, whose linkage is external
 	// extern int i5; // refers to pre vious, whose linkage is internal
+	@Test
 	public void test6_9_2s4() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -1012,6 +1089,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// if ('z' - 'a' == 25)
 	// g();
 	// }
+	@Test
 	public void test6_10_1s4() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -1023,6 +1101,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// #define join(c, d) in_between(c hash_hash d)
 	// char p[] = join(x, y); // equivalent to
 	// char p[] = "x ## y";
+	@Test
 	public void test6_10_3_3s4() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -1030,12 +1109,14 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// /* Start Example(C 6.10.3.5-3) */
 	// #define TABSIZE 100
 	// int table[TABSIZE];
+	@Test
 	public void test6_10_3_5s3() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
 
 	// /* Start Example(C 6.10.3.5-4) */
 	// #define max(a, b) ((a) > (b) ? (a) : (b))
+	@Test
 	public void test6_10_3_5s4() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -1059,6 +1140,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// p() i[q()] = { q(1), r(2,3), r(4,), r(,5), r(,) };
 	// char c[2][6] = { str(hello), str() };
 	// }
+	@Test
 	public void test6_10_3_5s5() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -1083,6 +1165,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// char * c = glue(HIGH, LOW);
 	// c = xglue(HIGH, LOW);
 	// }
+	@Test
 	public void test6_10_3_5s6() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
@@ -1091,6 +1174,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// #define t(x,y,z) x ## y ## z
 	// int j[] = { t(1,2,3), t(,4,5), t(6,,7), t(8,9,),
 	// t(10,,), t(,11,), t(,,12), t(,,) };
+	@Test
 	public void test6_10_3_5s7() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -1103,6 +1187,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// #define FUNC_LIKE2( a )(              \
 	//             	a                    \
 	//                   	)
+	@Test
 	public void test6_10_3_5s8() throws Exception {
 		parseCandCPP(getAboveComment(), true, 0);
 	}
@@ -1118,6 +1203,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// showlist(The first, second, and third items.);
 	// report(x>y, "x is %d but y is %d", x, y);
 	// }
+	@Test
 	public void test6_10_3_5s9() throws Exception {
 		parseCandCPP(getAboveComment(), false, 0);
 	}
@@ -1132,6 +1218,7 @@ public class AST2CSpecTest extends AST2SpecTestBase {
 	// };
 	// t f(t (t));
 	// long t;
+	@Test
 	public void test6_7_7s6() throws Exception {
 		parse(getAboveComment(), ParserLanguage.C, true, 0);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2KnRTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2KnRTests.java
@@ -15,6 +15,12 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.eclipse.cdt.core.dom.ast.IASTArrayDeclarator;
 import org.eclipse.cdt.core.dom.ast.IASTArraySubscriptExpression;
 import org.eclipse.cdt.core.dom.ast.IASTBinaryExpression;
@@ -58,19 +64,13 @@ import org.eclipse.cdt.internal.core.dom.parser.c.CParameter;
 import org.eclipse.cdt.internal.core.dom.parser.c.CScope;
 import org.eclipse.cdt.internal.core.dom.parser.c.CVisitor;
 import org.eclipse.cdt.internal.core.dom.parser.c.ICInternalBinding;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author dsteffle
  */
 public class AST2KnRTests extends AST2TestBase {
-
-	public AST2KnRTests() {
-	}
-
-	public AST2KnRTests(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testSimpleKRCTest1() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(char x);\n"); //$NON-NLS-1$
@@ -113,6 +113,7 @@ public class AST2KnRTests extends AST2TestBase {
 				.getBinding(CScope.NAMESPACE_TYPE_OTHER, "x".toCharArray())); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSimpleKRCTest2() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f();\n"); //$NON-NLS-1$
@@ -149,6 +150,7 @@ public class AST2KnRTests extends AST2TestBase {
 				.getBinding(CScope.NAMESPACE_TYPE_OTHER, "x".toCharArray())); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSimpleKRCTest3() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int const *f();\n"); //$NON-NLS-1$
@@ -175,6 +177,7 @@ public class AST2KnRTests extends AST2TestBase {
 		assertEquals(x3, x4);
 	}
 
+	@Test
 	public void testKRC_1() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int isroot (x, y) /* comment */ \n"); //$NON-NLS-1$
@@ -228,6 +231,7 @@ public class AST2KnRTests extends AST2TestBase {
 				.getBinding(CScope.NAMESPACE_TYPE_OTHER, "y".toCharArray())); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testKRCWithTypes() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("typedef char c;\n"); //$NON-NLS-1$
@@ -287,6 +291,7 @@ public class AST2KnRTests extends AST2TestBase {
 				.getBinding(CScope.NAMESPACE_TYPE_OTHER, "x".toCharArray())); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testKRCProblem1() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(x) char\n"); //$NON-NLS-1$
@@ -297,6 +302,7 @@ public class AST2KnRTests extends AST2TestBase {
 		assertTrue(CVisitor.getProblems(tu).length > 0);
 	}
 
+	@Test
 	public void testKRCProblem2() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int i=0;\n"); //$NON-NLS-1$
@@ -308,6 +314,7 @@ public class AST2KnRTests extends AST2TestBase {
 		assertTrue(CVisitor.getProblems(tu).length > 0);
 	}
 
+	@Test
 	public void testKRCProblem3() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(x) char y;\n"); //$NON-NLS-1$
@@ -344,6 +351,7 @@ public class AST2KnRTests extends AST2TestBase {
 		assertEquals(decls.length, 0);
 	}
 
+	@Test
 	public void testKRCProblem4() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(x,y,z) char x,y,z; int a;\n"); //$NON-NLS-1$
@@ -405,6 +413,7 @@ public class AST2KnRTests extends AST2TestBase {
 		assertEquals(decls[0], x2);
 	}
 
+	@Test
 	public void testKRCProblem5() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(x) char x,a;\n"); //$NON-NLS-1$
@@ -441,6 +450,7 @@ public class AST2KnRTests extends AST2TestBase {
 		assertEquals(decls.length, 0);
 	}
 
+	@Test
 	public void testKRC_monop_cards1() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#ifdef __STDC__\n"); //$NON-NLS-1$
@@ -493,8 +503,7 @@ public class AST2KnRTests extends AST2TestBase {
 		assertTrue(A.getDeclSpecifier() instanceof IASTElaboratedTypeSpecifier);
 		IASTName A_struct_name_2 = ((IASTElaboratedTypeSpecifier) A.getDeclSpecifier()).getName();
 		assertEquals(A_struct_name_2.toString(), "A_struct"); //$NON-NLS-1$
-		assertEquals(((IASTElaboratedTypeSpecifier) A.getDeclSpecifier()).getStorageClass(),
-				IASTDeclSpecifier.sc_typedef);
+		assertEquals(A.getDeclSpecifier().getStorageClass(), IASTDeclSpecifier.sc_typedef);
 		ICompositeType A_struct_type2 = (ICompositeType) A_struct_name_2.resolveBinding();
 		assertEquals(A_struct_type2, A_struct_type1);
 
@@ -577,6 +586,7 @@ public class AST2KnRTests extends AST2TestBase {
 				.getBinding(CScope.NAMESPACE_TYPE_OTHER, "x".toCharArray())); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testKRC_monop_cards2() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int\n"); //$NON-NLS-1$
@@ -603,7 +613,7 @@ public class AST2KnRTests extends AST2TestBase {
 
 		IASTSimpleDeclaration parm_decl = (IASTSimpleDeclaration) ((ICASTKnRFunctionDeclarator) getinp.getDeclarator())
 				.getParameterDeclarations()[0];
-		assertTrue(((IASTSimpleDeclSpecifier) parm_decl.getDeclSpecifier()).isConst());
+		assertTrue(parm_decl.getDeclSpecifier().isConst());
 		assertEquals(((IASTSimpleDeclSpecifier) parm_decl.getDeclSpecifier()).getType(),
 				IASTSimpleDeclSpecifier.t_char);
 		IASTDeclarator prompt = parm_decl.getDeclarators()[0];
@@ -625,6 +635,7 @@ public class AST2KnRTests extends AST2TestBase {
 		assertEquals(decls[0], prompt2);
 	}
 
+	@Test
 	public void testKRC_getParametersOrder() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(a, b) int b,a;{}\n"); //$NON-NLS-1$
@@ -639,6 +650,7 @@ public class AST2KnRTests extends AST2TestBase {
 		assertEquals(((CParameter) f_parms[1]).getName(), "b"); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testKRC_Ethereal_1() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("struct symbol {\n"); //$NON-NLS-1$
@@ -695,6 +707,7 @@ public class AST2KnRTests extends AST2TestBase {
 		assertEquals(lemp_name3.resolveBinding(), lemp_name4.resolveBinding());
 	}
 
+	@Test
 	public void testBug97447() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("void f(a) int a; {} \n"); //$NON-NLS-1$
@@ -709,6 +722,7 @@ public class AST2KnRTests extends AST2TestBase {
 		IParameter a = (IParameter) col.getName(4).resolveBinding();
 	}
 
+	@Test
 	public void testBug100104() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("typedef int ush;\n"); //$NON-NLS-1$
@@ -747,6 +761,7 @@ public class AST2KnRTests extends AST2TestBase {
 	//  {
 	//  	return 0;
 	//  }
+	@Test
 	public void testBug203050() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), ParserLanguage.C, ScannerKind.GNU, true);
 		assertTrue(tu.getDeclarations()[0] instanceof IASTSimpleDeclaration);
@@ -773,6 +788,7 @@ public class AST2KnRTests extends AST2TestBase {
 	//    char (*in_char)(void);
 	//    int conv_base;
 	//    {}
+	@Test
 	public void testFunctionPtrParameter_378614() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code, ParserLanguage.C, ScannerKind.GNU);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2SpecTestBase.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2SpecTestBase.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,14 +47,6 @@ import org.eclipse.cdt.internal.core.parser.ParserException;
  * @author dsteffle
  */
 public abstract class AST2SpecTestBase extends AST2TestBase {
-	public AST2SpecTestBase() {
-		super();
-	}
-
-	public AST2SpecTestBase(String name) {
-		super(name);
-	}
-
 	/**
 	 * checkSemantics is used to specify whether the example should have semantics checked
 	 * since several spec examples have syntactically correct code ONLY this flag was added

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateLValueRValueTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateLValueRValueTests.java
@@ -1,6 +1,7 @@
 package org.eclipse.cdt.core.parser.tests.ast2;
 
 import static org.eclipse.cdt.core.parser.ParserLanguage.CPP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
@@ -9,15 +10,9 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPFunction;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPFunctionInstance;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPFunctionTemplate;
 import org.eclipse.cdt.internal.core.parser.ParserException;
+import org.junit.jupiter.api.Test;
 
 public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
-
-	public AST2TemplateLValueRValueTests() {
-	}
-
-	public AST2TemplateLValueRValueTests(String name) {
-		super(name);
-	}
 
 	//	class clazz {
 	//	};
@@ -46,6 +41,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_lvalue_rvalue_caller_templateLvalue_templateRvalue_function() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -86,6 +82,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_lvalueTypedef_rvalueTypedef_caller_templateLvalue_templateRvalue_function() throws Exception {
 		parseAndCheckBindings();
 
@@ -128,6 +125,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_lvalueTypedefRef_rvalueTypedefRef_caller_templateLvalue_templateRvalue_function()
 			throws Exception {
 		parseAndCheckBindings();
@@ -170,6 +168,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_lvalueTypedefRef_rvalueTypedefRef_caller_templateTpedefLvalue_templateRvalue_function()
 			throws Exception {
 		parseAndCheckBindings();
@@ -204,6 +203,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	  int c;
 	//	  demo(c);
 	//	}
+	@Test
 	public void test_lvalue_rvalue_caller_templateLvalue_templateRvalue_lvalue_function() throws Exception {
 		parseAndCheckBindings();
 
@@ -225,6 +225,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	  clazz c;
 	//	  demo(c);
 	//	}
+	@Test
 	public void test_lvalue_caller_rvalue_function() throws Exception {
 		parseAndCheckBindingsForOneProblem();
 	}
@@ -241,6 +242,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	  clazz c;
 	//	  demo(c);
 	//	}
+	@Test
 	public void test_lvalue_caller_lvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -267,6 +269,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_rvalue_caller_lvalue_rvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -287,6 +290,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	  clazz c;
 	//	  demo(c);
 	//	}
+	@Test
 	public void test_lvalue_caller_templateRvalue_lvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -312,6 +316,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_rvalue_caller_templateRvalue_lvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -332,6 +337,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_rvalue_caller_lvalue_function() throws Exception {
 		parseAndCheckBindingsForOneProblem();
 	}
@@ -352,6 +358,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_rvalue_caller_rvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -372,6 +379,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_rvalue_caller_templateLvalue_function() throws Exception {
 		parseAndCheckBindingsForOneProblem();
 	}
@@ -393,6 +401,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_rvalue_caller_templateRvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -414,6 +423,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo<clazz>(getClazz());
 	//	}
+	@Test
 	public void test_templatedRvalue_caller__templateRvalue_lvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -433,6 +443,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//    clazz c;
 	//	  demo<clazz>(c);
 	//	}
+	@Test
 	public void test_templatedLvalue_caller__templateRvalue_lvalue_function() throws Exception {
 		parseAndCheckBindingsForProblem();
 	}
@@ -452,6 +463,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//    clazz c;
 	//	  demo(c);
 	//	}
+	@Test
 	public void test_lvalue_caller_templateLvalue_lvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -476,6 +488,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_rvalue_caller_templateLvalue_lvalue_function() throws Exception {
 		parseAndCheckBindingsForOneProblem();
 	}
@@ -500,6 +513,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo<clazz>(getClazz());
 	//	}
+	@Test
 	public void test_templatedRvalue_caller_templatedLValue_lvalAST2TemplateRValueRValueTestsue_function()
 			throws Exception {
 		parseAndCheckBindingsForProblem();
@@ -520,6 +534,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//    clazz c;
 	//	  demo<clazz>(c);
 	//	}
+	@Test
 	public void test_templatedLvalue_caller_templatedLValue_lvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -539,6 +554,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//    clazz c;
 	//	  demo(c);
 	//	}
+	@Test
 	public void test_lvalue_caller_templatedRvalue_rvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -563,6 +579,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_rvalue_caller_templatedRvalue_rvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -587,6 +604,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo<clazz>(getClazz());
 	//	}
+	@Test
 	public void test_templatedRvalue_caller_templatedRvalue_rvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -606,6 +624,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//    clazz c;
 	//	  demo<clazz>(c);
 	//	}
+	@Test
 	public void test_templatedLvalue_caller_templatedRvalue_rvalue_function() throws Exception {
 		parseAndCheckBindingsForProblem();
 	}
@@ -625,6 +644,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//    clazz c;
 	//	  demo(c);
 	//	}
+	@Test
 	public void test_lvalue_caller_templatedLvalue_rvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -649,6 +669,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_rvalue_caller_templatedLvalue_rvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -673,6 +694,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo<clazz>(getClazz());
 	//	}
+	@Test
 	public void test_templatedRvalue_caller_templatedLvalue_rvalue_function() throws Exception {
 		parseAndCheckBindingsForProblem();
 	}
@@ -692,6 +714,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//    clazz c;
 	//	  demo<clazz>(c);
 	//	}
+	@Test
 	public void test_templatedLvalue_caller_templatedLvalue_rvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -712,6 +735,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//    clazz c;
 	//	  demo(c);
 	//	}
+	@Test
 	public void test_lvalue_caller_templatedLvalue_templatedRvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -737,6 +761,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo(getClazz());
 	//	}
+	@Test
 	public void test_rvalue_caller_templatedLvalue_templatedRvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -762,6 +787,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo<clazz>(getClazz());
 	//	}
+	@Test
 	public void test_templatedRvalue_caller_templatedLvalue_templatedRvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -782,6 +808,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//    clazz c;
 	//	  demo<clazz>(c);
 	//	}
+	@Test
 	public void test_templatedLvalue_caller_templatedLvalue_templatedRvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -803,6 +830,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo<clazz>(getClazz());
 	//	}
+	@Test
 	public void test_templatedRvalue_caller_templatedLvalue_function() throws Exception {
 		parseAndCheckBindingsForProblem();
 	}
@@ -824,6 +852,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//	{
 	//	  demo<clazz>(getClazz());
 	//	}
+	@Test
 	public void test_templatedRvalue_caller_templatedRvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -840,6 +869,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//    clazz c;
 	//	  demo<clazz>(c);
 	//	}
+	@Test
 	public void test_templatedLvalue_caller_templatedLvalue_function() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -856,6 +886,7 @@ public class AST2TemplateLValueRValueTests extends AST2CPPTestBase {
 	//    clazz c;
 	//	  demo<clazz>(c);
 	//	}
+	@Test
 	public void test_templatedLvalue_caller_templatedRvalue_function() throws Exception {
 		parseAndCheckBindingsForProblem();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TemplateTests.java
@@ -27,6 +27,13 @@ import static org.eclipse.cdt.core.parser.tests.VisibilityAsserts.assertVisibili
 import static org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.SemanticUtil.TDEF;
 import static org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.SemanticUtil.getNestedType;
 import static org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.SemanticUtil.getUltimateType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.cdt.core.dom.IName;
 import org.eclipse.cdt.core.dom.ast.ASTTypeUtil;
@@ -49,7 +56,6 @@ import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.dom.ast.IASTTypeId;
 import org.eclipse.cdt.core.dom.ast.IBasicType;
 import org.eclipse.cdt.core.dom.ast.IBinding;
-import org.eclipse.cdt.core.dom.ast.ICompositeType;
 import org.eclipse.cdt.core.dom.ast.IEnumerator;
 import org.eclipse.cdt.core.dom.ast.IField;
 import org.eclipse.cdt.core.dom.ast.IFunction;
@@ -110,21 +116,10 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPDeferredClassInstance;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPInternalUnknownScope;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPUnknownBinding;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.SemanticUtil;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class AST2TemplateTests extends AST2CPPTestBase {
-
-	public AST2TemplateTests() {
-	}
-
-	public AST2TemplateTests(String name) {
-		super(name);
-	}
-
-	public static TestSuite suite() {
-		return suite(AST2TemplateTests.class);
-	}
 
 	private NameCollector getNameCollector(IASTTranslationUnit ast) {
 		NameCollector collector = new NameCollector();
@@ -132,6 +127,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 		return collector;
 	}
 
+	@Test
 	public void testBasicClassTemplate() throws Exception {
 		IASTTranslationUnit tu = parse("template <class T> class A{ T t; };", CPP); //$NON-NLS-1$
 		NameCollector col = new NameCollector();
@@ -164,6 +160,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    A<int> a;
 	//    a.t1; a.t2;
 	// }
+	@Test
 	public void testBasicTemplateInstance_a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -188,7 +185,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 		assertSame(((ICPPTemplateInstance) A_int).getTemplateDefinition(), A);
 
 		ICPPClassScope A_int_Scope = (ICPPClassScope) A_int.getCompositeScope();
-		assertNotSame(A_int_Scope, ((ICompositeType) A).getCompositeScope());
+		assertNotSame(A_int_Scope, A.getCompositeScope());
 
 		ICPPField t = (ICPPField) col.getName(11).resolveBinding();
 		assertTrue(t instanceof ICPPSpecialization);
@@ -215,6 +212,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    A<int> a;
 	//    a.f((int*)0);
 	// }
+	@Test
 	public void testBasicTemplateInstance_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -247,6 +245,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void foo() {
 	//    f<int>(0);
 	// }
+	@Test
 	public void testBasicTemplateFunction() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -276,6 +275,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template < class T > class pair {
 	//    template < class U > pair(const pair<U> &);
 	// };
+	@Test
 	public void testStackOverflow_a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -297,6 +297,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template < class T > class A {};
 	// template < class T > class A< T* > {};
 	// template < class T > class A< T** > {};
+	@Test
 	public void testBasicClassPartialSpecialization() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -325,6 +326,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template < class T > class A { typedef int TYPE; };
 	// template < class T > typename A<T>::TYPE foo(T);
 	// template < class T > typename A<T>::TYPE foo(T);
+	@Test
 	public void testStackOverflow_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -360,6 +362,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	struct A : public _A_::member_t {};
 	//
 	//	struct B : public A<B>{};
+	@Test
 	public void testStackOverflowInBaseComputation_418996() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPClassType B = helper.assertNonProblem("A<B>", 4);
@@ -371,6 +374,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    void f();
 	// };
 	// template < class T > void A<T>::f() { }
+	@Test
 	public void testTemplateMemberDef() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -389,6 +393,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    const int *p;
 	//    f(p); //calls f(const T *) , 3 is more specialized than 1 or 2
 	// }
+	@Test
 	public void test14_5_5_2s5_OrderingFunctionTemplates_a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -413,6 +418,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    float x;
 	//    f(x); //ambiguous 1 or 2
 	// }
+	@Test
 	public void test14_5_5_2s5_OrderingFunctionTemplates_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -431,6 +437,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void main() {
 	//     f({1,2,3});
 	// }
+	@Test
 	public void test_dr1591_DeduceArrayFromInitializerList_a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -450,6 +457,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void main() {
 	//     f({1,2,3});
 	// }
+	@Test
 	public void test_dr1591_DeduceArrayFromInitializerList_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -469,6 +477,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void main() {
 	//     f({1,2.0,3});
 	// }
+	@Test
 	public void test_dr1591_DeduceArrayFromInitializerList_c() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -486,6 +495,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 
 	// template < class T, template < class X > class U, T *pT > class A {
 	// };
+	@Test
 	public void testTemplateParameters() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -513,6 +523,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    A<int> * b;
 	//    b->a;
 	// }
+	@Test
 	public void testDeferredInstances() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -553,6 +564,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// A <int, char*, 5> a3;		//uses #4, T is char
 	// A <int, char*, 1> a4;		//uses #5, T is int, T2 is char, I is1
 	// A <int*, int*, 2> a5;		//ambiguous, matches #3 & #5.
+	@Test
 	public void test14_5_4_1s2_MatchingTemplateSpecializations() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -596,6 +608,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template <class T1, bool EN = true> class A { };
 	// template <class T1> class A <T1, (bool)consume_r1<T1>()> { };
 	// A<int> a1; // uses specialisation
+	@Test
 	public void testPrimitiveMatchingSpecializations() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -616,6 +629,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template <class T> void f(T*);
 	// template <> void f(int);       //ok
 	// template <> void f<int>(int*); //ok
+	@Test
 	public void test14_7_3_FunctionExplicitSpecialization() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -633,6 +647,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 
 	// template<class T> void f(T*);
 	// void g(int* p) { f(p); }
+	@Test
 	public void test14_5_5_1_FunctionTemplates_a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -647,6 +662,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 
 	// template<class T> void f(T);
 	// void g(int* p) { f(p); }
+	@Test
 	public void test14_5_5_1_FunctionTemplates_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -663,6 +679,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void g(){
 	//    int i = f<int>(5); // Y is int
 	// }
+	@Test
 	public void test14_8_1s2_FunctionTemplates() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -679,6 +696,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void g(){
 	//    f("Annemarie");
 	// }
+	@Test
 	public void test14_8_3s6_FunctionTemplates() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -699,6 +717,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    f(ip);                       //calls #2
 	//    g(ip);                       //calls #4
 	// }
+	@Test
 	public void test14_5_5_2s6_FunctionTemplates() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -726,6 +745,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    X* p;               // meaning X<T>
 	//    X<T>* p2;
 	// };
+	@Test
 	public void test14_6_1s1_LocalNames() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -747,6 +767,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    f(&a);              //call f<int>(int*)
 	//    f(&b);              //call f<char*>(char**)
 	// }
+	@Test
 	public void test14_8s2() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -778,6 +799,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template<class T> inline T g(T) {  }
 	// template<> inline void f<>(int) {  } //OK: inline
 	// template<> int g<>(int) {  }     // OK: not inline
+	@Test
 	public void test14_7_3s14() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -792,8 +814,8 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 		assertSame(f2.getSpecializedBinding(), f1);
 		assertSame(g2.getSpecializedBinding(), g1);
 
-		assertFalse(((ICPPFunction) f1).isInline());
-		assertTrue(((ICPPFunction) g1).isInline());
+		assertFalse(f1.isInline());
+		assertTrue(g1.isInline());
 		assertTrue(((ICPPFunction) f2).isInline());
 		assertFalse(((ICPPFunction) g2).isInline());
 	}
@@ -807,6 +829,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    X<int> x;
 	//    x.a.a.a.a;
 	// }
+	@Test
 	public void test14_7_1s14_InfiniteInstantiation() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -839,6 +862,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    Y* p; // meaning Y<int>
 	//    Y<char>* q; // meaning Y<char>
 	// };
+	@Test
 	public void test14_6_1s2() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -863,6 +887,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void foo () {
 	//    f(g);
 	// }
+	@Test
 	public void testBug45129() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -886,6 +911,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    A<int> a;
 	//    a.u;
 	// }
+	@Test
 	public void testBug76951() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -916,6 +942,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    A< int > a;
 	// };
 	// void f(A<int> p) { }
+	@Test
 	public void testInstances() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -932,6 +959,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 
 	// template <class T> void f(T);
 	// template <class T> void f(T) {}
+	@Test
 	public void testTemplateParameterDeclarations() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -954,6 +982,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    a->f(a);
 	//    a->pA;
 	// };
+	@Test
 	public void testDeferredInstantiation() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1000,6 +1029,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    ac.f('c'); //template
 	//    ac.f<>(1); //template
 	// }
+	@Test
 	public void test14_5_2s2_MemberSpecializations() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1044,6 +1074,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template <> class A<int> {};
 	// A<char> ac;
 	// A<int> ai;
+	@Test
 	public void testClassSpecializations() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1076,6 +1107,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// // explicit specialization syntax not used for a member of
 	// // explicitly specialized class template specialization
 	// void A<int>::f(int) {  }
+	@Test
 	public void test14_7_3s5_SpecializationMemberDefinition() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1113,6 +1145,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    C c;
 	//    b.f(c);
 	// }
+	@Test
 	public void testNestedSpecializations() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1155,6 +1188,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    template<class T> class A<T, T*> { };
 	// }
 	// A<int,int*> a;
+	@Test
 	public void test14_5_4s7_UsingClassTemplate() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1186,6 +1220,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    C<A> c;
 	//    c.y.x;   c.z.x;
 	// }
+	@Test
 	public void testTemplateTemplateParameter() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1234,6 +1269,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    A<int> a;
 	//    a.t;
 	// }
+	@Test
 	public void testNestedTypeSpecializations() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1268,6 +1304,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    A<int> a;
 	//    a.b.t;
 	// }
+	@Test
 	public void testNestedClassTypeSpecializations() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1307,6 +1344,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void f() {
 	//    A< C<B> > a; a.s;
 	// };
+	@Test
 	public void testTemplateParameterQualifiedType() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1359,6 +1397,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template <class U> void A<U>::f(){
 	//    U u;
 	// }
+	@Test
 	public void testTemplateScopes_a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1382,6 +1421,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    template < class T > void f(T);
 	// };
 	// template <class U> void A::f<>(U){}
+	@Test
 	public void testTemplateScopes_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1416,6 +1456,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	// A<B> ab;
 	// A<C> ac;
+	@Test
 	public void testEnclosingScopes_a() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 
@@ -1431,8 +1472,8 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 
 		assertInstance(b0.getScope(), ICPPTemplateScope.class);
 
-		IScope ts0 = ((ICPPClassType) b0.getSpecializedBinding()).getScope();
-		IScope ts1 = ((ICPPClassType) b1.getSpecializedBinding()).getScope();
+		IScope ts0 = b0.getSpecializedBinding().getScope();
+		IScope ts1 = b1.getSpecializedBinding().getScope();
 
 		assertInstance(ts0, ICPPTemplateScope.class);
 
@@ -1457,6 +1498,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    A<C>::B acb;
 	//    A<D>::B adb;
 	// }
+	@Test
 	public void testEnclosingScopes_b() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 
@@ -1484,6 +1526,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// };
 	//
 	// X<A>::Y::Z xayz;
+	@Test
 	public void testEnclosingScopes_c() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 
@@ -1508,6 +1551,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// };
 	//
 	// X<B,A>::N n;
+	@Test
 	public void testEnclosingScopes_d() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 
@@ -1534,6 +1578,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template<> template<> void A<int>::g(int,char);
 	// template<> template<> void A<int>::g<char>(int,char);
 	// template<> void A<int>::h(int) { }
+	@Test
 	public void test14_7_3s16() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1596,6 +1641,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template<class C> void N::B<C>::f(C) {
 	//    C b; // C is the template parameter, not N::C
 	// }
+	@Test
 	public void test14_6_1s6() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1629,6 +1675,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template <class T> class Array {};
 	// template <class T> void sort(Array<T> &);
 	// template void sort<>(Array<int> &);
+	@Test
 	public void testBug90689_ExplicitInstantiation() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1655,6 +1702,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template class Array<char>;
 	// template<class T> void sort(Array<T>& v) {  }
 	// template void sort(Array<char>&); // argument is deduced here
+	@Test
 	public void test14_7_2s2_ExplicitInstantiation() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1678,6 +1726,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    A<T>* p;
 	//    void f() { this; }
 	// };
+	@Test
 	public void testBug74204() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1698,6 +1747,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template <class T > void g(T t){
 	//    f(t);
 	// }
+	@Test
 	public void testDeferredFunctionTemplates() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1717,6 +1767,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//       init(a);
 	//    }
 	// };
+	@Test
 	public void testRelaxationForTemplateInheritance() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1743,6 +1794,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//       i->foo;  i[0].foo;
 	//    }
 	// }
+	@Test
 	public void testBug91707() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1773,6 +1825,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    A<B>::_T t;
 	//    (*t).i;
 	// }
+	@Test
 	public void testBug98961() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1796,6 +1849,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    }
 	//    void begin();
 	// };
+	@Test
 	public void testBug98784() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1811,6 +1865,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void m(){
 	//    f(A<int>(1));
 	// }
+	@Test
 	public void testBug99254a() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPConstructor ctor = bh.assertNonProblem("A(T t)", "A", ICPPConstructor.class);
@@ -1837,6 +1892,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void f(B* b){
 	//    b->add(core::A<int>(10, 2));
 	// }
+	@Test
 	public void testBug99254b() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPConstructor ctor = bh.assertNonProblem("A(T x, T y)", "A", ICPPConstructor.class);
@@ -1861,6 +1917,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void f(B* b){
 	//    b->add(A<int>(10));
 	// }
+	@Test
 	public void testBug99254c() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPConstructor ctor = bh.assertNonProblem("A(T)", "A", ICPPConstructor.class);
@@ -1876,6 +1933,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 		assertSame(add, add2);
 	}
 
+	@Test
 	public void testBug98666() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
 		IASTTranslationUnit tu = parse("A::template B<T> b;", CPP);
@@ -1896,6 +1954,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template <class T> template <class T2>
 	// struct A<T>::C::B<T2*>{};
 	// A<short>::C::B<int*> ab;
+	@Test
 	public void testBug90678() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -1928,6 +1987,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// int f(int);                  // #2
 	// int k = f(1);           // uses #2
 	// int l = f<>(1);         // uses #1
+	@Test
 	public void testBug95208() throws Exception {
 		String content = getAboveComment();
 		IASTTranslationUnit tu = parse(content, CPP);
@@ -1957,6 +2017,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    const int local = 10;
 	//    A<int, local> broken;
 	// };
+	@Test
 	public void testBug103578() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -1977,6 +2038,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    A< B > a;
 	//    a.base;
 	// }
+	@Test
 	public void testBug103715() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -2002,6 +2064,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// };
 	// void complex<float>::f(float){
 	// }
+	@Test
 	public void testBug74276() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -2028,6 +2091,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void m(){
 	//    myType t;
 	// }
+	@Test
 	public void testBug105852() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -2051,6 +2115,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    B k;
 	//    k.c;
 	//	}
+	@Test
 	public void testBug105769() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -2067,6 +2132,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    template <> C(char * c) : blah(c) {}
 	//    template <> C(wchar_t * c) : blah(c) {}
 	//	};
+	@Test
 	public void testBug162230() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -2102,6 +2168,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 
 	//	template< class T > class C {};
 	//	typedef struct C<int> CInt;
+	@Test
 	public void testBug169628() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -2126,6 +2193,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     makeClosure(this, &A::m1);
 	//   }
 	// };
+	@Test
 	public void testBug201204() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPFunction fn = bh.assertNonProblem("makeClosure(this", 11, ICPPFunction.class);
@@ -2152,6 +2220,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	 func(c, &C::m1);
 	//	 func(d, &C::m2);
 	// }
+	@Test
 	public void testBug233889() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPFunction fn1 = bh.assertNonProblem("func(c", 4, ICPPFunction.class);
@@ -2175,6 +2244,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// int main(map<int, int> x) {
 	//   GetPair(x, 1);
 	// }
+	@Test
 	public void testBug229917a() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPFunction fn = bh.assertNonProblem("GetPair(x", 7, ICPPFunction.class);
@@ -2192,6 +2262,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	// template <class _C>
 	// typename _C::value_type GetPair(_C& collection, typename _C::value_type::first_type key);
+	@Test
 	public void testBug229917b() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		IBinding b0 = bh.assertNonProblem("value_type GetPair", 10, IBinding.class);
@@ -2211,6 +2282,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void f(C<char>& str) {
 	//   str.m();
 	// }
+	@Test
 	public void testBug232086() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPFunction b0 = bh.assertNonProblem("m();", 1, ICPPFunction.class);
@@ -2234,6 +2306,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    	foo(a);
 	//    	bar(ca);
 	//    }
+	@Test
 	public void testBug214646() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 
@@ -2266,6 +2339,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  func(a1);
 	//	  func(a2);
 	//	}
+	@Test
 	public void testFunctionTemplate_245049a() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPFunction b0 = bh.assertNonProblem("func(a1)", 4, ICPPFunction.class);
@@ -2289,6 +2363,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  func(a1);
 	//	  func(a2);
 	//	}
+	@Test
 	public void testFunctionTemplate_245049b() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPFunction b0 = bh.assertNonProblem("func(a1)", 4, ICPPFunction.class);
@@ -2312,6 +2387,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// using ns::pair;
 	// using ns::make_pair;
 	// pair<int, int> p = make_pair(1, 2);
+	@Test
 	public void testFunctionTemplateWithUsing() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		bh.assertNonProblem("make_pair(1", 9, ICPPFunction.class);
@@ -2321,6 +2397,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void main() {
 	//    f(1);
 	// }
+	@Test
 	public void testFunctionTemplateImplicitInstantiation() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -2342,6 +2419,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo(+[]() {});
 	//	}
+	@Test
 	public void testFunctionTemplateWithLambdaArgument_443361() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -2359,6 +2437,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(B x) {
 	//	  f(a(x));
 	//	}
+	@Test
 	public void testFunctionTemplate_264963() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		bh.assertNonProblem("f(a(x));", 1, ICPPFunction.class);
@@ -2374,6 +2453,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  f(&A::m);
 	//	}
+	@Test
 	public void testFunctionTemplate_266532() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		bh.assertNonProblem("f(&A::m);", 1, ICPPFunction.class);
@@ -2390,6 +2470,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(A<B> p) {
 	//	  f(p);
 	//	}
+	@Test
 	public void testFunctionTemplate_272848a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -2406,6 +2487,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(A<int*> p) {
 	//	  f(p);
 	//	}
+	@Test
 	public void testFunctionTemplate_272848b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -2419,6 +2501,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(int* x) {
 	//	  f<int>(x);
 	//	}
+	@Test
 	public void testFunctionTemplate_309564() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -2428,6 +2511,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  f1(&f2);
 	//	}
+	@Test
 	public void testSimplifiedFunctionTemplateWithFunctionPointer_281783() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -2445,6 +2529,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(A<B> x) {
 	//	  f1(x, &f2);
 	//	}
+	@Test
 	public void testFunctionTemplateWithFunctionPointer_281783() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		bh.assertNonProblem("f1(x, &f2);", 2, ICPPFunction.class);
@@ -2471,6 +2556,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//            // foo -> CPPMethodTemplateSpecialization
 	//            // foo<int,int> -> CPPMethodInstance
 	//    }
+	@Test
 	public void testCPPConstructorTemplateSpecialization() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
@@ -2493,6 +2579,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template<class T> const T& (max)(const T& lhs, const T& rhs) {
 	//    return (lhs < rhs ? rhs : lhs);
 	// }
+	@Test
 	public void testNestedFuncTemplatedDeclarator_bug190241() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
@@ -2542,6 +2629,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// };
 	//
 	// void f(B<int>::tb r) {}
+	@Test
 	public void testTemplateTypedef_214447() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
@@ -2576,6 +2664,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// };
 	//
 	// void f(Vec<int>::reference r) {}
+	@Test
 	public void testRebindPattern_214447a() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
@@ -2616,6 +2705,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// };
 	//
 	// void f(Vec<int>::reference r) {}
+	@Test
 	public void testRebindPattern_214447b() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
@@ -2655,6 +2745,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// };
 	//
 	// void f(map<int>::value_type r) {}
+	@Test
 	public void testRebindPattern_236197() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
@@ -2687,6 +2778,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// };
 	//
 	// void main(Iter<int*>::iter_reference r);
+	@Test
 	public void testSpecializationSelection_229218() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
@@ -2713,6 +2805,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	struct B<T, typename A<T>::type> {};
 	//
 	//	typename B<A<int>, int>::type a;
+	@Test
 	public void testSpecializationSelection_509255a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -2729,6 +2822,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  A<char> a;
 	//	  waldo(a, 1);
 	//	}
+	@Test
 	public void testSpecializationSelection_509255b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -2800,6 +2894,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo(f([]() {}));
 	//	}
+	@Test
 	public void testSpecializationSelection_509255c() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -2817,6 +2912,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// };
 	//
 	// B<int>::b::a x;
+	@Test
 	public void testDefaultTemplateParameter() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
@@ -2847,6 +2943,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	A<char> x;
 	//  AI<char> y;
 	//  AT<char> z;
+	@Test
 	public void testDefaultTemplateParameter_281781() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -2867,6 +2964,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    	D<A> d;
 	//    	foo(d);
 	//    }
+	@Test
 	public void testUserDefinedConversions_224364() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPFunction fn = bh.assertNonProblem("foo(d)", 3, ICPPFunction.class);
@@ -2887,6 +2985,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    	D<B> d;
 	//    	foo(d);
 	//    }
+	@Test
 	public void testUserDefinedConversions_224364a() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPFunction fn = bh.assertNonProblem("foo(d)", 3, ICPPFunction.class);
@@ -2910,6 +3009,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    Z foo(Z z) {return z;}
 	//
 	//    Z z= foo(*new E<Z>());
+	@Test
 	public void testUserDefinedConversions_224364b() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPFunction fn = bh.assertNonProblem("foo(*new", 3, ICPPFunction.class);
@@ -2934,6 +3034,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    	C<X> cx;
 	//    	foo(cx);
 	//    }
+	@Test
 	public void testUserDefinedConversions_226231() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPFunction fn = bh.assertNonProblem("foo(cx", 3, ICPPFunction.class);
@@ -2953,6 +3054,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void ref(C<T> c) {
 	//	 return foo(c);
 	//	}
+	@Test
 	public void testUserDefinedConversions_239023() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ba.assertNonProblem("foo(c);", 3);
@@ -2963,6 +3065,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	const int i= 1;
 	//	A<i> a1;
+	@Test
 	public void testNonTypeArgumentIsIDExpression_229942a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -2982,6 +3085,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//     const int i= 1;
 	//  };
+	@Test
 	public void testNonTypeArgumentIsIDExpression_229942b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -2996,6 +3100,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	const int i= 1;
 	//	A<i+1> a1;
+	@Test
 	public void testExpressionArgumentIsExpression_229942() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -3011,6 +3116,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	const int i= 1;
 	//	A<typeid(1)> a1;
+	@Test
 	public void testTypeIdOperatorArgumentIsUnaryExpression_229942() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -3024,6 +3130,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template<class T1, class T2> class A {};
 	// template< class T1, class T2, int q1, int q2>
 	// class A< C<T1, q1>, C<T2, q2> > {};
+	@Test
 	public void testTemplateIdAsTemplateArgumentIsTypeId_229942() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -3054,6 +3161,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	inline const A<T> foo(const A<T> at) {
 	//		return at;
 	//	}
+	@Test
 	public void testTypeIdAsTemplateArgumentIsTypeId_229942a() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ba.assertNonProblem("T> at) {", 1);
@@ -3077,6 +3185,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template <class T>
 	//	inline const void foo(void (*f)(A<i>), T* t) { // disallowed, but we're testing the AST
 	//	}
+	@Test
 	public void testTypeIdAsTemplateArgumentIsTypeId_229942b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		NameCollector col = new NameCollector();
@@ -3093,6 +3202,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	typedef int td;
 	//	template<> class Alias<td const *> {
 	//	};
+	@Test
 	public void testNonAmbiguityCase_229942() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		NameCollector col = new NameCollector();
@@ -3119,6 +3229,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	C c1;   // OK since C++17 via implicit deduction guide using default template argument
 	//	C<> c2; // ok - default args
+	@Test
 	public void testMissingTemplateArgumentLists() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ba.assertProblem("B b1", 1);
@@ -3136,6 +3247,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<class T1,int N> inline void TestClass<T1,N>::fun1(void) {
 	//		member1 = 0;
 	//	}
+	@Test
 	public void testDefinitionOfClassTemplateWithNonTypeParameter() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPMethod f1 = ba.assertNonProblem("fun1(void);", 4, ICPPMethod.class);
@@ -3162,6 +3274,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void ref() {
 	//		A<short>::B<> b;
 	//	}
+	@Test
 	public void testNestedTemplateDefinitionParameter() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPTemplateTypeParameter T3a = ba.assertNonProblem("T3 f", 2, ICPPTemplateTypeParameter.class);
@@ -3178,6 +3291,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	A<B, 0>::X x;
 	//	A<B, 1>::Y y;
 	//	A<B, 2>::Z z;
+	@Test
 	public void testNonTypeArgumentDisambiguation_233460() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPClassType b2 = ba.assertNonProblem("A<B, 0>", 7, ICPPClassType.class, ICPPTemplateInstance.class);
@@ -3207,6 +3321,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	A<B, true>::X x; //3 should be an error
 	//	A<B, false>::Y y; //4 should be an error
+	@Test
 	public void testNonTypeBooleanArgumentDisambiguation() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 
@@ -3238,6 +3353,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		bar(t);
 	//		baz();
 	//	}
+	@Test
 	public void testBug207871() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 
@@ -3269,6 +3385,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	public:
 	//		C<y> go();
 	//	};
+	@Test
 	public void testDeferredNonTypeArgument() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPDeferredClassInstance ci = ba.assertNonProblem("C<y>", 4, ICPPDeferredClassInstance.class);
@@ -3281,6 +3398,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	class A {};
 	//
 	//	A<int> aint; // should be an error
+	@Test
 	public void testTypeArgumentToNonTypeParameter() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ba.assertProblem("A<int>", 6);
@@ -3301,6 +3419,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template <int I>
 	//	inline This<I>::This() : That<I>(I) {
 	//	}
+	@Test
 	public void testParameterReferenceInChainInitializer_a() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 
@@ -3334,6 +3453,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template <typename I>
 	//	inline This<I>::This() : That<I>() {
 	//	}
+	@Test
 	public void testParameterReferenceInChainInitializer_b() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 
@@ -3356,6 +3476,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// class A {};
 	//
 	// C<A,5L> ca5L;
+	@Test
 	public void testIntegralConversionInPartialSpecializationMatching_237914() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPTemplateInstance ctps = ba.assertNonProblem("C<A,5L>", 7, ICPPTemplateInstance.class, ICPPClassType.class);
@@ -3376,6 +3497,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void xx() {
 	//    ca5L.test= 0;
 	// }
+	@Test
 	public void testIntegralConversionInSpecializationMatching_237914() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPSpecialization ctps = ba.assertNonProblem("C<A,5L>", 7, ICPPSpecialization.class, ICPPClassType.class);
@@ -3404,6 +3526,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo(1);
 	//	}
+	@Test
 	public void testIntegralConversionOperator_495091a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -3430,6 +3553,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo(1);
 	//	}
+	@Test
 	public void testIntegralConversionOperator_495091b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -3444,6 +3568,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		public:
 	//			B(const B<T>& other) : A(other) {}
 	//	};
+	@Test
 	public void testChainInitializerLookupThroughDeferredClassBase() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ba.assertNonProblem("A(other", 1);
@@ -3459,6 +3584,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  typedef int INT;
 	//	  A<INT> x = waldo([](int data) { return false; });
 	//	}
+	@Test
 	public void testLambda_430428() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -3477,6 +3603,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//			B::foo(static_cast<A*>(t));
 	//		}
 	//	};
+	@Test
 	public void testMemberLookupThroughDeferredClassBase() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ba.assertNonProblem("foo(s", 3);
@@ -3492,6 +3619,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	typedef result<B>::type waldo;
+	@Test
 	public void testDependentBaseLookup_408314a() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ITypedef waldo = bh.assertNonProblem("waldo");
@@ -3514,6 +3642,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	typedef A<B>::result<int*>::type waldo;
+	@Test
 	public void testDependentBaseLookup_408314b() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ITypedef waldo = bh.assertNonProblem("waldo");
@@ -3536,6 +3665,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	typedef A<B>::result<B*>::type waldo;
+	@Test
 	public void testDependentBaseLookup_408314c() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ITypedef waldo = bh.assertNonProblem("waldo");
@@ -3553,6 +3683,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	inline int A<T>::bar() const {
 	//		return foo();
 	//	}
+	@Test
 	public void testMemberReferenceFromTemplatedMethodDefinition_238232() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ba.assertNonProblem("foo();", 3);
@@ -3578,6 +3709,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//			typedef detail::assoc_find<Sequence, T> filter;
 	//		};
 	//	}
+	@Test
 	public void testBug238180_ArrayOutOfBounds() throws Exception {
 		// The code above used to trigger an ArrayOutOfBoundsException
 		parse(getAboveComment(), CPP);
@@ -3597,6 +3729,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//			typedef A type;
 	//		};
 	//	} // detail
+	@Test
 	public void testBug238180_ClassCast() throws Exception {
 		// the code above used to trigger a ClassCastException
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
@@ -3619,6 +3752,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void bla(int g) {
 	//		test(new X(g));
 	//	}
+	@Test
 	public void testBug239586_ClassCast() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP);
 	}
@@ -3627,6 +3761,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		static int x;
 	//	};
 	//	template<typename T> int CT<T>::x = sizeof(T);
+	@Test
 	public void testUsingTemplParamInInitializerOfStaticField() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPTemplateTypeParameter t = ba.assertNonProblem("T)", 1, ICPPTemplateTypeParameter.class);
@@ -3651,6 +3786,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template <> struct Waldo<42> { typedef int type; };
 	//
 	//	Waldo<rounded::num>::type foo();  // ERROR
+	@Test
 	public void testDependentIdExprNamingStaticMember_508254() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -3697,6 +3833,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  cb.b = 6;
 	//	  func(cb);
 	//	}
+	@Test
 	public void testTemplateMetaProgramming_245027() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPMethod method = ba.assertNonProblem("method();", 6, ICPPMethod.class);
@@ -3723,6 +3860,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  int x;
 	//	  ns1::A<(sizeof(probe(x)) == 1)>::m(x);
 	//	}
+	@Test
 	public void testNonTypeTemplateParameter_252108() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), CPP);
 		ba.assertNonProblem("x))", 1, ICPPVariable.class);
@@ -3743,6 +3881,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    > > > > >
 	//    > > > > >
 	//    type;
+	@Test
 	public void testNestedArguments_246079() throws Throwable {
 		final Throwable[] th = { null };
 		Thread t = new Thread() {
@@ -3768,6 +3907,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	   void foo(T t);
 	//	};
 	//	template<class T> void A<T, int>::foo(T t) {}
+	@Test
 	public void testBug177418() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 
@@ -3806,6 +3946,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    template <class T, class U> T * CT<T, U>::instance (void) {
 	//    	return new CT<T, U>;
 	//    }
+	@Test
 	public void testNewOfThisTemplate() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP);
 	}
@@ -3814,6 +3955,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    class X {
 	//    	friend void f<>(int);
 	//    };
+	@Test
 	public void testFunctionSpecializationAsFriend() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -3841,6 +3983,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    template <typename T> typename XT<T>::mytype1 XT<T>::m1() {}
 	//    template <typename T> typename XT<T*>::mytype2 XT<T*>::m2() {}
 	//    XT<int>::mytype3 XT<int>::m3() {}
+	@Test
 	public void testMethodImplWithNonDeferredType() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -3866,6 +4009,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    	  template<typename T> void f(T);
 	//    };
 	//    template<typename T> void A<float>::f(T){}
+	@Test
 	public void testClassTemplateMemberFunctionTemplate_104262() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -3889,6 +4033,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    };
 	//    template<typename T> template <typename V> void XT<T>::Nested::m(V) {
 	//    }
+	@Test
 	public void testQualifiedMethodTemplate() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -3918,6 +4063,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo(1);
 	//	}
+	@Test
 	public void testMethodTemplate_497535a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -3940,6 +4086,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo(1);
 	//	}
+	@Test
 	public void testMethodTemplate_497535b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -3950,6 +4097,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//       XT<int> xt;
 	//       xt.partial;
 	//    }
+	@Test
 	public void testDefaultArgsWithPartialSpecialization() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -3961,6 +4109,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    		this->a= 1;
 	//    	}
 	//    };
+	@Test
 	public void testFieldReference_257186() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -3983,6 +4132,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    		f(b); g(b); h(b); m(b);
 	//    	}
 	//    };
+	@Test
 	public void testUnknownReferences_257194() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -4006,6 +4156,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//			v.x; v.y();
 	//    	}
 	//    };
+	@Test
 	public void testTypeOfUnknownReferences_257194a() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -4031,6 +4182,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//          v->x; v->y();
 	//    	}
 	//    };
+	@Test
 	public void testTypeOfUnknownReferences_257194b() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -4056,6 +4208,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//         typename T::F();
 	//      }
 	//    };
+	@Test
 	public void testTypeVsExpressionInArgsOfDependentTemplateID_257194() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -4094,6 +4247,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//  void test(B<A<int> >::reference p) {
 	//    func(p);
 	//  }
+	@Test
 	public void testTypedefReference_259871() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		bh.assertNonProblem("func(p)", 4, ICPPFunction.class);
@@ -4114,6 +4268,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  new C<B>(&B::m);
 	//	}
+	@Test
 	public void testTypedef() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4137,6 +4292,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  auto s2 = s1 += "";
 	//	  auto s3 = s2.append("foo");
 	//	}
+	@Test
 	public void testTypedefPreservation_380498a() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ICPPVariable s1 = ba.assertNonProblem("s1");
@@ -4161,6 +4317,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(const vector<Element>& v) {
 	//	  auto it = v.begin();
 	//	}
+	@Test
 	public void testTypedefPreservation_380498b() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ICPPVariable it = ba.assertNonProblem("it =", "it", ICPPVariable.class);
@@ -4202,6 +4359,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  for (auto s : v) {
 	//	  }
 	//	}
+	@Test
 	public void testTypedefPreservation_380498c() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ICPPVariable s = ba.assertNonProblem("s :", "s", ICPPVariable.class);
@@ -4222,6 +4380,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(A<const B> p) {
 	//	  p.waldo();
 	//	}
+	@Test
 	public void testTypeTraitWithQualifier_511143() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -4243,6 +4402,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//      new A<B, int>(&B::m);
 	//    }
 	//  };
+	@Test
 	public void testNestedTemplates_259872a() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		bh.assertNonProblem("A<B, int>", 9, ICPPClassType.class);
@@ -4268,6 +4428,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//      new A<B, int>(&B::m);
 	//    }
 	//  };
+	@Test
 	public void testNestedTemplates_259872b() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		bh.assertNonProblem("A<B, int>", 9, ICPPClassType.class);
@@ -4285,6 +4446,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    template <class T>
 	//    DumbPtr<T>::~DumbPtr/**/ () {
 	//    }
+	@Test
 	public void testCtorWithTemplateID_259600() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -4300,6 +4462,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    };
 	//    template <class T> template <class X> XT<T>::XT/**/(X* a) {}
 	//    template <class T> template <class X> XT<T>::XT<T>/**/(X& a) {}
+	@Test
 	public void testCtorTemplateWithTemplateID_259600() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -4324,6 +4487,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    void test() {
 	//    	XT<Derived>::TD x;
 	//    }
+	@Test
 	public void testResolutionOfUnknownBindings_262163() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -4358,6 +4522,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//  void test(BasicString<char> s) {
 	//    s.substr(0);
 	//  }
+	@Test
 	public void testResolutionOfUnknownBindings_262328() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		bh.assertNonProblem("substr(0)", 6, ICPPMethod.class);
@@ -4371,6 +4536,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//       field.m(c);
 	//    }
 	// };
+	@Test
 	public void testResolutionOfUnknownFunctions() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4383,6 +4549,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//       field[0].m(c);
 	//    }
 	// };
+	@Test
 	public void testResolutionOfUnknownArrayAccess() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4396,6 +4563,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    CT<char> x;
 	//    x.append(3, 'c');
 	// }
+	@Test
 	public void testConflictInTemplateArgumentDeduction() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -4417,6 +4585,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(const C& p) {
 	//	  p.m();
 	//	}
+	@Test
 	public void testConversionSequence_263159() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		ICPPMethod m = bh.assertNonProblem("m();", 1, ICPPMethod.class);
@@ -4437,6 +4606,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	A<C> make_A(C* p) {
 	//	  return A<C>(p);
 	//	}
+	@Test
 	public void testForwardDeclarations_264109() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		bh.assertNonProblem("A<C> make_A(C* p) {", 4, ICPPTemplateInstance.class);
@@ -4452,6 +4622,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		int* iptr;
 	//		any(CT<int>(iptr));
 	//	}
+	@Test
 	public void testConstructorTemplateInClassTemplate_264314() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4469,6 +4640,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    func(x, xint);
 	//	    func(y, xy, xint);
 	//	}
+	@Test
 	public void testDistinctDeferredInstances_264367() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4478,6 +4650,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//       m(0); // ok with a conversion from 0 to T
 	//    }
 	// };
+	@Test
 	public void testUnknownParameter_264988() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4489,6 +4662,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	int x = A<0>::e;
 	//	A<0>::E y;
+	@Test
 	public void testEnumeratorInTemplateInstance_265070() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4500,6 +4674,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		CT<int> i;
 	//		getline2(i);
 	//	}
+	@Test
 	public void testAmbiguousDeclaratorInFunctionTemplate_265342() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		bh.assertNonProblem("getline2(i)", 8, ICPPTemplateInstance.class);
@@ -4518,6 +4693,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//      };
 	//   };
 	// };
+	@Test
 	public void testOwnerOfFriendTemplate_265671() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		IFunction f = bh.assertNonProblem("f1(", 2, IFunction.class);
@@ -4551,6 +4727,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  f(a);
 	//	  a.m(a);
 	//	}
+	@Test
 	public void testOwnerOfFriendTemplateFunction_408181() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPFunction f = bh.assertNonProblemOnFirstIdentifier("f(a)");
@@ -4563,6 +4740,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     g(t);
 	// }
 	// template <typename T> void g(T t) {}
+	@Test
 	public void testDependentNameReferencingLaterDeclaration_265926a() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		IFunction gref = bh.assertNonProblem("g(t)", 1);
@@ -4588,6 +4766,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	class C {
 	//		void a() {};
 	//	};
+	@Test
 	public void testDependentNameReferencingLaterDeclaration_265926b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4599,6 +4778,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//       xt.operator T*()->something();
 	//    }
 	// };
+	@Test
 	public void testDeferredConversionOperator() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4612,6 +4792,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//			X<int> x;
 	//		}
 	//	};
+	@Test
 	public void testFriendClassTemplate_266992() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4623,6 +4804,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  S(a);
 	//	}
+	@Test
 	public void testFunctionTemplateWithArrayReferenceParameter_269926() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4635,6 +4817,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  S(a);
 	//	}
+	@Test
 	public void testFunctionTemplateWithArrayReferenceParameter_394024() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4652,6 +4835,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(B p) {
 	//	  f(p);
 	//	}
+	@Test
 	public void testTemplateConversionOperator_271948a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4671,6 +4855,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(B<int> x) {
 	//	  f(x);
 	//	}
+	@Test
 	public void testTemplateConversionOperator_271948b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4689,6 +4874,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	Mat x = MatExpr();
+	@Test
 	public void testOverloadedConversionOperators_550397() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -4696,6 +4882,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<unsigned int> struct ST{};
 	//	template<template<unsigned int> class T> class CT {};
 	//	typedef CT<ST> TDef;
+	@Test
 	public void testUsingTemplateTemplateParameter_279619() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4705,6 +4892,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  int a[2];
 	//	  T<2>(a);
 	//	}
+	@Test
 	public void testInstantiationOfArraySize_269926() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4714,6 +4902,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//	void CT<int>::init(void) {
 	//	}
+	@Test
 	public void testMethodSpecialization_322988() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4775,6 +4964,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  waldo(X());
 	//	  waldo(Y());
 	//	}
+	@Test
 	public void testInheritedConstructor_489710() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4788,6 +4978,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(A<int> x) {
 	//	  f(x);
 	//	}
+	@Test
 	public void testInlineFriendFunction_284690() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4806,6 +4997,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(A<int> x) {
 	//	  f(x);
 	//	}
+	@Test
 	public void testInlineFriendFunction_287409() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -4826,6 +5018,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<> struct CreateTL<NullType, NullType> {
 	//	   typedef NullType Type;
 	//	};
+	@Test
 	public void testDefaultArgument_289132() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4838,6 +5031,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//			n();  // must be a problem
 	//		}
 	//	};
+	@Test
 	public void testResolutionOfNonDependentNames_293052() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -4863,6 +5057,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		f4(i);
 	//		f3(&cd);  // must be a problem, cd is const
 	//	}
+	@Test
 	public void testArgumentDeduction_293409() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -4885,6 +5080,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		f(ch, cchar);
 	//		f(ch, cint);
 	//	}
+	@Test
 	public void testFunctionTemplateOrdering_293468() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4902,6 +5098,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  const int* a;
 	//	  func1  (a);
 	//	}
+	@Test
 	public void testFunctionTemplateOrdering_294539() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4913,6 +5110,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    foo(0);
 	//	}
+	@Test
 	public void testFunctionTemplateOrdering_DR1395_388805() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -4939,6 +5137,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    foo<int>(0);  // ERROR HERE
 	//	}
+	@Test
 	public void testFunctionTemplateOrdering_409094a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4968,6 +5167,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    waldo w;
 	//	    foo<waldo>(w);  // ERROR HERE
 	//	}
+	@Test
 	public void testFunctionTemplateOrdering_409094b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4981,6 +5181,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		a= 1 >> 2;
 	//		return a;
 	//	}
+	@Test
 	public void testClosingAngleBrackets1_261268() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -4993,6 +5194,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		a= 1 > > 3;         // must be syntax error
 	//		return a;
 	//	}
+	@Test
 	public void testClosingAngleBrackets2_261268() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.GNU, false);
@@ -5010,6 +5212,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//      y= a < a >> (1+2);	    // binary expression
 	//      a < a >> (1+2);	   		// binary expression via ambiguity
 	//	}
+	@Test
 	public void testClosingAngleBracketsAmbiguity_261268() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5019,6 +5222,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		int a=1;
 	//      a OPASSIGN(>>) 1;
 	//	}
+	@Test
 	public void testTokenPasteShiftROperator_261268() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5031,6 +5235,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	                    // X<int&>::g has the parameter type int&
 	//	X<const int&&> x2;  // X<const int&&>::f has the parameter type const int&
 	//	                    // X<const int&&>::g has the parameter type const int&&
+	@Test
 	public void testRValueReferences_294730() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -5060,6 +5265,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//  template<typename... Pack> void f5(Pack ...);
 	//  template<typename NonPack> void f6(NonPack ...);
 	//  template<typename... T> void f7() throw(T...);
+	@Test
 	public void testFunctionParameterPacks_280909() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -5089,6 +5295,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<typename... Pack> class C1 {};
 	//	template<template<typename... NP> class... Pack> class C2 {};
 	//	template<int... Pack> class C3 {};
+	@Test
 	public void testTemplateParameterPacks_280909() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -5118,6 +5325,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		c.b= 1;
 	//		c.mem();
 	//	}
+	@Test
 	public void testParameterPackExpansions_280909() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -5134,6 +5342,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 
 	//	template<typename... T> void f1(T*...);
 	//	template<typename T> void f2(T*...);
+	@Test
 	public void testTemplateParameterPacksAmbiguity_280909() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -5153,6 +5362,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		CTx<1> b;
 	//		CTx<1,2> c;
 	//	}
+	@Test
 	public void testNonTypeTemplateParameterPack_280909() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5160,6 +5370,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<typename... Types>
 	//	struct count { static const int value = sizeof...(Types);
 	//	};
+	@Test
 	public void testVariadicTemplateExamples_280909a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5170,6 +5381,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void g() {
 	//		f(add, subtract);
 	//	}
+	@Test
 	public void testVariadicTemplateExamples_280909b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5179,12 +5391,14 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	{public:
 	//	X(const Mixins&... mixins) : Mixins(mixins)... { }
 	//	};
+	@Test
 	public void testVariadicTemplateExamples_280909c() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	template<class... Types> class Tuple; // Types is a template type parameter pack
 	//	template<class T, int... Dims> struct multi array; // Dims is a non-type template parameter pack
+	@Test
 	public void testVariadicTemplateExamples_280909d() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5195,6 +5409,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<typename ... Elements> class Tuple;
 	//	Tuple<>* t; // OK: Elements is empty
 	//	Tuple* u; // syntax error
+	@Test
 	public void testVariadicTemplateExamples_280909e() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -5215,6 +5430,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	Y<A> ya; // okay
 	//	Y<B> yb; // okay
 	//	Y<C> yc; // okay
+	@Test
 	public void testVariadicTemplateExamples_280909f() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -5238,6 +5454,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<class T2, class T1> void A<T1,T2>::f2() {} // error
 	//	template<class... Types> void B<Types...>::f3() {} // OK
 	//	template<class... Types> void B<Types>::f4() {} // error
+	@Test
 	public void testVariadicTemplateExamples_280909g() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -5259,6 +5476,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  int k = g<int>(5.6); 		// Y is deduced to be double, Z is deduced to an empty sequence
 	//	  f<void>(g<int, bool>); 	// Y for outer f deduced to be
 	//  }							// int (*)(bool), Z is deduced to an empty sequence
+	@Test
 	public void testVariadicTemplateExamples_280909h() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -5280,6 +5498,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//   f("aa",3.0); 					// error: X cannot be deduced
 	//   f2<char, short, int, long>(); 	// okay
 	// }
+	@Test
 	public void testVariadicTemplateExamples_280909i() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -5294,6 +5513,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void g() {
 	//		f<int*, float*>(0, 0, 0); // Types is the sequence int*, float*, int
 	//	}
+	@Test
 	public void testVariadicTemplateExamples_280909j() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5305,6 +5525,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  f(x, y, z); // Types is deduced to int, float, const int
 	//	  g(x, y, z); // T1 is deduced to int, Types is deduced to float, int
 	//	}
+	@Test
 	public void testVariadicTemplateExamples_280909k() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5322,6 +5543,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	Y<int&, float&, double&> y2; // uses partial specialization. T is int&, Types contains float, double
 	//	Y<int, float, double> y3; // uses primary template, Types contains int, float, double
 	//	int fv = f(g); // okay, Types contains int, float
+	@Test
 	public void testVariadicTemplateExamples_280909n() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5333,6 +5555,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  Tuple<int, float> t2; // Types contains two arguments: int and float
 	//	  Tuple<0> error; // Error: 0 is not a type
 	// }
+	@Test
 	public void testVariadicTemplateExamples_280909p() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -5348,6 +5571,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  f(1); // okay: args contains one int argument
 	//	  f(2, 1.0); // okay: args contains two arguments, an int and a double
 	// }
+	@Test
 	public void testVariadicTemplateExamples_280909q() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5356,6 +5580,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<typename... Types> void g(Types... rest) {
 	//	   f(&rest...); // '&rest...' is a pack expansion, '&rest' is its pattern
 	//	}
+	@Test
 	public void testVariadicTemplateExamples_280909r() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5380,6 +5605,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  f(args); // error: parameter pack 'args' is not expanded
 	//	  f(h(args...) + args...); // okay: first 'args' expanded within h, second 'args' expanded within f.
 	//	}
+	@Test
 	public void testVariadicTemplateExamples_280909s() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -5413,6 +5639,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    bool b2 = contains_waldo<int, int>::value;
 	//	    bool b2 = contains_waldo<int, int, int>::value;
 	//	}
+	@Test
 	public void testRecursiveVariadicTemplate_397828() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5423,6 +5650,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	int x = A<>::waldo(0);
+	@Test
 	public void testVariadicTemplateWithNoArguments_422700() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5436,6 +5664,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//		bind(&Test::Update);
 	//	}
+	@Test
 	public void testFunctionOrdering_299608() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5448,6 +5677,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//        f<int>();          // f<int,double>(0,0)
 	//        f<int,char>();     // f<int,char>(0,0)
 	//    }
+	@Test
 	public void testDefaultTemplateArgsForFunctionTemplates_294730() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -5465,6 +5695,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 
 	//	template<typename T> class CT {};
 	//	extern template class CT<int>;
+	@Test
 	public void testExternTemplates_294730() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code);
@@ -5486,6 +5717,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	eval<C<17>> eC; // error: C does not match TT in partial specialization
 	//	eval<D<int, 17>> eD; // error: D does not match TT in partial specialization
 	//	eval<E<int, float>> eE; // error: E does not match TT in partial specialization
+	@Test
 	public void testExtendingVariadicTemplateTemplateParameters_302282() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -5520,6 +5752,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    f(1);
 	//    g(1);
 	// }
+	@Test
 	public void testExplicitSpecializations_296427() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -5545,6 +5778,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//	CT<int>::CT() :	value_(0) {
 	//	}
+	@Test
 	public void testConstructorOfExplicitSpecialization() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5559,6 +5793,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  func<int>(1);
 	//	}
+	@Test
 	public void testBug306213a() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -5575,6 +5810,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  func<int*>(1);
 	//	}
+	@Test
 	public void testBug306213b() throws Exception {
 		CPPASTNameBase.sAllowRecursionBindings = true;
 		final String code = getAboveComment();
@@ -5593,6 +5829,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		CT<int>::T1 a;
 	//		CT<const int>::T2 b;
 	//	}
+	@Test
 	public void testBug306213c() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5600,6 +5837,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<typename T1, typename T2> class CT {};
 	//	template<> class CT<int,char> {};
 	//	template<> class CT<char,char> {};
+	@Test
 	public void testBug311164() throws Exception {
 		CPPASTNameBase.sAllowNameComputation = true;
 		final String code = getAboveComment();
@@ -5630,6 +5868,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// NOTE: If, after refactoring some AST code, this test hangs, check
 	//		 if any methods that were added during the refactoring need
 	//		 to be added to ASTComparer.methodsToIgnore.
+	@Test
 	public void testBug316704() throws Exception {
 		StringBuilder code = new StringBuilder("typedef if_< bool,");
 		for (int i = 0; i < 50; i++) {
@@ -5658,6 +5897,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	A<int> a;
 	//
 	//	}
+	@Test
 	public void testBug377838() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5673,6 +5913,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	template void N::f<int>(int&);
 	//	template<> void N::f<long>(long&) {}
+	@Test
 	public void testInlineNamespaces_305980() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -5709,6 +5950,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		class X {} x;
 	//		g(x);
 	//	}
+	@Test
 	public void testUnnamedTypesAsTemplateArgument_316317a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5728,6 +5970,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		f(unnamed_obj); // OK
 	//		f(b); // OK
 	//	}
+	@Test
 	public void testUnnamedTypesAsTemplateArgument_316317b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5744,6 +5987,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		X x;
 	//		(x + 1)->s;
 	//	}
+	@Test
 	public void testOverloadResolutionBetweenMethodTemplateAndFunction() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5758,6 +6002,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int x = sizeof(f(c));
 	//  const int d[] = { 0 };
 	//	int y = sizeof(f(d));
+	@Test
 	public void testOverloadedFunctionTemplate_407579() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5766,6 +6011,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  f(1,1);
 	//	}
+	@Test
 	public void testFunctionParameterPacksInNonFinalPosition_324096() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5779,6 +6025,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		OutStream<char> out;
 	//		out << endl;
 	//	}
+	@Test
 	public void testInstantiationOfEndl_297457() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code);
@@ -5808,6 +6055,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    ostream<char> out;
 	//	    out << t << endl;
 	//	}
+	@Test
 	public void testInstantiationOfEndlInTemplate_417700() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5818,6 +6066,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	    sort(MySort<int>);
 	//	}
+	@Test
 	public void testAdressOfUniqueTemplateInst_326076() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5833,6 +6082,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  f(g, '1');
 	//	  f(g, 1);
 	//	}
+	@Test
 	public void testInstantiationOfFunctionTemplateWithOverloadedFunctionSetArgument_326492() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -5863,6 +6113,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  Ptr<ns::T> parm;
 	//	  f(parm);
 	//	}
+	@Test
 	public void testADLForTemplateSpecializations_327069() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5873,6 +6124,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void x(int* (*) (int*)) {
 	//	  x(f);
 	//	}
+	@Test
 	public void testPartialOrderingInNonCallContext_326900() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5885,6 +6137,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  X x;
 	//	  y(x);
 	//	}
+	@Test
 	public void testPartialOrderingForConversions_326900() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5901,6 +6154,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		  L<S>::CI l;
 	//		  l.m().foo = 1;
 	//	}
+	@Test
 	public void testNestedTypedefSpecialization_329795() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -5923,6 +6177,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  TestImpl::Inner2* ptr2=ptr1->ptr2;
 	//	  func(ptr2->ptr1);
 	//	}
+	@Test
 	public void testSpecializationViaNotDirectlyEnclosingTemplate_333186() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5936,6 +6191,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	struct C {};
 	//	template <class C& c> class Z{};
+	@Test
 	public void testNonTypeTemplateParameterWithTypenameKeyword_333186() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5943,6 +6199,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template <typename T, typename U = int> void f() {
 	//	    f<int>();
 	//	}
+	@Test
 	public void testDefaultTmplArgumentOfFunctionTemplate_333325() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5950,6 +6207,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template <void (*Func)()> class X {};
 	//	template <typename T> void Y();
 	//	X< Y<int> > x;
+	@Test
 	public void testFunctionInstanceAsTemplateArg_333529() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5976,6 +6234,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  P(C());
 	//	}
+	@Test
 	public void testFunctionInstanceAsTemplateArg_334472() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -5986,6 +6245,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    g<int>();
 	//	    g<int, int>();
 	//	}
+	@Test
 	public void testFunctionTemplateSignatures_335062() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6008,6 +6268,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void g() {
 	//		function(0);  // ERROR HERE
 	//	}
+	@Test
 	public void testSyntaxErrorInReturnTypeOfFunctionInstance_336426() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6016,6 +6277,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template <typename Functor> void f(Functor functor) {
 	//	    A<decltype(functor())> a;
 	//	}
+	@Test
 	public void testFunctionCallOnDependentName_337686() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6025,6 +6287,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  auto* b = a->f;
 	//	  b->g;
 	//	}
+	@Test
 	public void testDependentNameWithAuto_407480() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6037,6 +6300,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    h(s, 1);
 	//	    h(s, 1, 2);
 	//	}
+	@Test
 	public void testVariadicFunctionTemplate_333389() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6051,6 +6315,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  g(v1);
 	//	  g(v2);
 	//	}
+	@Test
 	public void testFunctionWithVoidParamInTypeDeduction() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6068,6 +6333,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    A(this, &B::m1);
 	//	  }
 	//	};
+	@Test
 	public void testFunctionWithVoidParamInTypeDeduction_423127() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6087,6 +6353,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	  waldo(A());
 	//	}
+	@Test
 	public void testAddressOfMethodTargeted_509396() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6105,6 +6372,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo(A());
 	//	}
+	@Test
 	public void testAddressOfMethodUntargeted_509396() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6127,6 +6395,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//      iFive.e= 0;
 	//		return 0;
 	//	}
+	@Test
 	public void testPartialSpecAfterExplicitInst_339475() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6144,6 +6413,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    S<1 && 2>::m();        // m is member of S
 	//	    s<1 && 2>::f();        // f is global
 	//	}
+	@Test
 	public void testTemplateIDAmbiguity_341747a() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings();
 		IASTFunctionDefinition fdef = getDeclaration(tu, 4);
@@ -6170,6 +6440,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	template<typename B= A<b>> struct T {};
 	//	struct Y : T<A<b>> {};
+	@Test
 	public void testTemplateIDAmbiguity_341747b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6183,6 +6454,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		S< a<b >::a;
 	//		a < S<bl>::a;
 	//	}
+	@Test
 	public void testTemplateIDAmbiguity_341747c() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6196,6 +6468,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		S* a=0;
 	//		a->B<c && c>::c;
 	//	}
+	@Test
 	public void testTemplateIDAmbiguity_341747d() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6213,6 +6486,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    ft(&Foo::function);
 	//	    return 0;
 	//	}
+	@Test
 	public void testAddressOfMethodForInstantiation_344310() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6227,6 +6501,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int test() {
 	//	    Subscribe(Callback<const int>(&CallMe)); // invalid arguments, symbol not
 	//	}
+	@Test
 	public void testParameterAdjustementInInstantiatedFunctionType_351609() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6245,11 +6520,13 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    CT<int&>::ref;
 	//    CT<int&&>::rref;
 	// }
+	@Test
 	public void testRRefVsRef_351927() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	template <typename = int> class A {};
+	@Test
 	public void testTemplateParameterWithoutName_352266() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6265,6 +6542,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	typedef CTTP<CT2> b;
 	//	typedef CTTP<CT3> c;
 	//	typedef CTTP<CT4> d;
+	@Test
 	public void testTemplateTemplateParameterMatching_352859() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6273,6 +6551,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<> int f() {
 	//	    return 0;
 	//	}
+	@Test
 	public void testArgumentDeductionFromReturnTypeOfExplicitSpecialization_355304() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
@@ -6292,6 +6571,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<typename T2> class B<int, T2> {};
 	//	template<> class B<int, int> {};
 	//  B<int, int> fooB();
+	@Test
 	public void testExplicitSpecializationOfForbiddenAsImplicit_356818() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6317,6 +6597,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		c.f(1);
 	//		c.f(1,1);
 	//	}
+	@Test
 	public void testSpecializationOfUsingDeclaration_357293() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6324,6 +6605,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<typename T> struct SS {};
 	//	template<template<typename T, typename S = SS<T> > class Cont>
 	//   	   Cont<int> f() {}
+	@Test
 	public void testReferenceToParameterOfTemplateTemplateParameter_357308() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6333,6 +6615,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	     f();
 	//	     f<>();
 	//	}
+	@Test
 	public void testTemplateArgumentDeductionWithoutParameters_358654() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6361,6 +6644,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo([]() { return B<A>(); }());
 	//	}
+	@Test
 	public void testTemplateArgumentDeductionWithFunctionSet_501549() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6384,6 +6668,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	typedef C<sizeof(char) == sizeof(C8), B> r;
 	//	typedef r::s t;
 	//	t::u x;
+	@Test
 	public void testBoolExpressionAsTemplateArgument_361604() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6396,6 +6681,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		void m();
 	//	};
 	//	template<typename T> void C<T>::m() {}
+	@Test
 	public void testDependentUsingDeclaration() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6440,6 +6726,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  ns::C<IsAorB<int>::value> a;
 	//	  f(a);
 	//	};
+	@Test
 	public void testDependentExpressions_a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6465,6 +6752,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	B<int>::pointer a;
+	@Test
 	public void testDependentExpressions_b() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
@@ -6479,6 +6767,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    if (T* i = foo<0>(0))
 	//	        return;
 	//	}
+	@Test
 	public void testDirectlyNestedAmbiguity_362976() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6501,6 +6790,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main(){
 	//		return MaxOfN<int,1,2>::result;
 	//	}
+	@Test
 	public void testNestedTemplateAmbiguity_363609() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6512,6 +6802,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//		B<A> b1;
 	//	}
+	@Test
 	public void testDefaultArgForNonTypeTemplateParameter_363743() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6534,6 +6825,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		delete C< a<b >::ptr;
 	//		delete C< A<B>::b >::ptr;
 	//	}
+	@Test
 	public void testTemplateAmbiguityInDeleteExpression_364225() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6541,6 +6833,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<int, int> struct a {};
 	//	const int b = 0, c = 1;
 	//	int a<b<c,b<c>::*mp6;  // syntax error here
+	@Test
 	public void testTemplateIDAmbiguity_445177() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6564,6 +6857,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	template<int I>
 	//	using W = typename EnableIf<(I < TupleSize<Tuple<int>>::value), int>::type;
+	@Test
 	public void testTemplateIDAmbiguity_497668() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6573,6 +6867,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//		foo(0);
 	//	}
+	@Test
 	public void testSyntaxFailureInstantiatingFunctionTemplate_365981a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6582,6 +6877,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	    bar(0);
 	//	}
+	@Test
 	public void testSyntaxFailureInstantiatingFunctionTemplate_365981b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6594,6 +6890,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	        }
 	//	    }
 	//	};
+	@Test
 	public void testResolvingAutoTypeWithDependentExpression_367472() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6611,6 +6908,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	vector v;
 	//	auto x1 = begin1(v);
 	//	auto x2 = begin2(v);
+	@Test
 	public void testResolvingAutoTypeWithDependentExpression_402409a() throws Exception {
 		BindingAssertionHelper helper = new AST2AssertionHelper(getAboveComment(), true);
 		helper.assertVariableType("x1", CommonCPPTypes.pointerToInt);
@@ -6633,6 +6931,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    begin1(v);
 	//	    begin2(v);
 	//	}
+	@Test
 	public void testResolvingAutoTypeWithDependentExpression_402409b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6642,6 +6941,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    foo(1,2,args...);
 	//	    foo(args...);
 	//	}
+	@Test
 	public void testPackExpansionsAsArguments_367560() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6654,6 +6954,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main()  {
 	//	    A<void (S::*)()> m;
 	//	}
+	@Test
 	public void testDeductionForConstFunctionType_367562() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6665,6 +6966,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template <typename B> struct derived<int, B> : public base<B> {
 	//	    typedef typename derived::type type;  // ERROR HERE
 	//	};
+	@Test
 	public void testTemplateShortNameInQualifiedName_367607() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
@@ -6678,6 +6980,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    typedef int type;
 	//	};
 	//	typedef B<A<int> >::type type;  // ERROR HERE
+	@Test
 	public void testPartialClassTemplateSpecUsingDefaultArgument_367997() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6688,6 +6991,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template <int> struct foo {};
 	//	template <> struct foo<1> { typedef int type; };
 	//	typedef foo<sizeof(check(0))>::type t;  // ERROR HERE
+	@Test
 	public void testValueForSizeofExpression_368309() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6713,6 +7017,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    auto e = *cur;
 	//	    e.x;            // ERROR HERE: "Field 'x' could not be resolved"
 	//	}
+	@Test
 	public void testAutoTypeWithTypedef_368311() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		IVariable v = bh.assertNonProblem("cur = r.begin()", 3);
@@ -6734,6 +7039,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    auto s = *it;
 	//	    s.x;  // ERROR HERE: "Field 'x' could not be resolved"
 	//	}
+	@Test
 	public void testSpecializationOfClassType_368610a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6752,6 +7058,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    auto s = *it;
 	//	    s.x;  // ERROR HERE: "Field 'x' could not be resolved"
 	//	}
+	@Test
 	public void testSpecializationOfClassType_368610b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6766,6 +7073,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		CT<int> x;
 	//		x.someFunc().y;
 	//	}
+	@Test
 	public void testSpecializationOfClassType_368610c() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6785,6 +7093,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	typedef B<int>::result::type waldo;
+	@Test
 	public void testSpecializationOfBaseClass_409078() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ITypedef waldo = bh.assertNonProblem("waldo");
@@ -6802,6 +7111,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	B<const A> a(&A::m);
+	@Test
 	public void testConstInTypeParameter_377223() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6850,6 +7160,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	typedef A<C> type;
+	@Test
 	public void testSfinae_a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6882,6 +7193,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  A<double>::get();
 	//	  A<int>::get();
 	//	}
+	@Test
 	public void testSfinae_b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -6911,6 +7223,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// int *ip = nullptr;
 	// B b1 { ip };
 	// B::p jp = nullptr;
+	@Test
 	public void testSfinae_c() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 
@@ -6946,6 +7259,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	// int b1 = C<marker>().ccc1;
 	// C<marker>::t b2;
+	@Test
 	public void testSfinae_d() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 
@@ -6974,6 +7288,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  f<int>();
 	//	}
+	@Test
 	public void testIsPOD_367993() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -6997,6 +7312,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		A<B, &B::Method> a; /* no error this line */
 	//		c.callDelegate(a); /* Invalid arguments 'Candidates are: void callDelegate(A<#0,#1> &)' */
 	//	}
+	@Test
 	public void testDeductionOfNonTypeTemplateArg_372587() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -7007,6 +7323,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//		b(f<int*, int>);
 	//	}
+	@Test
 	public void testFunctionSetWithNonMatchingTemplateArgs_379604() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -7023,6 +7340,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		C<X>::dtm v;
 	//		f(v);
 	//	}
+	@Test
 	public void testPointerToMemberAsDependentExpression_391001() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -7038,6 +7356,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	struct C {};
 	//
 	//	typedef C<&B::x> T;
+	@Test
 	public void testPointerToMemberOfTemplateClass_402861() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7053,6 +7372,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	List<N>::Base<&N::node> base;
+	@Test
 	public void testDependentTemplateParameterInNestedTemplate_407497() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7066,6 +7386,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	typedef enclosing<int>::nested<>::type waldo;
+	@Test
 	public void testDependentTemplateParameterInNestedTemplate_399454() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7081,6 +7402,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    Container<&memory>::iterator it;
 	//	    it.test;  // Field 'test' could not be resolved
 	//	}
+	@Test
 	public void testAddressAsTemplateArgument_391190() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -7091,6 +7413,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(int off) {
 	//	    off < CT<int>::const_min || off > CT<int>::const_min;
 	//	}
+	@Test
 	public void testTemplateIDAmbiguity_393959() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -7101,6 +7424,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//         Alias<int> x;
 	//     }
 	// };
+	@Test
 	public void testNestedAliasDeclarationNestingLevel() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -7122,6 +7446,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// template<typename T> class CT {           // nesting level 0
 	//     typedef Alias<T> TYPE;
 	// };
+	@Test
 	public void testAliasDeclarationNestingLevel() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -7145,6 +7470,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     Alias myA;
 	//     myA.x = 42;
 	// }
+	@Test
 	public void testSimpleAliasDeclaration() throws Exception {
 		parseAndCheckBindings();
 
@@ -7173,6 +7499,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     Alias myA;
 	//     myA.x = 42;
 	// }
+	@Test
 	public void testSpecifiedTemplateAliasDeclaration() throws Exception {
 		parseAndCheckBindings();
 
@@ -7197,6 +7524,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     Alias<float> myA;
 	//     myA = 42;
 	// }
+	@Test
 	public void testTemplatedAliasBasicType() throws Exception {
 		parseAndCheckBindings();
 
@@ -7222,6 +7550,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     TAlias<int> myA;
 	//     myA.t = 42;
 	// }
+	@Test
 	public void testTemplatedAliasDeclaration() throws Exception {
 		parseAndCheckBindings();
 
@@ -7263,6 +7592,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     myA.t2 = 42.0f;
 	//     myA.t3 = true;
 	// }
+	@Test
 	public void testTemplatedAliasDeclarationMultipleParameters() throws Exception {
 		parseAndCheckBindings();
 
@@ -7314,6 +7644,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     TAlias<S<int>> myA;
 	//     myA.t = S<int>();
 	// }
+	@Test
 	public void testTemplatedAliasDeclarationTemplateArgument() throws Exception {
 		parseAndCheckBindings();
 
@@ -7338,6 +7669,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     S<TAlias<int>> myA;
 	//     myA.t = S<int>();
 	// }
+	@Test
 	public void testTemplatedAliasAsTemplateArgument() throws Exception {
 		parseAndCheckBindings();
 
@@ -7362,6 +7694,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     TAlias<5, 4> myA;
 	//     myA.buff[0] = 1;
 	// }
+	@Test
 	public void testTemplatedAliasDeclarationValueArgument() throws Exception {
 		parseAndCheckBindings();
 
@@ -7386,6 +7719,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     TAlias<> myA;
 	//     myA.buff[0] = 1;
 	// }
+	@Test
 	public void testTemplatedAliasDefaultArguments() throws Exception {
 		parseAndCheckBindings();
 
@@ -7413,6 +7747,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     TAlias<float, int> myA;
 	//     myA.t = S<int>();
 	// }
+	@Test
 	public void testTemplatedAliasTemplateArgument() throws Exception {
 		parseAndCheckBindings();
 
@@ -7441,6 +7776,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     S<int> myS;
 	//     bar(myS);
 	// }
+	@Test
 	public void testTemplatedAliasAsFunctionParameter() throws Exception {
 		parseAndCheckBindings();
 
@@ -7466,6 +7802,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     TAlias<int> myA;
 	//     bar(myA);
 	// }
+	@Test
 	public void testTemplatedAliasAsFunctionArgument() throws Exception {
 		parseAndCheckBindings();
 
@@ -7487,6 +7824,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// }
 	// void bar(TAlias<int> arg){
 	// }
+	@Test
 	public void testTemplatedAliasRedefinitionOfSameFunction() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertNonProblem("bar(S", "bar", ICPPFunction.class);
@@ -7505,6 +7843,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     g(v);
 	//     f(v);
 	// }
+	@Test
 	public void testTemplatedAliasDeduction() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertNonProblem("g(v)", "g", ICPPFunction.class);
@@ -7515,6 +7854,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void foo(int) {
 	//     function f = &foo;
 	// }
+	@Test
 	public void testSimpleFunctionAliasDeclaration() throws Exception {
 		parseAndCheckBindings();
 
@@ -7541,6 +7881,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     TAlias<int> myA = myS;
 	//     myA.t = 42;
 	// }
+	@Test
 	public void testTemplatedAliasForTemplateReference() throws Exception {
 		parseAndCheckBindings();
 
@@ -7559,6 +7900,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void foo(int) {
 	//     function<int> f = &foo;
 	// }
+	@Test
 	public void testSimpleFunctionTemplateAliasDeclaration() throws Exception {
 		parseAndCheckBindings();
 
@@ -7581,6 +7923,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// void foo(int) {
 	//     function<int> f = &foo;
 	// }
+	@Test
 	public void testSimpleFunctionReferenceTemplateAliasDeclaration() throws Exception {
 		parseAndCheckBindings();
 
@@ -7608,6 +7951,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     TAlias<S<int> > myA;
 	//     myA.t = S<int>();
 	// }
+	@Test
 	public void testTemplatedAliasTemplateParameter() throws Exception {
 		parseAndCheckBindings();
 
@@ -7643,6 +7987,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  B<D>::Waldo<&D::m>();
 	//	}
+	@Test
 	public void testTemplatedAliasWithPointerToMember_448785() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7657,6 +8002,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	// }
 	// using namespace NS;
 	// Alias<int> intAlias;
+	@Test
 	public void testAliasDeclarationContext() throws Exception {
 		parseAndCheckBindings();
 
@@ -7720,6 +8066,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(E<A<int>>::type v) {
 	//	  f(v);
 	//	}
+	@Test
 	public void testAliasTemplate_395026a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7765,6 +8112,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  E<int*> v;
 	//	  f(*v[0]);
 	//	}
+	@Test
 	public void testAliasTemplate_395026b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7781,6 +8129,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(A<int>* c) {
 	//	  f(c);
 	//	}
+	@Test
 	public void testAliasTemplate_416280_1() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7797,6 +8146,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	struct D : public A<char> {
 	//	  B<int> b;
 	//	};
+	@Test
 	public void testAliasTemplate_416280_2() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7817,6 +8167,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	bool b = D<C>::template AD<int>::val;
+	@Test
 	public void testAliasTemplate_486618() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7855,6 +8206,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		waldo3(two, one);
 	//		waldo4(two, two);
 	//	}
+	@Test
 	public void testAliasTemplate_486971() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7914,6 +8266,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  C<A> a;
 	//	  waldo(a);
 	//	}
+	@Test
 	public void testAliasTemplate_502109() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7928,6 +8281,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    waldo(Alias<int>());
 	//	}
+	@Test
 	public void testTemplateIdNamingAliasTemplateInExpression_472615() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7942,6 +8296,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    typedef typename Traits<T>::template rebind<int> type;
 	//	};
 	//	typedef Meta<int>::type Waldo;
+	@Test
 	public void testNestedAliasTemplate_488456() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ITypedef waldo = helper.assertNonProblem("Waldo");
@@ -8013,6 +8368,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  F<int*> a;
 	//	  f(*a[0]);
 	//	}
+	@Test
 	public void testConstexprFunction_395238a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8042,6 +8398,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	B<bool>::type x;
 	//	B<int*>::type y;
+	@Test
 	public void testConstexprFunction_395238b() throws Exception {
 		BindingAssertionHelper ah = getAssertionHelper();
 		ITypedef td = ah.assertNonProblem("B<bool>::type", "type", ITypedef.class);
@@ -8059,6 +8416,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void bar() {
 	//	    A<f()>::g();
 	//	}
+	@Test
 	public void testConstexprFunctionCallInTemplateArgument_332829() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8071,6 +8429,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	struct Waldo {};
 	//
 	//	Waldo<IntConvertible{}> w;  // Syntax error
+	@Test
 	public void testUniformInitializationInTemplateArgument_510010() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8081,6 +8440,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//			++i;
 	//		}
 	//	}
+	@Test
 	public void testRegression_510010() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8110,6 +8470,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test(int x) {
 	//	  waldo(x);
 	//	}
+	@Test
 	public void testConstexprMethod_489987() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8126,6 +8487,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//	struct Cat {};
 	//	typedef S<is_convertible<Cat>::value>::type T;
+	@Test
 	public void testDependentExpressionInvolvingField_388623() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8138,6 +8500,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    foo(S());
 	//	}
+	@Test
 	public void testSfinaeInDefaultArgument() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8164,6 +8527,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	constexpr int value_via_adl = f(E1);     // ADL via enumeration argument finds is_augmented(E*)
 	//	constexpr int value_no_adl = g(int(E1)); // Error: no ADL performed, is_augmented(int*) is not found
+	@Test
 	public void testSfinaeInDependentContext() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertVariableValue("value_via_adl", 42);
@@ -8187,6 +8551,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	const bool B = has_type<int>::value;
+	@Test
 	public void testSfinaeInNestedTypeInTemplateArgument_402257() throws Exception {
 		BindingAssertionHelper helper = new AST2AssertionHelper(getAboveComment(), true);
 		ICPPVariable B = helper.assertNonProblem("B");
@@ -8214,6 +8579,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    S waldo;
 	//	    A() : waldo(B{}) {}
 	//	};
+	@Test
 	public void testSfinaeInTemplatedConversionOperator_409056() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -8238,6 +8604,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	typename enable_if<A<U>::value>::type waldo();
 	//
 	//	auto x = waldo<int>;
+	@Test
 	public void testSfinaeWhenResolvingAddressOfFunction_429928() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8260,6 +8627,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	typename enable_if<A<U>::value>::type waldo();
 	//
 	//	auto x = waldo<int>;
+	@Test
 	public void testSfinaeInNonTypeTemplateParameter_429928() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8275,6 +8643,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int waldo(int p);
 	//
 	//	int x = waldo(test<A>(0));
+	@Test
 	public void testSfinaeInConstructorCall_430230() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8290,6 +8659,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int waldo(int p);
 	//
 	//	int x = waldo(test<A>(0));
+	@Test
 	public void testSfinaeInNewExpression_430230a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8340,6 +8710,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	waldo();
 	//
 	//	auto x = waldo<A>;
+	@Test
 	public void testSfinaeInNewExpression_430230b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8357,6 +8728,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int waldo(int p);
 	//
 	//	int x = waldo(test<A>(0));
+	@Test
 	public void testSfinaeInNewExpressionWithDeletedConstructor_430230() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8382,6 +8754,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	    waldo<A>("");
 	//	}
+	@Test
 	public void testSfinaeInIdExpression_459940() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8395,6 +8768,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo(1);
 	//	}
+	@Test
 	public void testSfinaeInTrailingReturnType_495845() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8432,6 +8806,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo(1);
 	//	}
+	@Test
 	public void testSfinaeInTrailingReturnType_495952() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8444,6 +8819,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void foo() {
 	//	    new M<int>((int*)0, 0);
 	//	}
+	@Test
 	public void testVariadicConstructor_395247() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8461,6 +8837,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    static const int value = sizeof(waldo(f));
 	//	};
 	//	typedef identity<Int<S<>::value>>::type reference;
+	@Test
 	public void testDependentExpressions_395243a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8489,6 +8866,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		typedef int foo_type;
 	//	};
 	//	traits<has_foo_type<S>::value>::bar_type a;
+	@Test
 	public void testDependentExpressions_395243b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8507,6 +8885,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    for (auto s : v.arr)
 	//	        s.foo();
 	//	}
+	@Test
 	public void testDependentExpressions_395243c() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8524,6 +8903,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	            x->m();
 	//	    }
 	//	};
+	@Test
 	public void testDependentExpressions_395243d() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8541,6 +8921,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  int x = C<bool>::id;
 	//	}
+	@Test
 	public void testDependentEnumValue_389009() throws Exception {
 		BindingAssertionHelper ah = getAssertionHelper();
 		IEnumerator binding = ah.assertNonProblem("C<bool>::id", "id");
@@ -8579,6 +8960,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void bar(B<M>& v) {
 	//	    v.waldo();
 	//	}
+	@Test
 	public void testArgumentDependentLookupForEnumeration_506170() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8588,6 +8970,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//		foo(A<0>());
 	//	}
+	@Test
 	public void testVariadicNonTypeTemplateParameter_382074() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8615,6 +8998,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    meta<contains_foo<>::value>::type t;
 	//	    t.bar();
 	//	}
+	@Test
 	public void testVariadicNonTypeTemplateParameter_399039() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8630,6 +9014,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    typedef int type;
 	//	};
 	//	typedef common_type<int>::type type;
+	@Test
 	public void testClassTemplateSpecializationPartialOrdering_398044a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8645,6 +9030,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    A<bool(*)()> mf;
 	//	}
+	@Test
 	public void testClassTemplateSpecializationPartialOrdering_398044b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8658,6 +9044,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	struct waldo<R (...)>;
 	//
 	//	typedef waldo<int ()>::type Type;
+	@Test
 	public void testPartialSpecializationForVarargFunctionType_402807() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8671,6 +9058,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	struct waldo<R () &>;
 	//
 	//	typedef waldo<int ()>::type Type;
+	@Test
 	public void testPartialSpecializationForRefQualifiedFunctionType_485888() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8692,6 +9080,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	using ActualType = term_traits<T const &>::value_type;
 	//
 	//	using ExpectedType = char[4];
+	@Test
 	public void testQualifierTypeThatCollapsesAfterTypedefSubstitution_487698() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ITypedef actualType = helper.assertNonProblem("ActualType");
@@ -8719,6 +9108,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	    push_back(0);
 	//	}
+	@Test
 	public void testRegression_399142() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8735,6 +9125,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    W<A<char>::value>::type w;
 	//	}
+	@Test
 	public void testDependentExpressionInvolvingFieldInNestedClass_399362() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8753,6 +9144,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	typedef decltype(W<foo>()()) waldo;
+	@Test
 	public void testInstantiationOfConstMemberAccess_409107() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		IType waldo = bh.assertNonProblem("waldo");
@@ -8794,6 +9186,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    int main() {
 	//        S<contains_waldo<int>::value>::type t;
 	//    }
+	@Test
 	public void testVariadicTemplates_401024() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8811,6 +9204,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//        S s;
 	//        bar(foo(s(0)));
 	//    }
+	@Test
 	public void testVariadicTemplatesAndFunctionObjects_401479() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8846,6 +9240,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	    waldo<A>("");
 	//	}
+	@Test
 	public void testPackExpansionInNestedTemplate_459844() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8857,6 +9252,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	struct C : A<T>... {};
 	//
 	//	constexpr bool answer = __is_base_of(A<int>, C<int>);
+	@Test
 	public void testPackExpansionInBaseSpecifier_487703() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IVariable answer = helper.assertNonProblem("answer");
@@ -8870,6 +9266,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	struct SpecificMixin {};
 	//
 	//	constexpr bool answer = __is_base_of(SpecificMixin<int>, C<SpecificMixin>);
+	@Test
 	public void testTemplateTemplateParameterPack_487703a() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IVariable answer = helper.assertNonProblem("answer");
@@ -8884,6 +9281,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//  typedef C<SpecificMixin> Waldo;
 	//  constexpr bool answer = __is_base_of(SpecificMixin<Waldo>, Waldo);
+	@Test
 	public void testTemplateTemplateParameterPack_487703b() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IVariable answer = helper.assertNonProblem("answer");
@@ -8906,6 +9304,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     N::impl<T>::type operand;
 	//     operand.kind();
 	// }
+	@Test
 	public void testNameLookupInDependentExpression_399829a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8930,6 +9329,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//     N::impl<S>::type operand;
 	//     operand.kind();
 	// }
+	@Test
 	public void testNameLookupInDependentExpression_399829b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8953,6 +9353,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    S<true> operator==(T, T*);
 	//    template<typename T>
 	//    S<(is_int<T>::value)> operator==(T, T);
+	@Test
 	public void testRegression_399829() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -8968,6 +9369,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		S s;
 	//		auto waldo = bar(&s);
 	//	}
+	@Test
 	public void testDependentFieldReference_472436a() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("waldo", CommonCPPTypes.int_);
@@ -8987,6 +9389,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		S s;
 	//		auto waldo = bar(&s);
 	//	}
+	@Test
 	public void testDependentFieldReference_472436b() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("waldo", CommonCPPTypes.int_);
@@ -9009,6 +9412,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    S s;
 	//	    bind(s, 0, foo);
 	//	}
+	@Test
 	public void testNPE_401140() throws Exception {
 		BindingAssertionHelper helper = new AST2AssertionHelper(getAboveComment(), true);
 		helper.assertProblem("bind(s, 0, foo)", "bind");
@@ -9028,6 +9432,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int foo(void*, S<V::template xxx>* = 0);
 	//
 	//	int value = sizeof(foo<a3>(0));
+	@Test
 	public void testNPE_395074() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9038,6 +9443,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int combine(S1&& r1, S2&& r2);
 	//	template <typename S1, typename S2>
 	//	auto combine(S1 r1, S2 r2) -> decltype(combine<int>(forward<S1>(r1), forward<S2>(r2)));
+	@Test
 	public void testUnsupportedOperationExceptionInASTAmbiguousNode_402085() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9057,6 +9463,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    S<ice_or<false>::value>::type t;
 	//	}
+	@Test
 	public void testVariadicNonTypeTemplateParameter_401142() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9079,6 +9486,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    S<ice_or<false, false>::value>::type t;
 	//	}
+	@Test
 	public void testVariadicNonTypeTemplateParameter_401400() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9088,6 +9496,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		static constexpr int i = sizeof...(Args);
 	//	};
 	//	constexpr int bar = foo<int, double>::i;
+	@Test
 	public void testSizeofParameterPackOnTypeid_401973() throws Exception {
 		BindingAssertionHelper helper = new AST2AssertionHelper(getAboveComment(), true);
 		ICPPVariable bar = helper.assertNonProblem("bar");
@@ -9115,6 +9524,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	        typedef typename make_tuple_indices<1 + sizeof...(Args), 1>::type Index;
 	//	    }
 	//	};
+	@Test
 	public void testVariadicTemplatesNPE_401743() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9131,6 +9541,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    S<> s;
 	//	    s.waldo(0, 0);  // ERROR HERE
 	//	}
+	@Test
 	public void testParameterPackInNestedTemplate_441028() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9153,6 +9564,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	prober<B<A<>, 0>::t>::t g();
+	@Test
 	public void testParameterPack_485806() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9163,6 +9575,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    waldo<int>();
 	//	}
+	@Test
 	public void testExplicitArgumentsForParameterPack_404245() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertProblem("waldo<int>()", "waldo<int>");
@@ -9180,6 +9593,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void foo2(A<T>... t) {
 	//		bar(t.waldo...);
 	//	}
+	@Test
 	public void testMemberAccessInPackExpansion_442213() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9208,6 +9622,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void foo1(const T&... t) {
 	//		bar(t.waldo...);
 	//	}
+	@Test
 	public void testMemberAccessViaReferenceInPackExpansion_466845() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9230,6 +9645,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  A a;
 	//	  waldo(a, C<>());
 	//	}
+	@Test
 	public void testDecltypeInPackExpansion_486425a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9252,6 +9668,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  A a;
 	//	  waldo(a, C<>());
 	//	}
+	@Test
 	public void testDecltypeInPackExpansion_486425b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9266,6 +9683,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	decltype(__declval<T>()) declval();
 	//
 	//	using T = decltype(declval<int>());
+	@Test
 	public void testDeclvalDeclaration_540957() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9284,6 +9702,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    async();  // ERROR: Invalid arguments
 	//	}
+	@Test
 	public void testDependentPackExpansionInFunctionType_526684() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9300,6 +9719,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	typedef tuple_element<int, int>::type Waldo;
+	@Test
 	public void testSizeofParameterPack_527697() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ITypedef waldo = helper.assertNonProblem("Waldo");
@@ -9324,6 +9744,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	  function<0>();
 	//	}
+	@Test
 	public void testSizeofParameterPack_574196() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9346,6 +9767,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	  function<0>();
 	//	}
+	@Test
 	public void testSizeofParameterPack_574196_2() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9368,6 +9790,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	  function<0>();
 	//	}
+	@Test
 	public void testSizeofParameterPack_574196_3() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9390,6 +9813,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	  function<0>();
 	//	}
+	@Test
 	public void testSizeofParameterPack_574196_4() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9435,6 +9859,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	  function<1234>();
 	//	}
+	@Test
 	public void testSizeofParameterPack_574196_6() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9451,6 +9876,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    B b;
 	//	    waldo(b);
 	//	}
+	@Test
 	public void testTemplateArgumentDeduction_MultipleInheritance_527697() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9471,6 +9897,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	typedef A<C<const char*, K>> D;
 	//
 	//	typedef B<D>::type E;
+	@Test
 	public void testRegression_401743a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9493,6 +9920,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	typedef A<C<F, K>> D;
 	//
 	//	typedef B<D>::type E;
+	@Test
 	public void testRegression_401743b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9516,6 +9944,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  C<int>::pointer p;
 	//	  p->a = 0;
 	//	}
+	@Test
 	public void testPseudoRecursiveTypedef_408314() throws Exception {
 		CPPASTNameBase.sAllowRecursionBindings = true;
 		parseAndCheckBindings();
@@ -9525,6 +9954,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void foo(T t) {
 	//	    bar(t);
 	//	}
+	@Test
 	public void testUnqualifiedFunctionCallInTemplate_402498a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9540,6 +9970,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    auto x = foo(N::A());
 	//	}
+	@Test
 	public void testUnqualifiedFunctionCallInTemplate_402498b() throws Exception {
 		new AST2AssertionHelper(getAboveComment(), true).assertVariableType("x", CommonCPPTypes.int_);
 	}
@@ -9556,6 +9987,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    auto x = foo(N::A());
 	//	}
+	@Test
 	public void testUnqualifiedFunctionCallInTemplate_402498c() throws Exception {
 		BindingAssertionHelper helper = new AST2AssertionHelper(getAboveComment(), true);
 		ICPPVariable x = helper.assertNonProblem("x");
@@ -9585,6 +10017,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		auto x = foo(N::A());
 	//		x.woof();
 	//	}
+	@Test
 	public void testUnqualifiedFunctionCallInTemplate_402498d() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9595,6 +10028,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void foo(T t) {
 	//	    bar(t);
 	//	}
+	@Test
 	public void testUnqualifiedFunctionCallInTemplate_458316a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9615,6 +10049,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    foo(N::S()).meow();
 	//	}
+	@Test
 	public void testUnqualifiedFunctionCallInTemplate_458316b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9635,6 +10070,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	A<int> a;
 	//	auto b = foo(a);
+	@Test
 	public void testQualifiedNameLookupInTemplate_402854() throws Exception {
 		BindingAssertionHelper helper = new AST2AssertionHelper(getAboveComment(), true);
 		helper.assertVariableType("b", CommonCPPTypes.int_);
@@ -9647,6 +10083,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	struct B : public A<int> {
 	//	  B(int c) : A(c) {}
 	//	};
+	@Test
 	public void testTemplateBaseClassConstructorCall_402602() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9661,6 +10098,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//  private:
 	//    int privateMemberVariable;
 	//  };
+	@Test
 	public void testTemplateMemberAccessibility() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 
@@ -9692,6 +10130,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//  private:
 	//    int specializedPrivateVariable;
 	//  };
+	@Test
 	public void testTemplateSpecializationMemberAccessibility() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 
@@ -9727,6 +10166,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  a->protectedMemberVariable = 0;
 	//	  a->privateMemberVariable = 0;
 	//	}
+	@Test
 	public void testInstanceMemberAccessibility() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 
@@ -9776,6 +10216,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	  foo<myInt>();
 	//	}
+	@Test
 	public void testInstantiationOfTypedef_412555() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9793,6 +10234,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	template <class T>
 	//	void A<B<T>, T>::method() {}
+	@Test
 	public void testOutOfLineMethodOfPartialSpecialization_401152() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9812,6 +10254,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//		U<S>::type x;
 	//	}
+	@Test
 	public void testDependentDecltypeInNameQualifier_415198() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertNonProblem("decltype(foo(T()))::type");
@@ -9828,6 +10271,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	decltype(B::c)::type x;
+	@Test
 	public void testDependentDecltypeInNameQualifier_429837() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		assertSameType((ITypedef) helper.assertNonProblem("decltype(B::c)::type"), CommonCPPTypes.int_);
@@ -9849,6 +10293,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    template <typename T>
 	//	    void C<T*>::waldo() {}
 	//	}
+	@Test
 	public void testMemberOfPartialSpecialization_416788() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9874,6 +10319,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		myObject.method<0>();
 	//		return 0;
 	//	}
+	@Test
 	public void testSpecializedEnumerator_418770() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9890,6 +10336,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	class A {
 	//	    friend int ns::waldo<T>(const A<T>&);
 	//	};
+	@Test
 	public void testDependentSpecializationOfFunctionTemplateAsFriend_422505a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9904,6 +10351,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	class A {
 	//	    friend int waldo<T>(const A<T>&);
 	//	};
+	@Test
 	public void testDependentSpecializationOfFunctionTemplateAsFriend_422505b() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertNonProblem("waldo<T>", ICPPDeferredFunction.class);
@@ -9931,6 +10379,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  A a;
 	//	  waldo(a);
 	//	}
+	@Test
 	public void testDependentFunctionSet_485985() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9954,6 +10403,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo(0);
 	//	}
+	@Test
 	public void testDependentConversionOperator_486149() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -9968,6 +10418,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	constexpr bool waldo = negate(boolean<true>());
+	@Test
 	public void testDependentConversionOperator_486426() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPVariable waldo = helper.assertNonProblem("waldo");
@@ -9986,6 +10437,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	constexpr int waldo = S<int>::b;
+	@Test
 	public void testDependentConditionalExpression_506170() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 42);
@@ -10004,6 +10456,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  C<int> x;
 	//	  waldo(x, x);
 	//	}
+	@Test
 	public void testStrayFriends_419301() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10025,6 +10478,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void test() {
 	//	  waldo(foo(c, d));
 	//	}
+	@Test
 	public void testInstantiationOfFriendOfNestedClassInsideTemplate_484162() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10040,6 +10494,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	}
 	//
 	//	constexpr unsigned waldo = t(0u);
+	@Test
 	public void testSpecializationOfConstexprFunction_420995() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPVariable waldo = helper.assertNonProblem("waldo");
@@ -10065,6 +10520,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//        }
 	//
 	//	};
+	@Test
 	public void testConstexprFunctionCallWithNonConstexprArguments_429891() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10083,6 +10539,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	}
 	//
 	//	constexpr int waldo = foo<int>();
+	@Test
 	public void testInstantiationOfReturnExpression_484959() throws Exception {
 		getAssertionHelper().assertVariableValue("waldo", 42);
 	}
@@ -10105,6 +10562,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template <int D = D>
 	//	struct C3 { typedef B<D> type; };
 	//	C3<>::type c3;
+	@Test
 	public void testNameLookupInDefaultTemplateArgument_399145() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10133,6 +10591,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    g(a);
 	//	  }
 	//	}
+	@Test
 	public void testLocalTypeAsTemplateArgument_442832() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10154,6 +10613,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		Bar<int> var1;
 	//		auto var2 = foo(S());
 	//	}
+	@Test
 	public void testTypeOfUnknownMember_447728() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IVariable var1 = helper.assertNonProblem("var1");
@@ -10166,6 +10626,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    typedef decltype(T::member) C;
 	//	    typedef decltype(C::member) D;
 	//	}
+	@Test
 	public void testScopeOfUnkownMemberType_525982() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10200,6 +10661,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    S<int> s;
 	//	    s.waldo = 42;
 	//	}
+	@Test
 	public void testClassSpecializationInEnumerator_457511() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10212,6 +10674,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	  using type = TypeTemplate<Size_tTemplate<packSize()>>;
 	//	};
+	@Test
 	public void testAmbiguityResolutionOrder_462348a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10226,6 +10689,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    using type = TypeTemplate<Size_tTemplate<packSize()>>;
 	//	  };
 	//	};
+	@Test
 	public void testAmbiguityResolutionOrder_462348b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10277,6 +10741,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  B<int> b;
 	//	  b.method();
 	//	}
+	@Test
 	public void testAmbiguityResolution_469788() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10285,6 +10750,8 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	constexpr int waldo(T v) {
 	//	  return v < I ? 1 : 1 + waldo<I, T>(v / I);
 	//	}
+	@Test
+	@Disabled("Known failing")
 	public void _testAmbiguityResolution_497931() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10302,6 +10769,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		template <int>
 	//		static S<U> waldo(int);
 	//	};
+	@Test
 	public void testAmbiguityResolutionInNestedClassMethodBody_485388() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10319,6 +10787,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	template <template <typename...> class Op, typename... Args>
 	//	struct IsDetectedImpl<void_t<Op<Args...>>, Op, Args...> {};
+	@Test
 	public void testAmbiguityResolution_515453() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10355,6 +10824,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	B<T, a>::waldo(U) { // problems on B<T, a>::waldo and on U
 	//	  C<T>::c; // problems on C, T and ::c
 	//	}
+	@Test
 	public void testRegression_485388a() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -10378,6 +10848,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	  int waldo();
 	//	};
+	@Test
 	public void testRegression_485388b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10396,6 +10867,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    this->template method<WALDO>(0);
 	//	  }
 	//	};
+	@Test
 	public void testRegression_421823() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10422,6 +10894,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	  C<int> a;
 	//	  waldo(a);
 	//	}
+	@Test
 	public void testRecursiveTemplateClass_484786() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10434,6 +10907,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	typedef int Int;
 	//
 	//	void waldo() noexcept(S<Int>::value) {}
+	@Test
 	public void testDisambiguationInNoexceptSpecifier_467332() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10450,6 +10924,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    S()(0).meow();  // ERROR: Method 'meow' could not be resolved
 	//	}
+	@Test
 	public void testBraceInitialization_490475a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10467,6 +10942,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	constexpr S b = S{21, 0};
 	//
 	//	constexpr int waldo = foo(a, b);
+	@Test
 	public void testBraceInitialization_490475b() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IVariable waldo = helper.assertNonProblem("waldo");
@@ -10504,6 +10980,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	typedef ratio_multiply<S, ratio<1>>::type waldo;
+	@Test
 	public void testOOM_508254() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		// Just check that resolution does not throw an exception.
@@ -10541,6 +11018,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    MyContainer c;
 	//	    reverse(c);   // Ambiguous
 	//	}
+	@Test
 	public void testSFINAEInEvalIdWithFieldOwner_510834() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10559,6 +11037,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    waldo(foo(0));  // Error here
 	//	}
+	@Test
 	public void testSFINAEInDecltype_516291a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10577,6 +11056,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    waldo(foo(0));  // Error here
 	//	}
+	@Test
 	public void testSFINAEInDecltype_516291b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10593,6 +11073,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	struct Waldo<T, void_t<typename T::type>> {};
 	//
 	//	Waldo<int>::type foo();
+	@Test
 	public void testSFINAEInAliasTemplateArgs_516338() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10629,6 +11110,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void bar(arg<int, int>& x) {
 	//	    foo(x);
 	//	}
+	@Test
 	public void testInstantiationOfEvalIdWithFieldOwner_511108() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10645,6 +11127,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		test<D>();
 	//		test<const D>();
 	//	}
+	@Test
 	public void testDependentDestructorName_511122() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10658,12 +11141,14 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    A a;
 	//	    a.~alias<A>();
 	//	}
+	@Test
 	public void testDestructorCallViaAliasedTemplateName_511658() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	template <typename> struct Waldo {};
 	//	Waldo<void() noexcept> var;
+	@Test
 	public void testNoexceptSpecifierInTypeTemplateArgument_511186() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10684,6 +11169,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void func() {
 	//	  waldo(a);
 	//	}
+	@Test
 	public void testFriendFunctionDeclarationInNamespace_513681() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10698,6 +11184,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    foobar<int> obj;
 	//	    waldo(obj);         // Error: Invalid arguments
 	//	}
+	@Test
 	public void testDependentSizeofInDefaultArgument_513430() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10714,6 +11201,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    waldo(bar<S>());
 	//	}
+	@Test
 	public void testDependentMemberAccess_516290() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10726,6 +11214,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    A(int);
 	//	    A() : A(5) {}
 	//	};
+	@Test
 	public void testDelegatingConstructorInPartialSpecialization_512932() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10741,6 +11230,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    foo<E::F>();  // error here
 	//	}
+	@Test
 	public void testOverloadingOnTypeOfNonTypeTemplateParameter_512932() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10754,6 +11244,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	    waldo(CA());
 	//	}
+	@Test
 	public void testReferenceBinding_Regression_516284() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10774,6 +11265,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	// Instantiate with [T = int] and capture the return value.
 	//	constexpr int waldo = bar(0);
+	@Test
 	public void testDependentTypeBindingToAuto_408470() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		// Check that the TypeOfDependentExpression instantiated to the correct type.
@@ -10792,6 +11284,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	constexpr int waldo = Model<1302>::res;
+	@Test
 	public void testStaticConstexprFunctionWithDependentBody_521274a() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 1300);
@@ -10813,6 +11306,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	constexpr int waldo = Model<1302>::family_t::value;
+	@Test
 	public void testStaticConstexprFunctionWithDependentBody_521274b() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 1300);
@@ -10831,6 +11325,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    struct D : A<X> {};
 	//	    enum { val = D::template B<X>::val };
 	//	};
+	@Test
 	public void testMemberOfUnknownMemberClass_519819() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10870,6 +11365,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//			   >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 	//			   >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 	//			   >>>>>>>>>>>>> parser_killer_type;
+	@Test
 	public void testTemplateArgumentNestingDepthLimit_512297() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IASTTranslationUnit tu = helper.getTranslationUnit();
@@ -10906,6 +11402,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	auto parser_killer_2 = infinite<int>::generate<400>();
+	@Test
 	public void testTemplateInstantiationDepthLimit_512297() throws Exception {
 		CPPASTNameBase.sAllowRecursionBindings = true;
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -10918,6 +11415,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	using destructor_expr_t = decltype(declval<T>().~T());
 	//
 	//	typedef destructor_expr_t<int> Waldo;
+	@Test
 	public void testDestructorExpressionType_528846() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IType waldo = helper.assertNonProblem("Waldo");
@@ -10934,6 +11432,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	      i2 < 0, i2 < 0,
 	//	      i3 < 0, i3 < 0>();
 	//	}
+	@Test
 	public void testTemplateIdAmbiguity_529696() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10943,6 +11442,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	template <int... I>
 	//	void foo(index_sequence<I...>);
+	@Test
 	public void testTemplateAliasWithVariadicNonTypeArgs_530086a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -10959,6 +11459,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void foo() {
 	//	    bar<int>(integer_sequence<0>{});
 	//	}
+	@Test
 	public void testTemplateAliasWithVariadicArgs_530086b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11034,6 +11535,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	        });
 	//	    });
 	//	}
+	@Test
 	public void testLongDependentFunctionCallChain_530692() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11061,6 +11563,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	constexpr int tmp = get_from_variadic_pack<1>::apply(1,2);
 	//	constexpr int result = static_int<tmp>::value;
+	@Test
 	public void testInstantiationOfPackInNestedTemplate_540758() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11088,6 +11591,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	// Call the function
 	//	constexpr int waldo = foo<7>();
+	@Test
 	public void testConditionalInstantiationOfConstexprIfTrueBranch_527427() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 3);
@@ -11116,6 +11620,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	// Call the function
 	//	constexpr int waldo = foo<7>();
+	@Test
 	public void testConditionalInstantiationOfConstexprIfFalseBranch_527427() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 3);
@@ -11134,6 +11639,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	// Call the function
 	//	constexpr int waldo = fib<7>();
+	@Test
 	public void testConstexprFibonacciConstexprIf_527427() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 13);
@@ -11154,6 +11660,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	// Call the function
 	//	constexpr int waldo = foo<2>();
+	@Test
 	public void testConstexprIfDeclarationTrueBranch_527427() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 3);
@@ -11174,6 +11681,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	// Call the function
 	//	constexpr int waldo = foo<0>();
+	@Test
 	public void testConstexprIfDeclarationFalseBranch_527427() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 42);
@@ -11189,6 +11697,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	// Call the function
 	//	constexpr auto waldo = foo();
+	@Test
 	public void testReturnAutoConstexprIfDeclarationFalseBranchValueExpression_527427() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 42);
@@ -11204,6 +11713,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	// Call the function
 	//	constexpr auto waldo = foo();
+	@Test
 	public void testReturnAutoConstexprIfDeclarationTrueBranchValueExpression_527427() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("waldo", 42);
@@ -11236,6 +11746,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    char** end;
 	//	    foo({begin, end});
 	//	}
+	@Test
 	public void testOverloadResolutionWithInitializerList_531322() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11344,6 +11855,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//		static_assert(Dummy<T4>::value, "");
 	//	}
+	@Test
 	public void testMetaprogrammingWithAliasTemplates_534126() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11362,6 +11874,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	using hhh_d = hhh<A>;
 	//
 	//	using waldo = typename iii<hhh_d>::type;
+	@Test
 	public void testAliasTemplateAsTemplateTemplateArg_539076() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IType waldo = helper.assertNonProblem("waldo");
@@ -11378,6 +11891,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	template <class T>
 	//	using evaluate = trigger<foo<T>>;
+	@Test
 	public void testNonTypePackExpansion_540538() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11394,6 +11908,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	using bar = forward<dummy1>;
 	//	template <class> struct dummy2 {};
 	//	using trigger = dummy2<bar>;
+	@Test
 	public void testDependentTemplateTemplateArgument_540450() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11411,6 +11926,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	template <class T4>
 	//	using trigger = template_template_alias<foo<T4>::template apply>;
+	@Test
 	public void testAliasTemplateWithTemplateTemplateParameter_540676() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11433,6 +11949,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	template <typename> struct B;
 	//	using C = B<A>;
+	@Test
 	public void testInvalidAliasTemplateWithTemplateTemplateParameter_540676() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		bh.assertProblem("B<A>", 4);
@@ -11454,6 +11971,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template <class> struct trigger{};
 	//
 	//	using A = trigger<foo<my_type>::type>;
+	@Test
 	public void testParameterPackInAliasTemplateArgs_540741() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11469,6 +11987,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	using Waldo = Bind<int>::Type;
+	@Test
 	public void testPackExpansionExprInAliasTemplate_541549() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IType waldo = helper.assertNonProblem("Waldo");
@@ -11485,6 +12004,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    int* p;
 	//	    foo(p);
 	//	}
+	@Test
 	public void testDisambiguateFunctionWithDefaultArgument_541474() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11498,6 +12018,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	// Which one is this an explicit spec. of?
 	//	template <>
 	//	void foo(int*);
+	@Test
 	public void testDisambiguateFunctionWithDefaultArgumentExplicitInstantiation_541474() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11517,6 +12038,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//      // Which constructor is used for the conversion?
 	//	    bar(p);
 	//	}
+	@Test
 	public void testDisambiguateFunctionWithDefaultArgumentConversion_541474() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11532,6 +12054,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	    // Which one are we taking the address of?
 	//	    FPtr x = &foo;
 	//	}
+	@Test
 	public void testDisambiguateFunctionWithDefaultArgumentDeclaration_541474() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11546,6 +12069,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main( ) {
 	//		info(1);
 	//	}
+	@Test
 	public void testDisambiguateFunctionUnusedPack_541474() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11559,6 +12083,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//		foo(0);
 	//	}
+	@Test
 	public void testDisambiguateFunctionUnusedPackVsDefault_541474() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, CPP);
@@ -11580,6 +12105,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//		foo(0);
 	//	}
+	@Test
 	public void testDisambiguateFunctionUnusedPackVsDefault2_541474() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), CPP);
 		// clang (7.0.0) and gcc (7.3.1) disagree, clang thinks this is ambiguous
@@ -11604,6 +12130,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	typedef A<42,43> B;
 	//  static constexpr auto val1 = B::first;
 	//  static constexpr auto val2 = B::second;
+	@Test
 	public void testVariadicTemplateAuto_544681() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("val1", 42);
@@ -11622,6 +12149,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//  const_int_ref ref_forty_two = forty_two;
 	//
 	//  Waldo<id(ref_forty_two)>::type a;
+	@Test
 	public void testGlobalConstWorksAsConstExpression_545756() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11634,6 +12162,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	void foo() {
 	//	  auto len = "test"_test;
 	//	}
+	@Test
 	public void testStringLiteralOperatorTemplate_536986() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -11646,6 +12175,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	using type1 = integer_sequence<0, 1, 2>;
 	//	using type2 = make_integer_sequence<3>;
+	@Test
 	public void testIntegerPack_553794() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ITypedef type1 = helper.assertNonProblem("type1");
@@ -11664,6 +12194,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	static constexpr auto val1 = g("123");
 	//	static constexpr auto val2 = g((const char*)"123");
+	@Test
 	public void testParameterPackExpansions_array() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -11677,6 +12208,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<typename T> bool f() {
 	//	  return V<T> + V<T>;
 	//	}
+	@Test
 	public void testBinaryExpressionWithVariableTemplateVsPlusUnaryExpression() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11687,6 +12219,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<typename T> bool f() {
 	//	  return V<T> || V<T>;
 	//	}
+	@Test
 	public void testBinaryExpressionWithVariableTemplate() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11697,6 +12230,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<typename T> bool f() {
 	//	  return V<T> && V<T>; // can be parsed as V < T > &&V<T>
 	//	}
+	@Test
 	public void testBinaryExpressionWithVariableTemplateAmbiguousLabelReference() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11713,6 +12247,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	template<typename T> bool f() {
 	//	  return W<T> && X<T> && Y<T> && Z<T>; // can be parsed as (W) < (T) > (&&X<T>) ...
 	//	}
+	@Test
 	public void testBinaryExpressionWithVariableTemplateDeep() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11741,6 +12276,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//		// to decide if A<int>::Waldo is a template
 	//		A<factorial(5)>::Waldo<0>::f();
 	//	}
+	@Test
 	public void testBinaryExpressionWithVariableTemplate_bug497931_comment8() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11761,6 +12297,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	S<bool> bool_s_test;
+	@Test
 	public void testResolveFunctionTemplateInDeferredClassArg() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11779,6 +12316,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	S<bool> bool_s_test;
+	@Test
 	public void testResolveFunctionTemplateInDeferredBaseArg() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -11789,6 +12327,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	S<int> s(1);
+	@Test
 	public void testRecognizeConstructorWithSemicolonAfterBody() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -11799,6 +12338,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//			T t;
 	//		} s {};
 	//	};
+	@Test
 	public void testAllowAggregateInitializationInTemplateBody() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}
@@ -11826,6 +12366,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//  static constexpr auto conversion_value
 	//    = Derived<In<int>>::Converter<Out<double>>::conversion::value;
+	@Test
 	public void testUsingDeclaratorPullDependentBaseConstructors() throws Exception {
 		parseAndCheckImplicitNameBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -11862,6 +12403,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    = Derived<17, In<int>>::Converter<Out<double>>::conversion::value;
 	//
 	//  static_assert(conversion_value == 42);
+	@Test
 	public void testUsingDeclaratorPullDependentTemplateBaseConstructors() throws Exception {
 		parseAndCheckImplicitNameBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -11909,6 +12451,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//    = DerivedInstantiator<In<int>>::Converter<Out<double>>::conversion::value;
 	//
 	//  static_assert(conversion_value == 42);
+	@Test
 	public void testUsingDeclaratorPullRenamedDependentTemplateBaseConstructors() throws Exception {
 		parseAndCheckImplicitNameBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -11931,6 +12474,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	}
 	//	static constexpr auto value_if_false = if_false(true);
 	//	static constexpr auto value_if_true = if_true(false);
+	@Test
 	public void testIfThenElseClauseStaticAssert() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -11967,6 +12511,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	static constexpr auto value_calls_asserts_true = calls_asserts_true();
 	//	static constexpr auto value_asserts_false = asserts_false();
 	//	static constexpr auto value_calls_asserts_false = calls_asserts_false();
+	@Test
 	public void testStaticAssertInCompoundStatement() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -12031,6 +12576,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	};
 	//
 	//	constexpr bool selected_method_empty_args = C<int>::f();
+	@Test
 	public void testVariableTemplateNaryTypeIdInitializer() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertVariableValue("selected_method_empty_args", 1);
@@ -12073,6 +12619,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//	} // namespace std
 	//
 	//	constexpr int is_assignable_int_int = std::is_assignable<int, int>::value;
+	@Test
 	public void testStdDeclvalIsAssignable() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertVariableValue("is_assignable_int_int", 0);
@@ -12098,6 +12645,7 @@ public class AST2TemplateTests extends AST2CPPTestBase {
 	//
 	//	constexpr int bad_assignment = N::check<int, int>(0);
 	//	constexpr int good_assignment = N::check<int&, int>(0);
+	@Test
 	public void testAssignmentInDecltype() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		bh.assertVariableValue("bad_assignment", 0);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TestBase.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2TestBase.java
@@ -19,6 +19,11 @@
 package org.eclipse.cdt.core.parser.tests.ast2;
 
 import static org.eclipse.cdt.core.parser.ParserLanguage.CPP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -92,8 +97,7 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.CPPVisitor;
 import org.eclipse.cdt.internal.core.model.ASTStringUtil;
 import org.eclipse.cdt.internal.core.parser.ParserException;
 import org.eclipse.cdt.internal.core.parser.scanner.CPreprocessor;
-
-import junit.framework.AssertionFailedError;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author aniefer
@@ -162,18 +166,9 @@ public abstract class AST2TestBase extends SemanticTestBase {
 		return map;
 	}
 
-	public AST2TestBase() {
-		super();
-	}
-
-	public AST2TestBase(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void setUp() throws Exception {
+	@BeforeEach
+	protected void localSetUp() throws Exception {
 		sValidateCopy = true;
-		super.setUp();
 	}
 
 	protected IASTTranslationUnit parse(String code, ParserLanguage lang) throws ParserException {
@@ -518,7 +513,7 @@ public abstract class AST2TestBase extends SemanticTestBase {
 	protected CharSequence[] getContents(int sections) throws IOException {
 		CTestPlugin plugin = CTestPlugin.getDefault();
 		if (plugin == null)
-			throw new AssertionFailedError("This test must be run as a JUnit plugin test");
+			fail("This test must be run as a JUnit plugin test");
 		return TestSourceReader.getContentsForTest(plugin.getBundle(), "parser", getClass(), getName(), sections);
 	}
 
@@ -593,7 +588,7 @@ public abstract class AST2TestBase extends SemanticTestBase {
 
 	final protected void assertNoProblemBindings(NameCollector col) {
 		for (IASTName n : col.nameList) {
-			assertFalse("ProblemBinding for " + n.getRawSignature(), n.resolveBinding() instanceof IProblemBinding);
+			assertFalse(n.resolveBinding() instanceof IProblemBinding, "ProblemBinding for " + n.getRawSignature());
 		}
 	}
 

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2Tests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2Tests.java
@@ -20,6 +20,14 @@ package org.eclipse.cdt.core.parser.tests.ast2;
 
 import static org.eclipse.cdt.core.parser.ParserLanguage.C;
 import static org.eclipse.cdt.core.parser.ParserLanguage.CPP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 
@@ -134,8 +142,8 @@ import org.eclipse.cdt.internal.core.dom.parser.c.CVisitor;
 import org.eclipse.cdt.internal.core.dom.parser.c.ICInternalBinding;
 import org.eclipse.cdt.internal.core.model.ASTStringUtil;
 import org.eclipse.cdt.internal.core.parser.ParserException;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases on the AST.
@@ -143,18 +151,6 @@ import junit.framework.TestSuite;
 public class AST2Tests extends AST2TestBase {
 	private static final int NUM_TESTS = 3;
 	private static final int RETRY_INTERMITTENT_COUNT = 5;
-
-	public static TestSuite suite() {
-		return suite(AST2Tests.class);
-	}
-
-	public AST2Tests() {
-		super();
-	}
-
-	public AST2Tests(String name) {
-		super(name);
-	}
 
 	private void parseAndCheckBindings() throws Exception {
 		parseAndCheckBindings(ScannerKind.STD);
@@ -170,11 +166,13 @@ public class AST2Tests extends AST2TestBase {
 		return parseAndCheckBindings(code, C);
 	}
 
+	@Test
 	public void testBug75189() throws Exception {
 		parseAndCheckBindings("struct A{};\n typedef int (*F) (struct A*);"); //$NON-NLS-1$
 		parseAndCheckBindings("struct A{};\n typedef int (*F) (A*);", CPP); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testBug75340() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings("void f(int i = 0, int * p = 0);", CPP); //$NON-NLS-1$
 		IASTSimpleDeclaration sd = (IASTSimpleDeclaration) tu.getDeclarations()[0];
@@ -191,6 +189,7 @@ public class AST2Tests extends AST2TestBase {
 	// p2 = &MyStruct.b;
 	//         MyStruct.b = 1;
 	// }
+	@Test
 	public void testBug78103() throws Exception {
 		parseAndCheckBindings(getAboveComment());
 	}
@@ -199,6 +198,7 @@ public class AST2Tests extends AST2TestBase {
 	// int (*pm)(int) = &m;
 	// int f(int);
 	// int x = f((*pm)(5));
+	@Test
 	public void testBug43241() throws Exception {
 		parseAndCheckBindings(getAboveComment());
 	}
@@ -207,6 +207,7 @@ public class AST2Tests extends AST2TestBase {
 	// int (*zzz2) (char);
 	// int ((*zzz3)) (char);
 	// int (*(zzz4)) (char);
+	@Test
 	public void testBug40768() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		NameCollector col = new NameCollector();
@@ -218,6 +219,7 @@ public class AST2Tests extends AST2TestBase {
 	// void f(int y) {
 	//    int z = x + y;
 	// }
+	@Test
 	public void testBasicFunction() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -353,6 +355,7 @@ public class AST2Tests extends AST2TestBase {
 	//     S myS;
 	//     myS.x = 5;
 	// }
+	@Test
 	public void testSimpleStruct() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -459,6 +462,7 @@ public class AST2Tests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testCExpressions() throws ParserException {
 		validateSimpleUnaryExpressionC("++x", IASTUnaryExpression.op_prefixIncr); //$NON-NLS-1$
 		validateSimpleUnaryExpressionC("--x", IASTUnaryExpression.op_prefixDecr); //$NON-NLS-1$
@@ -505,10 +509,12 @@ public class AST2Tests extends AST2TestBase {
 		validateConditionalExpressionC("x ? y : x"); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testCPP20Expressions() throws ParserException {
 		validateSimpleBinaryExpressionCPP20("x<=>y", IASTBinaryExpression.op_threewaycomparison); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testMultipleDeclarators() throws Exception {
 		IASTTranslationUnit tu = parse("int r, s;", C); //$NON-NLS-1$
 		assertTrue(tu.isFrozen());
@@ -539,6 +545,7 @@ public class AST2Tests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testStructureTagScoping_1() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("struct A;             \n"); //$NON-NLS-1$
@@ -618,6 +625,7 @@ public class AST2Tests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testStructureTagScoping_2() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("struct A;             \n"); //$NON-NLS-1$
@@ -688,6 +696,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void test() {
 	//	  F(f("aaa"MACRO));
 	//	}
+	@Test
 	public void testStringConcatenationWithMacro() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			BindingAssertionHelper bh = getAssertionHelper(lang);
@@ -699,6 +708,7 @@ public class AST2Tests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testStructureDef() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("struct A;                \r\n"); //$NON-NLS-1$
@@ -811,6 +821,7 @@ public class AST2Tests extends AST2TestBase {
 	// void f(int x) {
 	//    struct x i;
 	// }
+	@Test
 	public void testStructureNamespace() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 
@@ -898,6 +909,7 @@ public class AST2Tests extends AST2TestBase {
 	// void f(int b) {
 	//    b;
 	// }
+	@Test
 	public void testFunctionParameters() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parse(code, C);
@@ -1004,6 +1016,7 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	// void f(int a, int b) { }
+	@Test
 	public void testSimpleFunction() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -1054,6 +1067,7 @@ public class AST2Tests extends AST2TestBase {
 	//    f();
 	// }
 	// void f() { }
+	@Test
 	public void testSimpleFunctionCall() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 
@@ -1119,6 +1133,7 @@ public class AST2Tests extends AST2TestBase {
 	//       i;
 	//    }
 	// }
+	@Test
 	public void testForLoop() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -1192,6 +1207,7 @@ public class AST2Tests extends AST2TestBase {
 	// void f() {
 	//    ((struct A *) 1)->x;
 	// }
+	@Test
 	public void testExpressionFieldReference() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -1249,6 +1265,7 @@ public class AST2Tests extends AST2TestBase {
 	//    }
 	//    end: ;
 	// }
+	@Test
 	public void testLabels() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -1283,6 +1300,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// typedef struct { } X;
 	// int f(X x);
+	@Test
 	public void testAnonStruct() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -1316,6 +1334,7 @@ public class AST2Tests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testLongLong() throws ParserException {
 		IASTTranslationUnit tu = parse("long long x;\n", C); //$NON-NLS-1$
 
@@ -1336,6 +1355,7 @@ public class AST2Tests extends AST2TestBase {
 	//    if (*cp != red)
 	//       return;
 	// }
+	@Test
 	public void testEnumerations() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -1474,6 +1494,7 @@ public class AST2Tests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testPointerToFunction() throws Exception {
 		IASTTranslationUnit tu = parse("int (*pfi)();", C); //$NON-NLS-1$
 		assertTrue(tu.isFrozen());
@@ -1503,6 +1524,7 @@ public class AST2Tests extends AST2TestBase {
 	// const char * const d;
 	// const char ** e;
 	// const char * const * const volatile ** const * f;
+	@Test
 	public void testBasicTypes() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -1599,6 +1621,7 @@ public class AST2Tests extends AST2TestBase {
 	// signed int signedInt = -2;
 	// unsigned int unsignedInt = 99;
 	// noSpec= 12;
+	@Test
 	public void testBug270275_int_is_equivalent_to_signed_int() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		IASTDeclaration[] declarations = tu.getDeclarations();
@@ -1620,6 +1643,7 @@ public class AST2Tests extends AST2TestBase {
 	// typedef struct A * AP;
 	// struct A * const a2;
 	// AP a3;
+	@Test
 	public void testCompositeTypes() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -1697,6 +1721,7 @@ public class AST2Tests extends AST2TestBase {
 	// char * b[][];
 	// const char * const c[][][];
 	// char* d[const][];
+	@Test
 	public void testArrayTypes() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -1778,6 +1803,7 @@ public class AST2Tests extends AST2TestBase {
 	// int * f(int i, char c);
 	// void (*g) (struct A *);
 	// void (* (*h)(struct A**)) (int d);
+	@Test
 	public void testFunctionTypes() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -1891,7 +1917,7 @@ public class AST2Tests extends AST2TestBase {
 			assertEquals(decls.length, 1);
 			assertEquals(decls[0], name_A1);
 
-			assertNull("Expected null, got " + name_d.resolveBinding(), name_d.resolveBinding());
+			assertNull(name_d.resolveBinding(), "Expected null, got " + name_d.resolveBinding());
 
 			tu = validateCopy(tu);
 		}
@@ -1910,6 +1936,7 @@ public class AST2Tests extends AST2TestBase {
 	// Coord xy = {.y = 10, .x = 11};
 	// Point point = {.width = 100, .pos = &xy};
 	// }
+	@Test
 	public void testDesignatedInitializers() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -2014,6 +2041,7 @@ public class AST2Tests extends AST2TestBase {
 	// int f() {
 	// struct S s = {.a=1,.b=2};
 	// }
+	@Test
 	public void testMoregetDeclarationsInAST1() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -2053,6 +2081,7 @@ public class AST2Tests extends AST2TestBase {
 	//  int a;
 	//  int b;
 	// } s = {.a=1,.b=2};
+	@Test
 	public void testMoregetDeclarationsInAST2() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -2092,6 +2121,7 @@ public class AST2Tests extends AST2TestBase {
 	// typedef s t;
 	// typedef t y;
 	// y x = {.a=1,.b=2};
+	@Test
 	public void testMoregetDeclarationsInAST3() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -2125,6 +2155,7 @@ public class AST2Tests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testFnReturningPtrToFn() throws Exception {
 		IASTTranslationUnit tu = parse("void (* f(int))() {}", C); //$NON-NLS-1$
 		assertTrue(tu.isFrozen());
@@ -2152,6 +2183,7 @@ public class AST2Tests extends AST2TestBase {
 	// type'', where the type qualifiers (if any) are those specified within the
 	// [ and ] of the
 	// array type derivation.
+	@Test
 	public void testArrayTypeToQualifiedPointerTypeParm() throws Exception {
 		IASTTranslationUnit tu = parse("void f(int parm[const 3]);", C); //$NON-NLS-1$
 		assertTrue(tu.isFrozen());
@@ -2179,6 +2211,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void test(int a[]) {
 	//	  func(&a);
 	//	}
+	@Test
 	public void testArrayPointer_261417() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper baC = new AST2AssertionHelper(code, false);
@@ -2190,6 +2223,7 @@ public class AST2Tests extends AST2TestBase {
 	// int f() {}
 	// int *f2() {}
 	// int (* f3())() {}
+	@Test
 	public void testFunctionDefTypes() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 
@@ -2233,6 +2267,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// any parameter to type function returning T is adjusted to be pointer to
 	// function returning T
+	@Test
 	public void testParmToFunction() throws Exception {
 		IASTTranslationUnit tu = parse("int f(int g(void)) { return g();}", C);
 		assertTrue(tu.isFrozen());
@@ -2265,14 +2300,14 @@ public class AST2Tests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testArrayPointerFunction() throws Exception {
 		IASTTranslationUnit tu = parse("int (*v[])(int *x, int *y);", C);
 
 		assertTrue(tu.isFrozen());
 		for (int i = 0; i < NUM_TESTS; i++) {
 			IASTSimpleDeclaration decl = (IASTSimpleDeclaration) tu.getDeclarations()[0];
-			IVariable v = (IVariable) ((IASTStandardFunctionDeclarator) decl.getDeclarators()[0]).getNestedDeclarator()
-					.getName().resolveBinding();
+			IVariable v = (IVariable) decl.getDeclarators()[0].getNestedDeclarator().getName().resolveBinding();
 
 			IType vt_1 = v.getType();
 			assertTrue(vt_1 instanceof IArrayType);
@@ -2296,11 +2331,10 @@ public class AST2Tests extends AST2TestBase {
 			assertEquals(((IBasicType) vpt_2_2).getType(), IBasicType.t_int);
 
 			// test tu.getDeclarationsInAST(IBinding)
-			IASTName[] decls = tu.getDeclarationsInAST(((IASTStandardFunctionDeclarator) decl.getDeclarators()[0])
-					.getNestedDeclarator().getName().resolveBinding());
+			IASTName[] decls = tu
+					.getDeclarationsInAST(decl.getDeclarators()[0].getNestedDeclarator().getName().resolveBinding());
 			assertEquals(decls.length, 1);
-			assertEquals(decls[0],
-					((IASTStandardFunctionDeclarator) decl.getDeclarators()[0]).getNestedDeclarator().getName());
+			assertEquals(decls[0], decl.getDeclarators()[0].getNestedDeclarator().getName());
 
 			tu = validateCopy(tu);
 		}
@@ -2309,6 +2343,7 @@ public class AST2Tests extends AST2TestBase {
 	// typedef void DWORD;
 	// typedef DWORD v;
 	// v signal(int);
+	@Test
 	public void testTypedefExample4a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 
@@ -2364,6 +2399,7 @@ public class AST2Tests extends AST2TestBase {
 	// typedef void DWORD;
 	// typedef DWORD (*pfv)(int);
 	// pfv signal(int, pfv);
+	@Test
 	public void testTypedefExample4b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -2444,6 +2480,7 @@ public class AST2Tests extends AST2TestBase {
 	// void (*signal1(int, void (*)(int)))(int);
 	// fv *signal2(int, fv *);
 	// pfv signal3(int, pfv);
+	@Test
 	public void testTypedefExample4c() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 
@@ -2523,6 +2560,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// const int x = 10;
 	// int y [ const static x ];
+	@Test
 	public void testBug80992() throws Exception {
 		ICASTArrayModifier mod = (ICASTArrayModifier) ((IASTArrayDeclarator) ((IASTSimpleDeclaration) parse(
 				getAboveComment(), C).getDeclarations()[1]).getDeclarators()[0]).getArrayModifiers()[0];
@@ -2534,6 +2572,7 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	// int y (int [ const *]);
+	@Test
 	public void testBug80978() throws Exception {
 		ICASTArrayModifier mod = (ICASTArrayModifier) ((IASTArrayDeclarator) ((IASTStandardFunctionDeclarator) ((IASTSimpleDeclaration) parse(
 				getAboveComment(), C).getDeclarations()[0]).getDeclarators()[0]).getParameters()[0].getDeclarator())
@@ -2570,6 +2609,7 @@ public class AST2Tests extends AST2TestBase {
 	//    if (a > 0)
 	//       g(*(&a + 2));
 	// }
+	@Test
 	public void testExternalDefs() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -2595,6 +2635,7 @@ public class AST2Tests extends AST2TestBase {
 	// int f() {
 	//    Coord xy = { .x = 10, .y = 11 };
 	// }
+	@Test
 	public void testFieldDesignators() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -2620,6 +2661,7 @@ public class AST2Tests extends AST2TestBase {
 	//    [member_one] = "one",
 	//    [member_two] = "two"
 	// };
+	@Test
 	public void testArrayDesignator() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -2646,6 +2688,7 @@ public class AST2Tests extends AST2TestBase {
 	// else if (a > 0)
 	// g(*(&a + 2));
 	// }
+	@Test
 	public void testBug83737() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -2671,6 +2714,7 @@ public class AST2Tests extends AST2TestBase {
 	//    }
 	//    end: ;
 	// }
+	@Test
 	public void testBug84090_LabelReferences() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -2691,6 +2735,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// enum col { red, blue };
 	// enum col c;
+	@Test
 	public void testBug84092_EnumReferences() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -2709,6 +2754,7 @@ public class AST2Tests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testBug84096_FieldDesignatorRef() throws Exception {
 		IASTTranslationUnit tu = parse("struct s { int a; } ss = { .a = 1 }; \n", C); //$NON-NLS-1$
 		assertTrue(tu.isFrozen());
@@ -2727,6 +2773,7 @@ public class AST2Tests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testProblems() throws Exception {
 		IASTTranslationUnit tu = parse("    a += ;", C, ScannerKind.GNU, false); //$NON-NLS-1$
 		IASTProblem[] ps = CVisitor.getProblems(tu);
@@ -2736,6 +2783,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// enum e;
 	// enum e{ one };
+	@Test
 	public void testEnumerationForwards() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -2759,6 +2807,7 @@ public class AST2Tests extends AST2TestBase {
 	//    int (*p) [2];
 	//    (&p)[0] = 1;
 	// }
+	@Test
 	public void testBug84185() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		NameCollector col = new NameCollector();
@@ -2778,6 +2827,7 @@ public class AST2Tests extends AST2TestBase {
 	//    int (*p) [2];
 	//    (&p)[0] = 1;
 	// }
+	@Test
 	public void testBug84185_2() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		NameCollector col = new NameCollector();
@@ -2800,12 +2850,14 @@ public class AST2Tests extends AST2TestBase {
 	// q = p;
 	// p = &((struct s) { j++ });
 	// }
+	@Test
 	public void testBug84176() throws Exception {
 		parse(getAboveComment(), C, ScannerKind.STD, true);
 	}
 
 	// struct s { double i; } f(void);
 	// struct s f(void) {}
+	@Test
 	public void testBug84266() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parse(code, C);
@@ -2827,6 +2879,7 @@ public class AST2Tests extends AST2TestBase {
 		assertSame(s_ref, s_decl);
 	}
 
+	@Test
 	public void testBug84266_2() throws Exception {
 		IASTTranslationUnit tu = parse("struct s f(void);", C); //$NON-NLS-1$
 		NameCollector col = new NameCollector();
@@ -2847,6 +2900,7 @@ public class AST2Tests extends AST2TestBase {
 		assertNotNull(s);
 	}
 
+	@Test
 	public void testBug84250() throws Exception {
 		assertTrue(((IASTDeclarationStatement) ((IASTCompoundStatement) ((IASTFunctionDefinition) parse(
 				"void f() { int (*p) [2]; }", C).getDeclarations()[0]).getBody()).getStatements()[0]) //$NON-NLS-1$
@@ -2855,6 +2909,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// struct s1 { struct s2 *s2p; /* ... */ }; // D1
 	// struct s2 { struct s1 *s1p; /* ... */ }; // D2
+	@Test
 	public void testBug84186() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			final String code = getAboveComment();
@@ -2883,6 +2938,7 @@ public class AST2Tests extends AST2TestBase {
 	//    (*funcp)()->a;
 	//    funcp()->a;
 	// }
+	@Test
 	public void testBug84267() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		NameCollector col = new NameCollector();
@@ -2910,6 +2966,7 @@ public class AST2Tests extends AST2TestBase {
 	//    int x;
 	//    { int x = x; }
 	// }
+	@Test
 	public void testBug84228() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		NameCollector col = new NameCollector();
@@ -2934,6 +2991,7 @@ public class AST2Tests extends AST2TestBase {
 		assertSame(ds[0], col.getName(11));
 	}
 
+	@Test
 	public void testBug84236() throws Exception {
 		String code = "double maximum(double a[ ][*]);"; //$NON-NLS-1$
 		IASTSimpleDeclaration d = (IASTSimpleDeclaration) parse(code, C).getDeclarations()[0];
@@ -2949,6 +3007,7 @@ public class AST2Tests extends AST2TestBase {
 	// void g() {
 	// B * bp;  //1
 	// }
+	@Test
 	public void testBug85049() throws Exception {
 		IASTTranslationUnit t = parse(getAboveComment(), C);
 		IASTFunctionDefinition g = (IASTFunctionDefinition) t.getDeclarations()[1];
@@ -2960,6 +3019,7 @@ public class AST2Tests extends AST2TestBase {
 
 	}
 
+	@Test
 	public void testBug86766() throws Exception {
 		IASTTranslationUnit tu = parse("char foo; void foo() {}", C); //$NON-NLS-1$
 		NameCollector col = new NameCollector();
@@ -2971,6 +3031,7 @@ public class AST2Tests extends AST2TestBase {
 		assertNotNull(foo);
 	}
 
+	@Test
 	public void testBug88338_C() throws Exception {
 		IASTTranslationUnit tu = parse("struct A; struct A* a;", C); //$NON-NLS-1$
 		NameCollector col = new NameCollector();
@@ -2994,6 +3055,7 @@ public class AST2Tests extends AST2TestBase {
 		assertFalse(col.getName(2).isReference());
 	}
 
+	@Test
 	public void test88460() throws Exception {
 		IASTTranslationUnit tu = parse("void f();", C); //$NON-NLS-1$
 		NameCollector col = new NameCollector();
@@ -3003,6 +3065,7 @@ public class AST2Tests extends AST2TestBase {
 		assertFalse(f.isStatic());
 	}
 
+	@Test
 	public void testBug90253() throws Exception {
 		IASTTranslationUnit tu = parse("void f(int par) { int v1; };", C); //$NON-NLS-1$
 		NameCollector col = new NameCollector();
@@ -3032,6 +3095,7 @@ public class AST2Tests extends AST2TestBase {
 	//       S :  ;
 	//    }
 	// }
+	@Test
 	public void testFind() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		NameCollector col = new NameCollector();
@@ -3055,6 +3119,7 @@ public class AST2Tests extends AST2TestBase {
 		assertSame(bs[2], S4);
 	}
 
+	@Test
 	public void test92791() throws Exception {
 		IASTTranslationUnit tu = parse("void f() { int x, y; x * y; }", C); //$NON-NLS-1$
 		NameCollector col = new NameCollector();
@@ -3069,6 +3134,7 @@ public class AST2Tests extends AST2TestBase {
 			assertFalse(col.getName(i).resolveBinding() instanceof IProblemBinding);
 	}
 
+	@Test
 	public void testBug85786() throws Exception {
 		IASTTranslationUnit tu = parse("void f(int); void foo () { void * p = &f; ((void (*) (int)) p) (1); }", C); //$NON-NLS-1$
 		NameCollector nameResolver = new NameCollector();
@@ -3081,6 +3147,7 @@ public class AST2Tests extends AST2TestBase {
 	// i= i&0x00ff;
 	// i= (i)&0x00ff;
 	// }
+	@Test
 	public void testBug95720() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		NameCollector nameResolver = new NameCollector();
@@ -3096,6 +3163,7 @@ public class AST2Tests extends AST2TestBase {
 	// TWO("string"); /* err */
 	// return 0;
 	// }
+	@Test
 	public void testBug94365() throws Exception {
 		parse(getAboveComment(), C);
 	}
@@ -3104,6 +3172,7 @@ public class AST2Tests extends AST2TestBase {
 	// void main() {
 	// MACRO('"');
 	// }
+	@Test
 	public void testBug95119_a() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		IASTDeclaration[] declarations = tu.getDeclarations();
@@ -3119,6 +3188,7 @@ public class AST2Tests extends AST2TestBase {
 	// void main() {
 	// MACRO('X');
 	// }
+	@Test
 	public void testBug95119_b() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C);
 		IASTDeclaration[] declarations = tu.getDeclarations();
@@ -3133,12 +3203,14 @@ public class AST2Tests extends AST2TestBase {
 	// typedef long _TYPE;
 	// typedef _TYPE TYPE;
 	// int function(TYPE (* pfv)(int parm));
+	@Test
 	public void testBug81739() throws Exception {
 		parse(getAboveComment(), C);
 	}
 
 	// float _Complex x;
 	// double _Complex y;
+	@Test
 	public void testBug95757() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.GNU, true);
 		IASTDeclaration[] decls = tu.getDeclarations();
@@ -3154,6 +3226,7 @@ public class AST2Tests extends AST2TestBase {
 	// int foo();
 	// typeof({ int x = foo();
 	//          x; }) zoot;
+	@Test
 	public void testBug93980() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
@@ -3168,6 +3241,7 @@ public class AST2Tests extends AST2TestBase {
 		assertEquals(((IBasicType) t).getType(), IBasicType.t_int);
 	}
 
+	@Test
 	public void testBug95866() throws Exception {
 		IASTTranslationUnit tu = parse("int test[10] = { [0 ... 9] = 2 };", C, ScannerKind.GNU, true); //$NON-NLS-1$
 		NameCollector col = new NameCollector();
@@ -3175,6 +3249,7 @@ public class AST2Tests extends AST2TestBase {
 		assertNoProblemBindings(col);
 	}
 
+	@Test
 	public void testBug98502() throws Exception {
 		IASTTranslationUnit tu = parse("typedef enum { ONE } e;", C, ScannerKind.GNU, true); //$NON-NLS-1$
 		NameCollector col = new NameCollector();
@@ -3191,6 +3266,7 @@ public class AST2Tests extends AST2TestBase {
 	// void f() {
 	//    PIPERR;
 	// }
+	@Test
 	public void testBug98365() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
@@ -3200,6 +3276,7 @@ public class AST2Tests extends AST2TestBase {
 		assertSame(etor, col.getName(6).resolveBinding());
 	}
 
+	@Test
 	public void testBug99262() throws Exception {
 		parse("void foo() {void *f; f=__null;}", C, ScannerKind.GNU, true); //$NON-NLS-1$
 	}
@@ -3209,6 +3286,7 @@ public class AST2Tests extends AST2TestBase {
 	// void f2() {
 	//   f1(__null);
 	// }
+	@Test
 	public void testBug240567() throws Exception {
 		BindingAssertionHelper bh = new AST2AssertionHelper(getAboveComment(), false);
 		bh.assertNonProblem("f1(__null", 2, IFunction.class);
@@ -3218,6 +3296,7 @@ public class AST2Tests extends AST2TestBase {
 	//    int a;
 	//    { a; int a; }
 	// }
+	@Test
 	public void testBug98960() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
@@ -3231,6 +3310,7 @@ public class AST2Tests extends AST2TestBase {
 		assertNotSame(a2, a3);
 	}
 
+	@Test
 	public void testBug100408() throws Exception {
 		IASTTranslationUnit tu = parse("int foo() { int x=1; (x)*3; }", C); //$NON-NLS-1$
 		NameCollector col = new NameCollector();
@@ -3247,6 +3327,7 @@ public class AST2Tests extends AST2TestBase {
 	// struct nfa * nfa;
 	// {
 	// }
+	@Test
 	public void testBug98760() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
@@ -3267,10 +3348,12 @@ public class AST2Tests extends AST2TestBase {
 	// #define MY_DETAILS { 20, 30 }
 	// Employee e = (Employee)MY_DETAILS;
 	// }
+	@Test
 	public void testBug79650() throws Exception {
 		parseAndCheckBindings(getAboveComment());
 	}
 
+	@Test
 	public void testBug80171() throws Exception {
 		parseAndCheckBindings("static var;"); //$NON-NLS-1$
 	}
@@ -3287,6 +3370,7 @@ public class AST2Tests extends AST2TestBase {
 	// {
 	// }
 	// }
+	@Test
 	public void testBug79067() throws Exception {
 		parseAndCheckBindings(getAboveComment());
 	}
@@ -3298,6 +3382,7 @@ public class AST2Tests extends AST2TestBase {
 	// enum COLOR ret;
 	// return ret;
 	// }
+	@Test
 	public void testBug84759() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment());
 		IASTFunctionDefinition fd = (IASTFunctionDefinition) tu.getDeclarations()[1];
@@ -3308,6 +3393,7 @@ public class AST2Tests extends AST2TestBase {
 	// int f() {
 	// int x = 4;  while (x < 10) blah: ++x;
 	// }
+	@Test
 	public void test1043290() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment());
 		IASTFunctionDefinition fd = (IASTFunctionDefinition) tu.getDeclarations()[0];
@@ -3324,6 +3410,7 @@ public class AST2Tests extends AST2TestBase {
 	//    for (int x; ;)
 	//       blah: x;
 	// }
+	@Test
 	public void testBug104390_2() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.GNU);
 		NameCollector col = new NameCollector();
@@ -3341,6 +3428,7 @@ public class AST2Tests extends AST2TestBase {
 	// do { ++i; } while (i < 10);
 	// return 0;
 	// }
+	@Test
 	public void testBug104800() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment());
 		IASTFunctionDefinition f = (IASTFunctionDefinition) tu.getDeclarations()[0];
@@ -3348,6 +3436,7 @@ public class AST2Tests extends AST2TestBase {
 		assertEquals(body.getStatements().length, 3);
 	}
 
+	@Test
 	public void testBug107150() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#define FUNC_PROTOTYPE_PARAMS(list)    list\r\n"); //$NON-NLS-1$
@@ -3378,6 +3467,7 @@ public class AST2Tests extends AST2TestBase {
 		assertFalse(tu.getDeclarations()[1] instanceof IASTProblemDeclaration);
 	}
 
+	@Test
 	public void testBug107150b() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#define FUNC_PROTOTYPE_PARAMS(list)    list\r\n"); //$NON-NLS-1$
@@ -3450,6 +3540,7 @@ public class AST2Tests extends AST2TestBase {
 	//         _addToListHead(newWindow);
 	//     return newWindow;
 	// }
+	@Test
 	public void testBug143502() throws Exception {
 		parse(getAboveComment(), C, ScannerKind.GNU, false);
 	}
@@ -3464,6 +3555,7 @@ public class AST2Tests extends AST2TestBase {
 	//    z= (a)/z;
 	//    z= (a)%z;
 	// }
+	@Test
 	public void testBracketAroundIdentifier_168924() throws IOException, ParserException {
 		String content = getAboveComment();
 		IASTTranslationUnit tu = parse(content, C, ScannerKind.GNU, true);
@@ -3483,6 +3575,7 @@ public class AST2Tests extends AST2TestBase {
 	//  void func() {
 	//     MAC(");
 	//  }
+	@Test
 	public void testBug179383() throws ParserException, IOException {
 		parse(getAboveComment(), C, ScannerKind.STD, false);
 	}
@@ -3491,6 +3584,7 @@ public class AST2Tests extends AST2TestBase {
 	 * Bug in not removing single-line comments from macros.
 	 * @throws Exception
 	 */
+	@Test
 	public void testMacroCommentsBug_177154() throws Exception {
 		// simple case
 		String simple = "#define LIT 1  // my value\r\n" + "int func(int x) {\r\n" + "}\r\n" + "int main() {\r\n"
@@ -3528,6 +3622,7 @@ public class AST2Tests extends AST2TestBase {
 	// void foo() {
 	//    decl('a');
 	// }
+	@Test
 	public void testBug181305_1() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit tu = parse(getAboveComment(), lang, ScannerKind.GNU, true);
@@ -3539,8 +3634,8 @@ public class AST2Tests extends AST2TestBase {
 			IASTFunctionCallExpression expr = (IASTFunctionCallExpression) expr_stmt.getExpression();
 			IASTIdExpression idExpr = (IASTIdExpression) expr.getFunctionNameExpression();
 			IBinding binding = idExpr.getName().resolveBinding();
-			assertTrue(lang.toString(), binding instanceof IFunction);
-			assertFalse(lang.toString(), binding instanceof IProblemBinding);
+			assertTrue(binding instanceof IFunction, lang.toString());
+			assertFalse(binding instanceof IProblemBinding, lang.toString());
 			assertEquals(binding.getName(), "decl");
 		}
 	}
@@ -3549,6 +3644,7 @@ public class AST2Tests extends AST2TestBase {
 	// void foo() {
 	//    decl('a');
 	// }
+	@Test
 	public void testBug181305_2() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit tu = parse(getAboveComment(), lang, ScannerKind.GNU, true);
@@ -3560,11 +3656,12 @@ public class AST2Tests extends AST2TestBase {
 			IASTFunctionCallExpression expr = (IASTFunctionCallExpression) expr_stmt.getExpression();
 			IASTIdExpression idExpr = (IASTIdExpression) expr.getFunctionNameExpression();
 			IBinding binding = idExpr.getName().resolveBinding();
-			assertTrue(lang.toString(), binding instanceof IVariable);
-			assertFalse(lang.toString(), binding instanceof IProblemBinding);
+			assertTrue(binding instanceof IVariable, lang.toString());
+			assertFalse(binding instanceof IProblemBinding, lang.toString());
 		}
 	}
 
+	@Test
 	public void testBug181735() throws Exception {
 		String code = "int (*f)(int);\n" + "int g(int n) {return n;}\n" + "int g(int n, int m) {return n;}\n"
 				+ "void foo() { f=g; }";
@@ -3576,11 +3673,13 @@ public class AST2Tests extends AST2TestBase {
 	// void test() {
 	//    char d= *"b";
 	// }
+	@Test
 	public void testBug181942() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values())
 			parse(getAboveComment(), lang, ScannerKind.GNU, true);
 	}
 
+	@Test
 	public void testMacroCommentsBug_177154_2() throws Exception {
 		String noCommentMacro = "#define Sonar16G(x) ((Sonr16G(x)<<16)|0xff000000L)\r\n";
 		String commentMacro = "#define Sonar16G(x) ((Sonr16G(x)<<16)|0xff000000L)	// add the varf value\r\n";
@@ -3607,11 +3706,13 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	// int __builtin_sin;
+	@Test
 	public void testBug182464() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values())
 			parseAndCheckBindings(getAboveComment(), lang, ScannerKind.GNU);
 	}
 
+	@Test
 	public void testBug186018() throws Exception {
 		String code = "int main() { \n" + "    switch(1) { \n" + "        case 1 : \n" + "        case 2 : \n"
 				+ "            printf(\"pantera rules\"); \n" + "    } \n" + "}\n";
@@ -3643,6 +3744,7 @@ public class AST2Tests extends AST2TestBase {
 	//	    int c = (*a).method();      // Problem: method
 	//	  }
 	//	};
+	@Test
 	public void test186736() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), CPP);
 		assertTrue(tu.isFrozen());
@@ -3695,6 +3797,7 @@ public class AST2Tests extends AST2TestBase {
 	//	    int b2 = a2->method();        // Problem: method
 	//	  }
 	//	};
+	@Test
 	public void test186736_variant1() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), CPP);
 		assertTrue(tu.isFrozen());
@@ -3733,6 +3836,7 @@ public class AST2Tests extends AST2TestBase {
 	//		(&aa)->foo();
 	//		(&a)->foo();
 	//	}
+	@Test
 	public void test186736_variant2() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), CPP);
 		validateCopy(tu);
@@ -3742,6 +3846,7 @@ public class AST2Tests extends AST2TestBase {
 	// int32 f(int32 (*p)) {
 	//   return *p;
 	// }
+	@Test
 	public void test167833() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP);
 		parseAndCheckBindings(getAboveComment(), C);
@@ -3752,6 +3857,7 @@ public class AST2Tests extends AST2TestBase {
 	// char str[] = " multi \
 	// line \
 	// string";
+	@Test
 	public void testBug188707_backslashNewline() throws Exception {
 		parseAndCheckBindings(getAboveComment());
 	}
@@ -3763,6 +3869,7 @@ public class AST2Tests extends AST2TestBase {
 	// typedef H *H;
 	// typedef I *************I;
 	// typedef int (*J)(J);
+	@Test
 	public void testBug192165() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit tu = parse(getAboveComment(), lang, ScannerKind.GNU, false);
@@ -3800,11 +3907,13 @@ public class AST2Tests extends AST2TestBase {
 	// #define INVALID(a, b)  ## a ## b
 	// INVALID(1, 2)
 	//
+	@Test
 	public void test192639() throws Exception {
 		parse(getAboveComment(), CPP, ScannerKind.STD, false);
 		parse(getAboveComment(), C, ScannerKind.STD, false);
 	}
 
+	@Test
 	public void test195943() throws Exception {
 		final int depth = 100;
 		StringBuilder buffer = new StringBuilder();
@@ -3820,6 +3929,7 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	// int array[12]= {};
+	@Test
 	public void testBug196468_emptyArrayInitializer() throws Exception {
 		final String content = getAboveComment();
 		parse(content, CPP, ScannerKind.STD);
@@ -3842,6 +3952,7 @@ public class AST2Tests extends AST2TestBase {
 	//	   foo("a", bar(), bar); // Eclipse Syntax error
 	//     return 0;
 	//  }
+	@Test
 	public void testBug197633_parenthesisInVarargMacros() throws Exception {
 		final String content = getAboveComment();
 		parse(content, CPP);
@@ -3851,6 +3962,7 @@ public class AST2Tests extends AST2TestBase {
 	// void  (__attribute__((__stdcall__))* foo1) (int);
 	// void  (* __attribute__((__stdcall__)) foo2) (int);
 	// void  (* __attribute__((__stdcall__))* foo3) (int);
+	@Test
 	public void testBug191450_attributesInBetweenPointers() throws Exception {
 		parse(getAboveComment(), CPP, ScannerKind.GNU, true);
 		parse(getAboveComment(), C, ScannerKind.GNU, true);
@@ -3860,6 +3972,7 @@ public class AST2Tests extends AST2TestBase {
 	// namespace NameClash {};
 	// namespace NameClash2 {};
 	// class NameClash2 {};
+	@Test
 	public void testBug202271_nameClash() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 		assertTrue(tu.isFrozen());
@@ -3879,6 +3992,7 @@ public class AST2Tests extends AST2TestBase {
 	// #define MACRO 1
 	// int a= MACRO;
 	// int b= WRAP(MACRO);
+	@Test
 	public void testBug94673_refsForMacrosAsArguments() throws Exception {
 		String content = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(content, CPP, ScannerKind.GNU);
@@ -3936,6 +4050,7 @@ public class AST2Tests extends AST2TestBase {
 	//	    ASSERT(a > b, "Error!");// marked with error also
 	//	    ASSERT(false);// fine
 	//	}
+	@Test
 	public void testBug188855_gccExtensionForVariadicMacros() throws Exception {
 		CharSequence[] buffer = getContents(2);
 		final String content1 = buffer[0].toString();
@@ -3969,6 +4084,8 @@ public class AST2Tests extends AST2TestBase {
 	//
 	// 	Point points[] = {{.x=1, .y=1}, {.x=2, .y=2}};
 	// }
+	@Test
+	@Disabled("Known failing")
 	public void _testBug210019_nestedDesignatedInitializers() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), C);
 		NameCollector col = new NameCollector();
@@ -4046,6 +4163,7 @@ public class AST2Tests extends AST2TestBase {
 	//   [0].x=1, 2,
 	//   3, 4
 	// };
+	@Test
 	public void testBug210019_designatedInitializers() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), C);
 		assertTrue(tu.isFrozen());
@@ -4085,6 +4203,7 @@ public class AST2Tests extends AST2TestBase {
 	// void test() {
 	//    externFunc();
 	// }
+	@Test
 	public void testBug183126_nestedLinkageSpecs() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP);
 	}
@@ -4099,6 +4218,7 @@ public class AST2Tests extends AST2TestBase {
 	//  f2(&i); // ok
 	//  f3(&i); // ok
 	// }
+	@Test
 	public void testBug213029_cvConversion() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP, ScannerKind.STD);
 		NameCollector col = new NameCollector();
@@ -4119,6 +4239,7 @@ public class AST2Tests extends AST2TestBase {
 	//   int foux=0, bhar=0;
 	//   foux = (foux) - bhar1;
 	// }
+	@Test
 	public void testBug100641_106279_castAmbiguity() throws Exception {
 		boolean cpp = false;
 		do {
@@ -4161,6 +4282,7 @@ public class AST2Tests extends AST2TestBase {
 	//    	f4(vi);
 	//    	f4(cvi);
 	//    }
+	@Test
 	public void testBug222418_a() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 		ba.assertNonProblem("f1(i)", 2);
@@ -4200,6 +4322,7 @@ public class AST2Tests extends AST2TestBase {
 	//    	f1(vi); // (3)
 	//    	f1(cvi); // (4)
 	//    }
+	@Test
 	public void testBug222418_b() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 
@@ -4218,6 +4341,7 @@ public class AST2Tests extends AST2TestBase {
 	//    void f1(const int r) {} // 2
 	//    void f1(volatile int r) {} // 3
 	//    void f1(const volatile int r) {} // 4
+	@Test
 	public void testBug222418_b_regression() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 		ba.assertNonProblem("f1(int", 2, ICPPFunction.class);
@@ -4244,6 +4368,7 @@ public class AST2Tests extends AST2TestBase {
 	//    	fc(five()); // should be an error
 	//    	fd(five()); // should be an error
 	//    }
+	@Test
 	public void testBug222418_c() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 
@@ -4276,6 +4401,7 @@ public class AST2Tests extends AST2TestBase {
 	//		f_const(2);    // ok
 	//		f_nonconst(2); // should be an error
 	//	}
+	@Test
 	public void testBug222418_d() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 		ba.assertNonProblem("f_const(2", 7, ICPPFunction.class);
@@ -4315,6 +4441,7 @@ public class AST2Tests extends AST2TestBase {
 	//		f4(vi);
 	//		f4(cvi);
 	//	}
+	@Test
 	public void testBug222418_e() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 		ba.assertNonProblem("f1(i)", 2);
@@ -4390,6 +4517,7 @@ public class AST2Tests extends AST2TestBase {
 	//
 	//		return 0;
 	//	}
+	@Test
 	public void testBug222418_f() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 		ba.assertNonProblem("foo1(a)", 4);
@@ -4415,6 +4543,7 @@ public class AST2Tests extends AST2TestBase {
 	//    const B& b2= b;
 	//    f(b2);
 	// }
+	@Test
 	public void testBug222418_g_regression() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 		ba.assertNonProblem("f(b2)", 1);
@@ -4426,6 +4555,7 @@ public class AST2Tests extends AST2TestBase {
 	//    int& r= a;
 	//    f(r);
 	// }
+	@Test
 	public void testBug222418_h_regression() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 		ba.assertNonProblem("f(r)", 1);
@@ -4439,6 +4569,7 @@ public class AST2Tests extends AST2TestBase {
 	//    B& b2= b;
 	//    f(b2);
 	// }
+	@Test
 	public void testBug222418_i_regression() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 		ba.assertNonProblem("f(b2)", 1);
@@ -4478,6 +4609,7 @@ public class AST2Tests extends AST2TestBase {
 	//
 	//		return ri;
 	//	}
+	@Test
 	public void testBug222418_j() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 
@@ -4517,6 +4649,7 @@ public class AST2Tests extends AST2TestBase {
 	//    A a;
 	//    a.foo();
 	// }
+	@Test
 	public void testBug222418_k_regression() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 		ba.assertNonProblem("foo();", 3);
@@ -4538,6 +4671,7 @@ public class AST2Tests extends AST2TestBase {
 	//		foo(b);
 	//		foo(c);
 	//	}
+	@Test
 	public void testBug222444_a() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 		ICPPFunction foo1 = ba.assertNonProblem("foo(b", 3, ICPPFunction.class);
@@ -4559,6 +4693,7 @@ public class AST2Tests extends AST2TestBase {
 	//
 	//		foo(c);
 	//	}
+	@Test
 	public void testBug222444_b() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 		ICPPFunction foo2 = ba.assertNonProblem("foo(c", 3, ICPPFunction.class);
@@ -4579,6 +4714,7 @@ public class AST2Tests extends AST2TestBase {
 	//
 	//		foo(c);
 	//	}
+	@Test
 	public void testBug222444_c() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 		ICPPFunction foo2 = ba.assertNonProblem("foo(c", 3, ICPPFunction.class);
@@ -4588,6 +4724,7 @@ public class AST2Tests extends AST2TestBase {
 	// void test() {
 	//    a= b ? : c;
 	// }
+	@Test
 	public void testOmittedPositiveExpression_212905() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C);
@@ -4599,6 +4736,7 @@ public class AST2Tests extends AST2TestBase {
 	// static __inline__  __u32 f(int x) {
 	//   return x;
 	// }
+	@Test
 	public void testRedefinedGCCKeywords_226112() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -4607,6 +4745,7 @@ public class AST2Tests extends AST2TestBase {
 
 	//	int foo asm ("myfoo") __attribute__((__used__)), ff asm("ss") = 2;
 	//	extern void func () asm ("FUNC") __attribute__((__used__));
+	@Test
 	public void testASMLabels_226121() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -4616,6 +4755,7 @@ public class AST2Tests extends AST2TestBase {
 	// void test() {
 	//    ({1;}) != 0;
 	// }
+	@Test
 	public void testCompoundStatementExpression_226274() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -4625,6 +4765,7 @@ public class AST2Tests extends AST2TestBase {
 	//  int main() {
 	//      (typeof(({ 0; }))) 0;
 	//  }
+	@Test
 	public void testTypeofStatementExpressionInCastExpression_427950() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -4635,6 +4776,7 @@ public class AST2Tests extends AST2TestBase {
 	//    __typeof__(count) a= 1;
 	//    int ret0 = ((__typeof__(count)) 1);
 	// }
+	@Test
 	public void testTypeofUnaryExpression_226492() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -4644,6 +4786,7 @@ public class AST2Tests extends AST2TestBase {
 	// void test(int count) {
 	//    typeof(count==1) a= 1;
 	// }
+	@Test
 	public void testTypeofExpression_226492() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -4653,6 +4796,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void func() {
 	//	  typeof(__attribute__((regparm(3)))void (*)(int *)) a;
 	//	}
+	@Test
 	public void testTypeofExpressionWithAttribute_226492() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -4668,6 +4812,7 @@ public class AST2Tests extends AST2TestBase {
 	//        const typeof(t) x;
 	//        x.field;
 	//    }
+	@Test
 	public void testTypeofInsideQualifier_471907() throws Exception {
 		parseAndCheckBindings(getAboveComment(), C);
 	}
@@ -4677,6 +4822,7 @@ public class AST2Tests extends AST2TestBase {
 	//       case 1 ... 3: break;
 	//    }
 	// }
+	@Test
 	public void testCaseRange_211882() throws Exception {
 		final String code = getAboveComment();
 		{
@@ -4708,6 +4854,7 @@ public class AST2Tests extends AST2TestBase {
 	//	typedef int* TIntPtr;
 	//	int x(int (int * a));
 	//	int x(int(TIntPtr));
+	@Test
 	public void testInfiniteRecursion_269052() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -4719,12 +4866,14 @@ public class AST2Tests extends AST2TestBase {
 	//			return typename T::t();
 	//		}
 	//	};
+	@Test
 	public void testTypenameInExpression() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
 	}
 
 	//	struct __attribute__((declspec)) bla;
+	@Test
 	public void testAttributeInElaboratedTypeSpecifier_227085() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -4733,6 +4882,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// struct X;
 	// void test(struct X* __restrict result);
+	@Test
 	public void testRestrictReference_227110() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, CPP, ScannerKind.GNU);
@@ -4740,6 +4890,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// char buf[256];
 	// int x= sizeof(buf)[0];
+	@Test
 	public void testSizeofUnaryWithParenthesis_227122() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C);
@@ -4755,6 +4906,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void test1() {
 	//		X* it = buffer == 0 ?  new (buffer) X : 0;
 	//	}
+	@Test
 	public void testPlacementNewInConditionalExpression_227104() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, CPP);
@@ -4763,6 +4915,7 @@ public class AST2Tests extends AST2TestBase {
 	// int f(x) {
 	//    return 0;
 	// }
+	@Test
 	public void testBug228422_noKnrParam() throws Exception {
 		CharSequence buffer = getContents(1)[0];
 		parse(buffer.toString(), C, ScannerKind.STD);
@@ -4787,6 +4940,7 @@ public class AST2Tests extends AST2TestBase {
 	//    	myUnion.bar=3;
 	//    	myUnionPointer->bar=4;
 	//    }
+	@Test
 	public void testBug228504_nonExistingMembers() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), lang);
@@ -4816,6 +4970,7 @@ public class AST2Tests extends AST2TestBase {
 	//    	testint(t-t);
 	//    	testint(0-t);
 	//    }
+	@Test
 	public void testTypeOfPointerOperations() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code, C);
@@ -4832,6 +4987,7 @@ public class AST2Tests extends AST2TestBase {
 	//    void function2() {
 	//        function1(); // ref
 	//    }
+	@Test
 	public void testOutOfOrderResolution_232300() throws Exception {
 		String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -4846,6 +5002,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// #define foo __typeof__((int*)0 - (int*)0)
 	// typedef foo ptrdiff_t;
+	@Test
 	public void testRedefinePtrdiff_230895() throws Exception {
 		String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -4862,6 +5019,7 @@ public class AST2Tests extends AST2TestBase {
 	// int b= a; // ref
 	// struct S;
 	// typedef struct S S; // td
+	@Test
 	public void testRedefineStructInScopeThatIsFullyResolved() throws Exception {
 		String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -4880,6 +5038,7 @@ public class AST2Tests extends AST2TestBase {
 	//    void test() {
 	//    	checkLong(__builtin_expect(1, 1));
 	//    }
+	@Test
 	public void testReturnTypeOfBuiltin_234309() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -4889,6 +5048,7 @@ public class AST2Tests extends AST2TestBase {
 	//    typedef void VOID;
 	//    VOID func(void) {
 	//    }
+	@Test
 	public void testTypedefVoid_221567() throws Exception {
 		String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -4914,6 +5074,7 @@ public class AST2Tests extends AST2TestBase {
 	//    	printf(str(this is a // this should go away
 	//    	string));
 	//    }
+	@Test
 	public void testCommentInExpansion_84276() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment());
 		IASTFunctionDefinition func = (IASTFunctionDefinition) tu.getDeclarations()[0];
@@ -4930,6 +5091,7 @@ public class AST2Tests extends AST2TestBase {
 	// int f3(int (tint));
 	// int f4(int (identifier));
 	// int f5(int *(tint[10]));
+	@Test
 	public void testParamWithFunctionType_84242() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -4954,6 +5116,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// class C { };
 	// void f1(int(C)) { }
+	@Test
 	public void testParamWithFunctionTypeCpp_84242() throws Exception {
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);
 
@@ -4963,6 +5126,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// int (*f1(int par))[5] {};
 	// int (*f1 (int par))[5];
+	@Test
 	public void testFunctionReturningPtrToArray_216609() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -4984,6 +5148,7 @@ public class AST2Tests extends AST2TestBase {
 	// void (f2)();
 	// void (f3());
 	// void ((f4)());
+	@Test
 	public void testNestedFunctionDeclarators() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -5038,6 +5203,7 @@ public class AST2Tests extends AST2TestBase {
 	//    int a,b;
 	//    { b; a; int a; }
 	//  }
+	@Test
 	public void testLocalVariableResolution_235831() throws Exception {
 		final String comment = getAboveComment();
 		final boolean[] isCpps = { false, true };
@@ -5054,6 +5220,7 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	// int foo(int (*ptr) (int, int));
+	@Test
 	public void testComplexParameterBinding_214482() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -5065,6 +5232,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// void test() {}
 	// +
+	@Test
 	public void testTrailingSyntaxErrorInTU() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -5079,6 +5247,7 @@ public class AST2Tests extends AST2TestBase {
 	// int test;
 	// +
 	// };
+	@Test
 	public void testTrailingSyntaxErrorInCompositeType() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -5096,6 +5265,7 @@ public class AST2Tests extends AST2TestBase {
 	//       +
 	//    }
 	// }
+	@Test
 	public void testTrailingSyntaxErrorInCompoundStatements() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -5112,6 +5282,7 @@ public class AST2Tests extends AST2TestBase {
 	//  ;
 	// };
 	// ;
+	@Test
 	public void testEmptyDeclarations() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -5132,6 +5303,7 @@ public class AST2Tests extends AST2TestBase {
 	//          foux= 0;
 	//    foux= 1;
 	// }
+	@Test
 	public void testSwitchWithoutCompound_105334() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -5167,6 +5339,7 @@ public class AST2Tests extends AST2TestBase {
 	// a*a*(t)+a*a*a		// a,a,*,t,a,unary+,cast,*,a,*,a,*
 	// (typeof a)(t)-a  	// typeof a,t,a,unary-,cast,cast
 	// (typeof a)(a)-a  	// typeof a,a,cast,a,-
+	@Test
 	public void testBinaryVsCastAmbiguities_237057() throws Exception {
 		CharSequence[] input = getContents(2);
 		String code = input[0].toString();
@@ -5178,7 +5351,7 @@ public class AST2Tests extends AST2TestBase {
 				final IASTTranslationUnit tu = parse(code + exprStr + ";}", lang);
 				final IASTFunctionDefinition fdef = getDeclaration(tu, 2);
 				IASTExpression expr = getExpressionOfStatement(fdef, 0);
-				assertEquals("expr: " + exprStr, io[1].trim(), polishNotation(expr));
+				assertEquals(io[1].trim(), polishNotation(expr), "expr: " + exprStr);
 				assertEquals(exprStr, expr.getRawSignature());
 				checkOffsets(exprStr, expr);
 			}
@@ -5207,6 +5380,7 @@ public class AST2Tests extends AST2TestBase {
 	// (t)(a)+1				// t,a,cast,1,+
 	// (f)(a)+1				// f,a,(),1,+
 	// (t)(t)+1				// t,t,1,unary+,cast,cast
+	@Test
 	public void testCastVsFunctionCallAmbiguities_237057() throws Exception {
 		CharSequence[] input = getContents(2);
 		String code = input[0].toString();
@@ -5218,7 +5392,7 @@ public class AST2Tests extends AST2TestBase {
 				final IASTTranslationUnit tu = parse(code + exprStr + ";}", lang);
 				final IASTFunctionDefinition fdef = getDeclaration(tu, 4);
 				IASTExpression expr = getExpressionOfStatement(fdef, 0);
-				assertEquals("expr: " + exprStr, io[1].trim(), polishNotation(expr));
+				assertEquals(io[1].trim(), polishNotation(expr), "expr: " + exprStr);
 				assertEquals(exprStr, expr.getRawSignature());
 				checkOffsets(exprStr, expr);
 			}
@@ -5232,6 +5406,7 @@ public class AST2Tests extends AST2TestBase {
 	// a=b=1   			    		// a,b,1,=,=
 	// 0, a= 1 ? 2,3 : b= 4, 5    	// 0,a,1,2,3,,,b,4,=,?,=,5,,
 	// 1 ? 2 ? 3 : 4 ? 5 : 6 : 7    // 1,2,3,4,5,6,?,?,7,?
+	@Test
 	public void testBinaryExpressionBinding() throws Exception {
 		CharSequence[] input = getContents(2);
 		String code = input[0].toString();
@@ -5243,7 +5418,7 @@ public class AST2Tests extends AST2TestBase {
 				final IASTTranslationUnit tu = parse(code + exprStr + ";}", lang);
 				final IASTFunctionDefinition fdef = getDeclaration(tu, 1);
 				IASTExpression expr = getExpressionOfStatement(fdef, 0);
-				assertEquals("expr: " + exprStr, io[1].trim(), polishNotation(expr));
+				assertEquals(io[1].trim(), polishNotation(expr), "expr: " + exprStr);
 				assertEquals(exprStr, expr.getRawSignature());
 				checkOffsets(exprStr, expr);
 			}
@@ -5257,6 +5432,7 @@ public class AST2Tests extends AST2TestBase {
 	// a=b=1   			    		// a,b,1,=,=
 	// 1 ? 2,3 : b= 4	    		// 1,2,3,,,b,4,=,?
 	// 1 ? 2 ? 3 : 4 ? 5 : 6 : 7    // 1,2,3,4,5,6,?,?,7,?
+	@Test
 	public void testConstantExpressionBinding() throws Exception {
 		CharSequence[] input = getContents(2);
 		String code = input[0].toString();
@@ -5271,7 +5447,7 @@ public class AST2Tests extends AST2TestBase {
 				IASTParameterDeclaration pdecl = (IASTParameterDeclaration) fdtor.getChildren()[1];
 				IASTExpression expr = (IASTExpression) ((IASTEqualsInitializer) pdecl.getDeclarator().getInitializer())
 						.getInitializerClause();
-				assertEquals("expr: " + exprStr, io[1].trim(), polishNotation(expr));
+				assertEquals(io[1].trim(), polishNotation(expr), "expr: " + exprStr);
 				assertEquals(exprStr, expr.getRawSignature());
 				checkOffsets(exprStr, expr);
 			}
@@ -5283,31 +5459,32 @@ public class AST2Tests extends AST2TestBase {
 			IASTBinaryExpression bexpr = (IASTBinaryExpression) expr;
 			checkOffsets(exprStr, bexpr.getOperand1());
 			checkOffsets(exprStr, bexpr.getOperand2());
-			assertEquals("in expr: " + exprStr, offset(bexpr), offset(bexpr.getOperand1()));
-			assertTrue("in expr: " + exprStr, endOffset(bexpr.getOperand1()) < offset(bexpr.getOperand2()));
-			assertEquals("in expr: " + exprStr, endOffset(bexpr), endOffset(bexpr.getOperand2()));
+			assertEquals((long) offset(bexpr), (long) offset(bexpr.getOperand1()), "in expr: " + exprStr);
+			assertTrue(endOffset(bexpr.getOperand1()) < offset(bexpr.getOperand2()), "in expr: " + exprStr);
+			assertEquals((long) endOffset(bexpr), (long) endOffset(bexpr.getOperand2()), "in expr: " + exprStr);
 		} else if (expr instanceof IASTCastExpression) {
 			IASTCastExpression castExpr = (IASTCastExpression) expr;
 			checkOffsets(exprStr, castExpr.getOperand());
-			assertTrue("in expr: " + exprStr, offset(castExpr) < offset(castExpr.getTypeId()));
-			assertTrue("in expr: " + exprStr, endOffset(castExpr.getTypeId()) < offset(castExpr.getOperand()));
-			assertEquals("in expr: " + exprStr, endOffset(castExpr), endOffset(castExpr.getOperand()));
+			assertTrue(offset(castExpr) < offset(castExpr.getTypeId()), "in expr: " + exprStr);
+			assertTrue(endOffset(castExpr.getTypeId()) < offset(castExpr.getOperand()), "in expr: " + exprStr);
+			assertEquals((long) endOffset(castExpr), (long) endOffset(castExpr.getOperand()), "in expr: " + exprStr);
 		} else if (expr instanceof IASTUnaryExpression) {
 			IASTUnaryExpression unaryExpr = (IASTUnaryExpression) expr;
 			checkOffsets(exprStr, unaryExpr.getOperand());
 			switch (unaryExpr.getOperator()) {
 			case IASTUnaryExpression.op_bracketedPrimary:
-				assertTrue("in expr: " + exprStr, offset(unaryExpr) < offset(unaryExpr.getOperand()));
-				assertTrue("in expr: " + exprStr, endOffset(unaryExpr.getOperand()) < endOffset(unaryExpr));
+				assertTrue(offset(unaryExpr) < offset(unaryExpr.getOperand()), "in expr: " + exprStr);
+				assertTrue(endOffset(unaryExpr.getOperand()) < endOffset(unaryExpr), "in expr: " + exprStr);
 				break;
 			case IASTUnaryExpression.op_postFixDecr:
 			case IASTUnaryExpression.op_postFixIncr:
-				assertEquals("in expr: " + exprStr, offset(expr), offset(unaryExpr.getOperand()));
-				assertTrue("in expr: " + exprStr, endOffset(unaryExpr.getOperand()) < endOffset(expr));
+				assertEquals((long) offset(expr), (long) offset(unaryExpr.getOperand()), "in expr: " + exprStr);
+				assertTrue(endOffset(unaryExpr.getOperand()) < endOffset(expr), "in expr: " + exprStr);
 				break;
 			default:
-				assertTrue("in expr: " + exprStr, offset(unaryExpr) < offset(unaryExpr.getOperand()));
-				assertEquals("in expr: " + exprStr, endOffset(unaryExpr), endOffset(unaryExpr.getOperand()));
+				assertTrue(offset(unaryExpr) < offset(unaryExpr.getOperand()), "in expr: " + exprStr);
+				assertEquals((long) endOffset(unaryExpr), (long) endOffset(unaryExpr.getOperand()),
+						"in expr: " + exprStr);
 				break;
 			}
 		}
@@ -5413,12 +5590,14 @@ public class AST2Tests extends AST2TestBase {
 	//		int x;
 	//	} spinlock_t;
 	//	spinlock_t _lock = (spinlock_t) {  };
+	@Test
 	public void testCompoundInitializer_145387() throws Exception {
 		// valid in C99, not in C++.
 		parseAndCheckBindings(getAboveComment(), C, ScannerKind.GNU);
 	}
 
 	// enum __declspec(uuid("uuid")) bla { a, b};
+	@Test
 	public void testDeclspecInEnumSpecifier_241203() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			parseAndCheckBindings(getAboveComment(), lang, ScannerKind.GNU);
@@ -5433,6 +5612,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void test() {
 	//		Vector <__declspec(dllexport) int> a;
 	//	}
+	@Test
 	public void testDeclspecTypeId_574578() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
@@ -5442,6 +5622,7 @@ public class AST2Tests extends AST2TestBase {
 	//
 	//MyStruct __declspec(dllexport) foo;
 	//MyStruct  __declspec(dllexport) __declspec(deprecated) bar;
+	@Test
 	public void testDeclspecAfterDeclSpecifierIdentifier_464624() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			parseAndCheckBindings(getAboveComment(), lang, ScannerKind.GNU);
@@ -5456,6 +5637,7 @@ public class AST2Tests extends AST2TestBase {
 	//    struct Outer o;
 	//    o.a1=0; o.a2=0; o.a3=0;
 	// }
+	@Test
 	public void testAnonymousUnionMember() throws Exception {
 		final boolean[] isCpps = { false, true };
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -5471,6 +5653,7 @@ public class AST2Tests extends AST2TestBase {
 	//    if (__builtin_types_compatible_p(typeof(p), char[])) {
 	//    }
 	// }
+	@Test
 	public void testBuiltinTypesCompatible_241570() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			parseAndCheckBindings(getAboveComment(), lang, ScannerKind.GNU);
@@ -5481,6 +5664,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void test() {
 	//	    alloc(__func__);
 	//	}
+	@Test
 	public void testPredefinedFunctionName_247747() throws Exception {
 		parseAndCheckBindings(getAboveComment(), C, ScannerKind.STD);
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.STD);
@@ -5492,6 +5676,7 @@ public class AST2Tests extends AST2TestBase {
 	//	    alloc(__FUNCTION__);
 	//	    alloc(__PRETTY_FUNCTION__);
 	//	}
+	@Test
 	public void testPredefinedFunctionNameGcc_247747() throws Exception {
 		parseAndCheckBindings(getAboveComment(), C, ScannerKind.GNU);
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
@@ -5500,6 +5685,7 @@ public class AST2Tests extends AST2TestBase {
 	//	int foo = 42;
 	//  typedef char StupidType;
 	//  StupidType const *bar = (StupidType const*)&foo;
+	@Test
 	public void testUnusualDeclSpecOrdering_251514() throws Exception {
 		parseAndCheckBindings(getAboveComment(), C, ScannerKind.GNU);
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
@@ -5511,6 +5697,7 @@ public class AST2Tests extends AST2TestBase {
 	//	#define SEMI_IF ; if
 	//	#define IF_COND if (1)
 	//  void test() {
+	@Test
 	public void testLeadingSyntax_250251() throws Exception {
 		String code = getAboveComment();
 
@@ -5602,6 +5789,7 @@ public class AST2Tests extends AST2TestBase {
 	//  #define P_BLOCK ){}
 	//	#define IF_COND if (1)
 	//  void test() {
+	@Test
 	public void testTrailingSyntax_250251() throws Exception {
 		String code = getAboveComment();
 
@@ -5686,6 +5874,7 @@ public class AST2Tests extends AST2TestBase {
 	//	#define SEMI_IF ; if
 	//	#define IF_COND if (1)
 	//  void test() {
+	@Test
 	public void testSyntax_250251() throws Exception {
 		String code = getAboveComment();
 
@@ -5765,6 +5954,7 @@ public class AST2Tests extends AST2TestBase {
 	//     <<
 	//     y;
 	// }
+	@Test
 	public void testSyntaxWithNL_280175() throws Exception {
 		String code = getAboveComment();
 		int offsetX = code.indexOf('x', code.indexOf('x') + 1);
@@ -5802,6 +5992,7 @@ public class AST2Tests extends AST2TestBase {
 	// int b= a+4;
 	// int* c= &b;
 	// enum X {e0, e4=4, e5, e2=2, e3};
+	@Test
 	public void testValues() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -5838,6 +6029,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void caller() {
 	//	   myfunc("");
 	//	}
+	@Test
 	public void testReferencesInInitializer_251514() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -5851,6 +6043,7 @@ public class AST2Tests extends AST2TestBase {
 	// void test() {
 	//    const void* p = &"string";
 	// }
+	@Test
 	public void testAdressOfStringLiteral_252970() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -5863,6 +6056,7 @@ public class AST2Tests extends AST2TestBase {
 	// 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 
 	// };
+	@Test
 	public void testScalabilityOfLargeTrivialInitializer_253690() throws Exception {
 		sValidateCopy = false;
 		final int AMOUNT = 250000;
@@ -5875,7 +6069,7 @@ public class AST2Tests extends AST2TestBase {
 				long diff = memoryUsed() - mem;
 				// Allow a copy of the buffer, plus less than 1.5 bytes per initializer.
 				final int expected = code.length() * 2 + AMOUNT + AMOUNT / 2;
-				assertTrue(String.valueOf(diff) + " expected < " + expected, diff < expected);
+				assertTrue(diff < expected, String.valueOf(diff) + " expected < " + expected);
 				assertTrue(tu.isFrozen());
 			});
 		}
@@ -5891,6 +6085,7 @@ public class AST2Tests extends AST2TestBase {
 
 	//	   }
 	//	};
+	@Test
 	public void testLargeTrivialAggregateInitializer_253690() throws Exception {
 		sValidateCopy = false;
 		final int AMOUNT = 250000;
@@ -5904,7 +6099,7 @@ public class AST2Tests extends AST2TestBase {
 				// Allow a copy of the buffer, plus less than 1.5 bytes per
 				// initializer.
 				final int expected = code.length() * 2 + AMOUNT + AMOUNT / 2;
-				assertTrue(String.valueOf(diff) + " expected < " + expected, diff < expected);
+				assertTrue(diff < expected, String.valueOf(diff) + " expected < " + expected);
 				assertTrue(tu.isFrozen());
 			});
 		}
@@ -5915,6 +6110,7 @@ public class AST2Tests extends AST2TestBase {
 	// 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 
 	// };
+	@Test
 	public void testMaximumTrivialExpressionsInInitializers_412380() throws Exception {
 		sValidateCopy = false;
 		final int AMOUNT = 250000;
@@ -5931,7 +6127,7 @@ public class AST2Tests extends AST2TestBase {
 				final int initializerSize = maximumTrivialExpressionsInInitializer * additionalBytesPerInitializer;
 				// Allow a copy of the buffer, plus less than 1.5 bytes per initializer.
 				final int expected = code.length() * 2 + AMOUNT + AMOUNT / 2 + initializerSize;
-				assertTrue(String.valueOf(diff) + " expected < " + expected, diff < expected);
+				assertTrue(diff < expected, String.valueOf(diff) + " expected < " + expected);
 				assertTrue(tu.isFrozen());
 				tu.accept(new ASTVisitor() {
 					{
@@ -6018,6 +6214,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// int n= 0;
 	// int a[]= {0x00, sizeof(n)};
+	@Test
 	public void testNonTrivialInitializer_253690() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -6032,6 +6229,7 @@ public class AST2Tests extends AST2TestBase {
 	// void test() {
 	//    const void* p = 1+2;
 	// }
+	@Test
 	public void testGetChildren_256127() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -6078,6 +6276,7 @@ public class AST2Tests extends AST2TestBase {
 	//		struct s v;
 	//		v.mem = 1;
 	//	}
+	@Test
 	public void testNestedDeclarator_257540() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C);
@@ -6092,6 +6291,7 @@ public class AST2Tests extends AST2TestBase {
 	//	    cs foo;
 	//	    foo = ((cs) {1.2,1});
 	//	}
+	@Test
 	public void testCompoundLiterals_258496() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C);
@@ -6101,6 +6301,7 @@ public class AST2Tests extends AST2TestBase {
 	// __thread int i;
 	// static __thread int j;
 	// extern __thread int k;
+	@Test
 	public void testThreadLocalVariables_260387() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -6111,6 +6312,7 @@ public class AST2Tests extends AST2TestBase {
 	//    int a,b;
 	//    if ((a)+b);
 	// }
+	@Test
 	public void testAmbiguityResolutionInIfCondition_261043() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -6127,6 +6329,7 @@ public class AST2Tests extends AST2TestBase {
 	//    const TInt; // declaration without name
 	//    const a;    // declares a;
 	// };
+	@Test
 	public void testAmbiguousDeclaration_259373() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -6149,6 +6352,7 @@ public class AST2Tests extends AST2TestBase {
 	//		pg->glob= 0;
 	//		pl->loc= 1;
 	//	}
+	@Test
 	public void testLocalVsGlobalStruct_255973() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -6159,6 +6363,7 @@ public class AST2Tests extends AST2TestBase {
 	// typedef struct A A;
 	// struct A; // struct
 	// struct A* a;
+	@Test
 	public void testTypedefWithSameName() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -6179,6 +6384,7 @@ public class AST2Tests extends AST2TestBase {
 	//	size_t x = a + 5;
 	//	size_t y = 2 + a;
 	//	size_t y = a * 2;
+	@Test
 	public void testTypeOfExpressionWithTypedef_380498_1() throws Exception {
 		String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -6201,6 +6407,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void test(Func f) {
 	//	  f();
 	//	}
+	@Test
 	public void testTypeOfExpressionWithTypedef_380498_2() throws Exception {
 		String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -6213,6 +6420,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// typedef int TInt;
 	// int a= TInt; //ref
+	@Test
 	public void testTypeAsExpressionIsProblem_261175() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -6227,6 +6435,7 @@ public class AST2Tests extends AST2TestBase {
 	//    c= sizeof(x(y));
 	//    x(y);
 	// }
+	@Test
 	public void testSizeofFunctionType_252243() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -6237,6 +6446,7 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	// int* v;
+	@Test
 	public void testPointerOperatorsAsChildren_260461() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -6258,6 +6468,7 @@ public class AST2Tests extends AST2TestBase {
 	//  int g = 1234l;
 	//  int h = -123ll;
 	//  int i = 8888uL;
+	@Test
 	public void testBug269705_int_literal() throws Exception {
 		final String code = getAboveComment();
 
@@ -6364,6 +6575,7 @@ public class AST2Tests extends AST2TestBase {
 	//  int c = 100000.99F;
 	//  int d = 0.123l;
 	//  int e = 1.3L;
+	@Test
 	public void testBug269705_float_literal() throws Exception {
 		final String code = getAboveComment();
 
@@ -6444,6 +6656,7 @@ public class AST2Tests extends AST2TestBase {
 	//	    __STDC_VERSION__;
 	//	    __TIME__;
 	//	}
+	@Test
 	public void testPredefinedMacroNamesC() throws Exception {
 		parseAndCheckBindings(getAboveComment(), C);
 	}
@@ -6478,6 +6691,7 @@ public class AST2Tests extends AST2TestBase {
 	//    var = shortInt + longDouble;
 	//    var = _char + longDouble;
 	// }
+	@Test
 	public void testTypePromotion_long_double() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit ast = parseAndCheckBindings(getAboveComment(), lang);
@@ -6530,6 +6744,7 @@ public class AST2Tests extends AST2TestBase {
 	//    var = _char + _double;
 	//
 	// }
+	@Test
 	public void testTypePromotion_double() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit ast = parseAndCheckBindings(getAboveComment(), lang);
@@ -6578,6 +6793,7 @@ public class AST2Tests extends AST2TestBase {
 	//    var = _char + _float;
 	//
 	// }
+	@Test
 	public void testTypePromotion_float() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit ast = parseAndCheckBindings(getAboveComment(), lang);
@@ -6625,6 +6841,7 @@ public class AST2Tests extends AST2TestBase {
 	//
 	// }
 	//
+	@Test
 	public void testTypePromotion_longlongint() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit ast = parseAndCheckBindings(getAboveComment(), lang, ScannerKind.GNU); // support for long long
@@ -6669,6 +6886,7 @@ public class AST2Tests extends AST2TestBase {
 	//    var = _char + longInt;
 	//
 	// }
+	@Test
 	public void testTypePromotion_longint() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit ast = parseAndCheckBindings(getAboveComment(), lang);
@@ -6709,6 +6927,7 @@ public class AST2Tests extends AST2TestBase {
 	//    var = _char + _int;
 	//
 	// }
+	@Test
 	public void testTypePromotion_int() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit ast = parseAndCheckBindings(getAboveComment(), lang);
@@ -6747,6 +6966,7 @@ public class AST2Tests extends AST2TestBase {
 	//    var = _char + shortInt;
 	//
 	// }
+	@Test
 	public void testTypePromotion_short_int() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit ast = parseAndCheckBindings(getAboveComment(), lang);
@@ -6781,6 +7001,7 @@ public class AST2Tests extends AST2TestBase {
 	//    /* The following should all be signed int */
 	//    var = _char + _char;
 	// }
+	@Test
 	public void testTypePromotion_char() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit ast = parseAndCheckBindings(getAboveComment(), lang);
@@ -6841,6 +7062,7 @@ public class AST2Tests extends AST2TestBase {
 	//      /* (6) Should be an unsigned long int*/
 	//      var = unsignedLongInt + signedLongInt;
 	//  }
+	@Test
 	public void testTypePromotion_signedAndUnsignedInts() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit ast = parseAndCheckBindings(getAboveComment(), lang);
@@ -6954,6 +7176,7 @@ public class AST2Tests extends AST2TestBase {
 	//      // with 64bit long and long long types expression type should be an unsigned long long int
 	//      var = signedLongLongInt + unsignedLongInt;
 	//  }
+	@Test
 	public void testTypeConversion_signedHigherRankSameSizeInts() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit ast = parseAndCheckBindings(getAboveComment(), lang, ScannerKind.STD);
@@ -6993,6 +7216,7 @@ public class AST2Tests extends AST2TestBase {
 	//    +c;
 	//    ~c;
 	// }
+	@Test
 	public void testPromotionInUnaryExpressions() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit ast = parseAndCheckBindings(getAboveComment(), lang);
@@ -7014,6 +7238,7 @@ public class AST2Tests extends AST2TestBase {
 	//
 	//  int MyGlobal[10];
 	//
+	@Test
 	public void testBug273797() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), C);
 		IASTName n = ((IASTSimpleDeclaration) tu.getDeclarations()[0]).getDeclarators()[0].getName();
@@ -7036,6 +7261,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void test() {
 	//	        (int) value1;
 	//	}
+	@Test
 	public void testBug278797() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), C);
 		IASTFunctionDefinition func = (IASTFunctionDefinition) tu.getDeclarations()[1];
@@ -7050,6 +7276,7 @@ public class AST2Tests extends AST2TestBase {
 	//int a[2][3] = {{1,2,3},{4,5,6}};
 	//int b[3][2] = {{1,2},{3,4},{5,6}};
 	//
+	@Test
 	public void testBug277458() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), lang);
@@ -7095,6 +7322,7 @@ public class AST2Tests extends AST2TestBase {
 	//typedef int my_buf[16];
 	//void goo(my_buf in);
 	//
+	@Test
 	public void testBug284248() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), lang);
@@ -7114,6 +7342,7 @@ public class AST2Tests extends AST2TestBase {
 	//    _ISalnum2 = 11 > 8 ? 1 : 2
 	//};
 	//
+	@Test
 	public void testBug295851() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), lang);
@@ -7138,6 +7367,7 @@ public class AST2Tests extends AST2TestBase {
 	//     structure.a = 1;
 	//     structure.ptr = goo;
 	// }
+	@Test
 	public void testBindingsOnFields() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), C, ScannerKind.STD);
 		IASTCompoundStatement bodyStmt = (IASTCompoundStatement) ((IASTFunctionDefinition) tu.getDeclarations()[2])
@@ -7194,6 +7424,7 @@ public class AST2Tests extends AST2TestBase {
 	//	    var4[1].a  = 1;
 	//	    var5[1].a  = 1;
 	//	}
+	@Test
 	public void testArraySubscriptExpressionGetExpressionType() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), lang);
@@ -7223,6 +7454,7 @@ public class AST2Tests extends AST2TestBase {
 	//	    ptr + 1;
 	//	    1 + ptr;
 	//	}
+	@Test
 	public void testPointerExpression_131037() throws Exception {
 		for (ParserLanguage lang : ParserLanguage.values()) {
 			IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), lang);
@@ -7231,8 +7463,7 @@ public class AST2Tests extends AST2TestBase {
 				if (d instanceof IASTFunctionDefinition) {
 					for (IASTStatement s : ((IASTCompoundStatement) ((IASTFunctionDefinition) d).getBody())
 							.getStatements()) {
-						IType t = ((IASTBinaryExpression) ((IASTExpressionStatement) s).getExpression())
-								.getExpressionType();
+						IType t = ((IASTExpressionStatement) s).getExpression().getExpressionType();
 						assertTrue(t instanceof IPointerType || t instanceof IArrayType);
 						assertEquals("char", ((IPointerType) t).getType().toString());
 					}
@@ -7243,6 +7474,7 @@ public class AST2Tests extends AST2TestBase {
 
 	//	extern int a[];
 	//	int a[1];
+	@Test
 	public void testIncompleteArrays_269926() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C);
@@ -7251,6 +7483,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// void f1(const int* p);
 	// void f2(const int* p) {}
+	@Test
 	public void testDroppingOfStorageDecl_293322() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, false);
@@ -7262,6 +7495,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// typedef int f(int);
 	// f ff;
+	@Test
 	public void testFunctionDeclViaTypedef_86495() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -7275,6 +7509,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// void f() {
 	// int a=
+	@Test
 	public void testLargeExpression_294029() throws Exception {
 		// when running the test in a suite, it cannot handle more than 160 parenthesis.
 		// run as a single test it does > 500.
@@ -7297,6 +7532,7 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	//	static a[2]= {0,0};
+	@Test
 	public void testSkipAggregateInitializer_297550() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code, C, ScannerKind.STD, 0);
@@ -7304,6 +7540,7 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	//	static a[2]= {0,0};
+	@Test
 	public void testNoSkipTrivialAggregateInitializer_412380() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code, C, ScannerKind.STD);
@@ -7312,6 +7549,7 @@ public class AST2Tests extends AST2TestBase {
 
 	//	static int i = 0;
 	//	static a[1]= {i};
+	@Test
 	public void testNoSkipNonTrivialAggregateInitializer_412380() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code, C, ScannerKind.STD, 0);
@@ -7319,6 +7557,7 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	// typeof(b(1)) b(int);
+	@Test
 	public void testRecursiveFunctionType_321856() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, false);
@@ -7327,6 +7566,7 @@ public class AST2Tests extends AST2TestBase {
 		f.getType();
 	}
 
+	@Test
 	public void testDeepBinaryExpression_294969() throws Exception {
 		sValidateCopy = false;
 		StringBuilder buf = new StringBuilder("void f() {0");
@@ -7340,6 +7580,7 @@ public class AST2Tests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testDeepElseif_298455() throws Exception {
 		sValidateCopy = false;
 		StringBuilder buf = new StringBuilder("void f() {if (0) {}");
@@ -7354,6 +7595,7 @@ public class AST2Tests extends AST2TestBase {
 	}
 
 	// void f () __attribute__ ((int));
+	@Test
 	public void testAttributeSyntax_298841() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -7363,6 +7605,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void func(int* obj) {
 	//	    int* obj = 0;
 	//	}
+	@Test
 	public void testParameterRedeclaration_301779() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, true);
@@ -7378,6 +7621,7 @@ public class AST2Tests extends AST2TestBase {
 	//	#pragma once
 	//	_Pragma ("once")
 	//  ONCE()
+	@Test
 	public void testPragmaOperator_294730() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code, C);
@@ -7401,6 +7645,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void test() {
 	//		int a= (min)(1, 2);
 	//	}
+	@Test
 	public void testFunctionNameExpression() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -7411,6 +7656,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void funca(){
 	//	}
 	//  MACRO
+	@Test
 	public void testEmptyTrailingMacro_303152() throws Exception {
 		final String code = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -7431,6 +7677,7 @@ public class AST2Tests extends AST2TestBase {
 	//	    va_list list;
 	//	    x = va_arg(list, int(*)[3]);
 	//	}
+	@Test
 	public void testVaArgWithFunctionPtr_311030() throws Exception {
 		final String code = getAboveComment();
 		parseAndCheckBindings(code, C, ScannerKind.GNU);
@@ -7440,6 +7687,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void test() {
 	//	    __builtin_va_list result;
 	//	}
+	@Test
 	public void testLocalVariableOfTypeVaList_313270() throws Exception {
 		final String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, false);
@@ -7455,6 +7703,7 @@ public class AST2Tests extends AST2TestBase {
 
 	//	void foo(int i);
 	//	void foo(int j) { }
+	@Test
 	public void testParameterBindings_316931() throws Exception {
 		String code = getAboveComment();
 		parseAndCheckBindings(code);
@@ -7474,6 +7723,7 @@ public class AST2Tests extends AST2TestBase {
 
 	// typedef __typeof__((int*)0-(int*)0) ptrdiff_t;
 	// typedef __typeof__(sizeof(int)) size_t;
+	@Test
 	public void testPtrDiffRecursion_317004() throws Exception {
 		final String comment = getAboveComment();
 		String code = comment;
@@ -7497,6 +7747,7 @@ public class AST2Tests extends AST2TestBase {
 	//		int tmp = a;
 	//	}
 	//	void f(int);
+	@Test
 	public void testParameterResolution() throws Exception {
 		final String code = getAboveComment();
 
@@ -7515,6 +7766,7 @@ public class AST2Tests extends AST2TestBase {
 	//	#ifdef B // inactive, not taken.
 	//	#endif   // inactive
 	//	#endif   // active
+	@Test
 	public void testInactivePreprocessingStatements() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment());
 		IASTPreprocessorStatement[] stmts = tu.getAllPreprocessorStatements();
@@ -7532,6 +7784,7 @@ public class AST2Tests extends AST2TestBase {
 	//	    sizeof(10); // wrong - getExpressionType returns float
 	//	    sizeof(int); // wrong - getExpressionType returns float
 	//	}
+	@Test
 	public void testTypeOfSizeof_355052() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code, CPP);
@@ -7553,11 +7806,13 @@ public class AST2Tests extends AST2TestBase {
 	//	    typedef int foobar_t;
 	//	    foobar_t *a = 0, *b = a;
 	//	}
+	@Test
 	public void testAmbiguousStatement_360541() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	// typedef int T[sizeof(int)];
+	@Test
 	public void testSizeofExpression_362464() throws Exception {
 		String code = getAboveComment();
 		for (ParserLanguage l : ParserLanguage.values()) {
@@ -7575,6 +7830,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void macro_test() {
 	//	    NULL_STATEMENT_MACRO //comment
 	//	}
+	@Test
 	public void testCommentAfterMacroExpansion_367827() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), CPP);
 		IASTComment comment = tu.getComments()[0];
@@ -7587,17 +7843,20 @@ public class AST2Tests extends AST2TestBase {
 	//	  for (__decltype(n + 0) i = 0; i < n; i++) {
 	//	  }
 	//	}
+	@Test
 	public void testGCCDecltype_397227() throws Exception {
 		parseAndCheckBindings(getAboveComment(), CPP, ScannerKind.GNU);
 	}
 
 	// #define macro(R) #R""
+	@Test
 	public void testNoRawStringInPlainC_397127() throws Exception {
 		parseAndCheckBindings(getAboveComment(), C, ScannerKind.GNU);
 	}
 
 	// #define X
 	// int a=X-1;X
+	@Test
 	public void testMacroReferences_399394() throws Exception {
 		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment());
 		assertEquals(2, countMacroRefs(tu));
@@ -7626,19 +7885,23 @@ public class AST2Tests extends AST2TestBase {
 	//	void (*function(A *a))(void) {
 	//	    a->x;
 	//	}
+	@Test
 	public void testFunctionReturningFunctionPointer_413204() throws Exception {
 		parseAndCheckBindings();
 	}
 
 	//	double d = 00.9;
+	@Test
 	public void testOctalFloatingPointLiteral_394048() throws Exception {
 		parseAndCheckBindings();
 	}
 
+	@Test
 	public void testMacOS9LineEnding_151329a() throws Exception {
 		parseAndCheckBindings("int waldo;\r#define bar");
 	}
 
+	@Test
 	public void testMaxOS9LineEnding_151329b() throws Exception {
 		// This tests that if there is an \r\n in a macro continuation,
 		// the \r is not treated as an extra newline. The code
@@ -7659,6 +7922,7 @@ public class AST2Tests extends AST2TestBase {
 	//	#ifndef X
 	//	u8 var;
 	//	#endif
+	@Test
 	public void testU8TokenAfterIfdef_429361() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -7672,6 +7936,7 @@ public class AST2Tests extends AST2TestBase {
 	//	foo:
 	//		return;
 	//	}
+	@Test
 	public void testExpressionLabelReference_84144() throws Exception {
 		parseAndCheckBindings(ScannerKind.GNU);
 	}
@@ -7683,6 +7948,7 @@ public class AST2Tests extends AST2TestBase {
 	//	L:
 	//	    return;
 	//	}
+	@Test
 	public void testExpressionLabelReferenceCast_486140a() throws Exception {
 		// Here, the cast-expression is the only valid parse.
 		parseAndCheckBindings(ScannerKind.GNU);
@@ -7696,6 +7962,7 @@ public class AST2Tests extends AST2TestBase {
 	//	L:
 	//	    return;
 	//	}
+	@Test
 	public void testExpressionLabelReferenceCast_486140b() throws Exception {
 		// Here, the cast-expression and the binary-expression are both
 		// syntactically valid, but the correct parse is the cast-expression.
@@ -7705,6 +7972,7 @@ public class AST2Tests extends AST2TestBase {
 	//	int test(int waldo, int other) {
 	//	    return (waldo) && other;
 	//	}
+	@Test
 	public void testBinaryExprNotMisparsedAsCast_486140() throws Exception {
 		// Again cast-expression and binary-expression are both syntactically
 		// valid, but this time the correct parse is binary-expression.
@@ -7715,6 +7983,7 @@ public class AST2Tests extends AST2TestBase {
 	//	int NextVersion() {
 	//		return __atomic_add_fetch(&version, 1, 5);
 	//	}
+	@Test
 	public void testAtomicBuiltin_bug456131() throws Exception {
 		parseAndCheckBindings(ScannerKind.GNU);
 	}
@@ -7723,11 +7992,13 @@ public class AST2Tests extends AST2TestBase {
 	//	int get() {
 	//		return __atomic_load_n(&cv_var, 0);
 	//	}
+	@Test
 	public void testAtomicLoadNOfConstVolatile() throws Exception {
 		parseAndCheckBindings(ScannerKind.GNU);
 	}
 
 	//	void waldo(...);
+	@Test
 	public void testVariadicCFunction_452416() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper(C);
 		IFunction waldo = bh.assertNonProblem("waldo");
@@ -7743,6 +8014,7 @@ public class AST2Tests extends AST2TestBase {
 	//	  (f ? f->a : ((void*) 0))->a; // second 'a' cannot be resolved
 	//	  return 0;
 	//	}
+	@Test
 	public void testVoidPointerInTernaryOperator_460741() throws Exception {
 		parseAndCheckBindings(getAboveComment(), C);
 	}
@@ -7754,6 +8026,7 @@ public class AST2Tests extends AST2TestBase {
 	//		const struct MyStruct a, b;
 	//		(0 ? a : b).str;
 	//	}
+	@Test
 	public void testCVQualifiedTypesInConversionOperator_495423() throws Exception {
 		parseAndCheckBindings(getAboveComment(), C);
 	}
@@ -7768,6 +8041,7 @@ public class AST2Tests extends AST2TestBase {
 	//	};
 	//	_Alignas(32) struct S s;
 	//	_Alignas(struct S) int t;
+	@Test
 	public void testAlignas_451082() throws Exception {
 		parseAndCheckBindings(getAboveComment(), C);
 	}
@@ -7775,6 +8049,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void foo(int waldo) {
 	//		(waldo = 5) && waldo;
 	//	}
+	@Test
 	public void testTypeIdWithEqualsInitializer_484824() throws Exception {
 		// Test that 'waldo = 5' is not parsed as a type-id, causing
 		// the entire expression to be parsed as a cast-expression.
@@ -7804,6 +8079,7 @@ public class AST2Tests extends AST2TestBase {
 	//		void* ref1 = && existent;
 	//		void* ref2 = && nonexistent;
 	//	}
+	@Test
 	public void testLabelResolution_484979() throws Exception {
 		labelResolutionHelper(getAssertionHelper(C));
 		labelResolutionHelper(getAssertionHelper(CPP));
@@ -7814,6 +8090,7 @@ public class AST2Tests extends AST2TestBase {
 	//	void foo(bool cond) {
 	//		cond ? arr1 : arr2;
 	//	}
+	@Test
 	public void testArrayTypesInConditionalExpression_520049() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper(C);
 		IASTConditionalExpression expr = helper.assertNode("cond ? arr1 : arr2");
@@ -7827,6 +8104,7 @@ public class AST2Tests extends AST2TestBase {
 	//        struct S* s;
 	//        s.waldo;
 	//    }
+	@Test
 	public void testMemberAccessOnPointerType_526857() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper(C);
 		helper.assertProblem("s.waldo", "waldo");
@@ -7853,6 +8131,7 @@ public class AST2Tests extends AST2TestBase {
 	//
 	//      return 0;
 	//  }
+	@Test
 	public void testProblemExpressionType_403153() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper(C);
 		IASTExpression expr = helper.assertNode("*gd->queue->request_fn");
@@ -7864,6 +8143,7 @@ public class AST2Tests extends AST2TestBase {
 	//		unsigned char a;
 	//		unsigned char b;
 	//	} example2_s;
+	@Test
 	public void testStructAttribute_467346() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper(C);
 		IASTDeclaration[] decls = helper.getTranslationUnit().getDeclarations();

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2UtilOldTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2UtilOldTests.java
@@ -19,16 +19,12 @@ import org.eclipse.cdt.core.dom.ast.IASTInitializerClause;
 import org.eclipse.cdt.core.dom.ast.IASTSimpleDeclaration;
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.parser.ParserLanguage;
+import org.junit.jupiter.api.Test;
 
 public class AST2UtilOldTests extends AST2TestBase {
-	public AST2UtilOldTests() {
-	}
-
-	public AST2UtilOldTests(String name) {
-		super(name);
-	}
 
 	// Kind PRIMARY_EMPTY : void
+	@Test
 	public void testPrimaryEmpty() throws Exception {
 		IASTTranslationUnit tu = parse("int x = f();".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -39,6 +35,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind PRIMARY_INTEGER_LITERAL : int
+	@Test
 	public void testPrimaryIntegerLiteral() throws Exception {
 		IASTTranslationUnit tu = parse("int x = f(1, 2+3);".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -49,6 +46,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind PRIMARY_CHAR_LITERAL : char
+	@Test
 	public void testPrimaryCharLiteral() throws Exception {
 		IASTTranslationUnit tu = parse("int x = f('c');".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -59,6 +57,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind PRIMARY_FLOAT_LITERAL : float
+	@Test
 	public void testPrimaryFloatLiteral() throws Exception {
 		IASTTranslationUnit tu = parse("int x = f(1.13);".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -69,6 +68,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind PRIMARY_STRING_LITERAL : char*
+	@Test
 	public void testPrimaryStringLiteral() throws Exception {
 		IASTTranslationUnit tu = parse("int x = f(\"str\");".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -79,6 +79,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind PRIMARY_BOOLEAN_LITERAL : bool
+	@Test
 	public void testPrimaryBooleanLiteral() throws Exception {
 		IASTTranslationUnit tu = parse("int x = f(true);".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -89,6 +90,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind PRIMARY_THIS : type of inner most enclosing structure scope
+	@Test
 	public void testPrimaryThis() throws Exception {
 		IASTTranslationUnit tu = parse("int x = f(this);".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -99,6 +101,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind PRIMARY_BRACKETED_EXPRESSION : LHS
+	@Test
 	public void testPrimaryBracketedExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = f(1, (2+3));".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -109,6 +112,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ID_EXPRESSION : type of the ID
+	@Test
 	public void testIdExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = f(a);".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -119,6 +123,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind POSTFIX_SUBSCRIPT
+	@Test
 	public void testPostfixSubscript() throws Exception {
 		IASTTranslationUnit tu = parse("int x = f(pa[1]);".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -128,6 +133,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 				"f(pa[1])"); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testPostfixSubscriptA() throws Exception {
 		IASTTranslationUnit tu = parse("int x = f(pa[1][2]);".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -138,6 +144,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind POSTFIX_FUNCTIONCALL : return type of called function
+	@Test
 	public void testPostfixFunctioncallBug42822() throws Exception {
 		IASTTranslationUnit tu = parse("int x = bar( foo( 3.0 ), foo( 5.0 ) ) ;".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -148,6 +155,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind POSTFIX_SIMPLETYPE_* : simple type
+	@Test
 	public void testPostfixSimpletypesBug42823() throws Exception {
 		IASTTranslationUnit tu = parse(
 				"int someInt = foo( int(3), short(4), double(3.0), float(4.0), char( 'a'), wchar_t( 'a' ), signed( 2 ), unsigned( 3 ), bool( false ), long( 3L ) );" //$NON-NLS-1$
@@ -161,6 +169,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind POSTFIX_DOT_IDEXPRESSION : type of member in the scope of the container
+	@Test
 	public void testPostfixDotExpression() throws Exception {
 		IASTTranslationUnit tu = parse(
 				"class A {int m;}; \n A  a; \n int foo(char); int foo( int ); \n int x = foo( a.m );".toString(), //$NON-NLS-1$
@@ -173,6 +182,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind POSTFIX_ARROW_IDEXPRESSION : type of member in the scope of the container
+	@Test
 	public void testPostfixArrowExpression() throws Exception {
 		IASTTranslationUnit tu = parse(
 				"class A {int m;}; \n A * a; \n int foo(char); int foo( int ); \n int x = foo( a->m );".toString(), //$NON-NLS-1$
@@ -185,6 +195,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind POSTFIX_INCREMENT : LHS
+	@Test
 	public void testPostfixIncrement() throws Exception {
 		IASTTranslationUnit tu = parse("int y = foo( x++ );".toString(), ParserLanguage.CPP); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -195,6 +206,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind POSTFIX_DECREMENT : LHS
+	@Test
 	public void testPostfixDecrement() throws Exception {
 		IASTTranslationUnit tu = parse("int y = foo( x-- );".toString(), ParserLanguage.CPP); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -205,6 +217,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind POSTFIX_DYNAMIC_CAST
+	@Test
 	public void testPostfixDynamicCast() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( dynamic_cast<B*>(a) );".toString(), ParserLanguage.CPP); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -215,6 +228,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind POSTFIX_REINTERPRET_CAST
+	@Test
 	public void testPostfixReinterpretCast() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( reinterpret_cast<double *>(a) );".toString(), ParserLanguage.CPP); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -225,6 +239,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind POSTFIX_STATIC_CAST
+	@Test
 	public void testPostfixStaticCast() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( static_cast<char>(a) );".toString(), ParserLanguage.CPP); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -235,6 +250,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind POSTFIX_CONST_CAST
+	@Test
 	public void testPostfixConstCast() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( const_cast<int *>(&a) );".toString(), ParserLanguage.CPP); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -245,6 +261,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind POSTFIX_TYPEID_EXPRESSION : LHS
+	@Test
 	public void testPostfixTypeIdExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( typeid(5) );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -255,6 +272,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind POSTFIX_TYPEID_EXPRESSION : type of the ID
+	@Test
 	public void testPostfixTypeIdExpression2() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( typeid(a) );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -265,6 +283,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 	// Kind POSTFIX_TYPEID_TYPEID : type of the ID
 
+	@Test
 	public void testPostfixTypeIdTypeId2() throws Exception {
 		IASTTranslationUnit tu = parse("class A { }; int foo( int ); int x = foo( typeid(const A) );".toString(), //$NON-NLS-1$
 				ParserLanguage.CPP);
@@ -276,6 +295,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind UNARY_INCREMENT : LHS
+	@Test
 	public void testUnaryIncrement() throws Exception {
 		IASTTranslationUnit tu = parse("int y = foo( ++x );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -286,6 +306,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind UNARY_DECREMENT : LHS
+	@Test
 	public void testUnaryDecrement() throws Exception {
 		IASTTranslationUnit tu = parse("int y = foo( --x );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -296,6 +317,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind UNARY_STAR_CASTEXPRESSION : LHS + t_pointer
+	@Test
 	public void testUnaryStarCastExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = f(*pa);".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -306,6 +328,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind UNARY_AMPSND_CASTEXPRESSION : LHS + t_reference
+	@Test
 	public void testUnaryAmpersandCastExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = f(&pa);".toString(), ParserLanguage.CPP); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -316,6 +339,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind UNARY_PLUS_CASTEXPRESSION  : LHS
+	@Test
 	public void testUnaryPlusCastExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( +5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -326,6 +350,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind UNARY_MINUS_CASTEXPRESSION : LHS
+	@Test
 	public void testUnaryMinusCastExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( -5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -336,6 +361,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind UNARY_NOT_CASTEXPRESSION : LHS
+	@Test
 	public void testUnaryNotCastExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( !b );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -346,6 +372,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind UNARY_TILDE_CASTEXPRESSION : LHS
+	@Test
 	public void testTildeNotCastExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int y = foo( ~x );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -356,6 +383,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind UNARY_SIZEOF_UNARYEXPRESSION : unsigned int
+	@Test
 	public void testUnarySizeofUnaryExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int y = foo( sizeof(5) );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -366,6 +394,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind UNARY_SIZEOF_TYPEID : unsigned int
+	@Test
 	public void testUnarySizeofTypeId() throws Exception {
 		IASTTranslationUnit tu = parse("int x, y = foo( sizeof(x) );".toString(), ParserLanguage.CPP); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -375,6 +404,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind NEW_TYPEID
+	@Test
 	public void testNewTypeId() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( new A() );".toString(), ParserLanguage.CPP); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -385,6 +415,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind CASTEXPRESSION
+	@Test
 	public void testCastExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( (A*)b );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -395,6 +426,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind MULTIPLICATIVE_MULTIPLY : usual arithmetic conversions
+	@Test
 	public void testMultiplicativeMultiply() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a * b );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -405,6 +437,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind MULTIPLICATIVE_DIVIDE : usual arithmetic conversions
+	@Test
 	public void testMultiplicativeDivide() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( b / a );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -415,6 +448,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind MULTIPLICATIVE_MODULUS : usual arithmetic conversions
+	@Test
 	public void testMultiplicativeModulus() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( b % a );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -425,6 +459,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ADDITIVE_PLUS : usual arithmetic conversions
+	@Test
 	public void testAdditivePlus() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( b + a );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -435,6 +470,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ADDITIVE_MINUS : usual arithmetic conversions
+	@Test
 	public void testAdditiveMinus() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( b - a );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -445,6 +481,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind SHIFT_LEFT : LHS
+	@Test
 	public void testShiftLeft() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a << 5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -455,6 +492,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind SHIFT_RIGHT : LHS
+	@Test
 	public void testShiftRight() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a >> 5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -465,6 +503,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind RELATIONAL_LESSTHAN : bool
+	@Test
 	public void testRelationalLessThan() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( b < 3 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -475,6 +514,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind RELATIONAL_GREATERTHAN : bool
+	@Test
 	public void testRelationalGreaterThan() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( b > 3 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -485,6 +525,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind RELATIONAL_LESSTHANEQUALTO : bool
+	@Test
 	public void testRelationalLessThanOrEqual() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( b <= 3 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -495,6 +536,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind RELATIONAL_GREATERTHANEQUALTO : bool
+	@Test
 	public void testRelationalGreaterThanOrEqual() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( b >= 3 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -505,6 +547,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind EQUALITY_EQUALS : bool
+	@Test
 	public void testEqualityEquals() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( b == 3 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -515,6 +558,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind EQUALITY_NOTEQUALS : bool
+	@Test
 	public void testEqualityNotEquals() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( b != 3 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -525,6 +569,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ANDEXPRESSION  : usual arithmetic conversions
+	@Test
 	public void testAndExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a & b );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -535,6 +580,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind EXCLUSIVEOREXPRESSION : usual arithmetic conversions
+	@Test
 	public void testExclusiveOrExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a ^ b );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -545,6 +591,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind INCLUSIVEOREXPRESSION : : usual arithmetic conversions
+	@Test
 	public void testInclusiveOrExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a | b );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -555,6 +602,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind LOGICALANDEXPRESSION : bool
+	@Test
 	public void testLogicalAndExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a && b );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -565,6 +613,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind LOGICALOREXPRESSION  : bool
+	@Test
 	public void testLogicalOrExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a || b );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -575,6 +624,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind CONDITIONALEXPRESSION : conditional Expression Conversions
+	@Test
 	public void testConditionalExpression() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a > 5 ? b : c );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -585,6 +635,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ASSIGNMENTEXPRESSION_NORMAL : LHS
+	@Test
 	public void testAssignmentExpressionNormal() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a = 5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -595,6 +646,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ASSIGNMENTEXPRESSION_PLUS : LHS
+	@Test
 	public void testAssignmentExpressionPlus() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a += 5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -605,6 +657,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ASSIGNMENTEXPRESSION_MINUS : LHS
+	@Test
 	public void testAssignmentExpressionMinus() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a -= 5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -615,6 +668,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ASSIGNMENTEXPRESSION_MULT : LHS
+	@Test
 	public void testAssignmentExpressionMulti() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a *= 5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -625,6 +679,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ASSIGNMENTEXPRESSION_DIV : LHS
+	@Test
 	public void testAssignmentExpressionDiv() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a /= 5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -635,6 +690,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ASSIGNMENTEXPRESSION_MOD : LHS
+	@Test
 	public void testAssignmentExpressionMod() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a %= 5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -645,6 +701,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ASSIGNMENTEXPRESSION_LSHIFT : LHS
+	@Test
 	public void testAssignmentExpressionLShift() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a >>= 5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -655,6 +712,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ASSIGNMENTEXPRESSION_RSHIFT : LHS
+	@Test
 	public void testAssignmentExpressionRShift() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a <<= 5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -665,6 +723,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ASSIGNMENTEXPRESSION_AND : LHS
+	@Test
 	public void testAssignmentExpressionAnd() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a &= 5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -675,6 +734,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ASSIGNMENTEXPRESSION_OR : LHS
+	@Test
 	public void testAssignmentExpressionOr() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a |= 5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();
@@ -685,6 +745,7 @@ public class AST2UtilOldTests extends AST2TestBase {
 	}
 
 	// Kind ASSIGNMENTEXPRESSION_XOR : LHS
+	@Test
 	public void testAssignmentExpressionXOr() throws Exception {
 		IASTTranslationUnit tu = parse("int x = foo( a ^= 5 );".toString(), ParserLanguage.C); //$NON-NLS-1$
 		IASTDeclaration[] d = tu.getDeclarations();

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2UtilTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2UtilTests.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.eclipse.cdt.core.dom.ast.IASTCastExpression;
 import org.eclipse.cdt.core.dom.ast.IASTCompoundStatement;
 import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
@@ -26,18 +28,14 @@ import org.eclipse.cdt.core.dom.ast.IFunction;
 import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.internal.core.model.ASTStringUtil;
 import org.eclipse.cdt.internal.core.parser.scanner.ExpressionEvaluator;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author dsteffle
  */
 public class AST2UtilTests extends AST2TestBase {
-	public AST2UtilTests() {
-	}
 
-	public AST2UtilTests(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testSimpleSignature() throws Exception {
 		StringBuilder buff = new StringBuilder();
 		buff.append("int l, m, n=0;\n"); //$NON-NLS-1$
@@ -96,6 +94,7 @@ public class AST2UtilTests extends AST2TestBase {
 				"b + c"); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSimpleParameter() throws Exception {
 		StringBuilder buff = new StringBuilder();
 		buff.append("int a(int x);\n"); //$NON-NLS-1$
@@ -164,6 +163,7 @@ public class AST2UtilTests extends AST2TestBase {
 				"(const char * const)"); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSimpleCParameterSignature() throws Exception {
 		StringBuilder buff = new StringBuilder();
 		buff.append("int a(int x);\n"); //$NON-NLS-1$
@@ -180,6 +180,7 @@ public class AST2UtilTests extends AST2TestBase {
 		isParameterSignatureEqual(((IASTSimpleDeclaration) d[3]).getDeclarators()[0], "(int[])"); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testSimpleTypeId() throws Exception {
 		StringBuilder buff = new StringBuilder();
 		buff.append("int x = sizeof( int );\n"); //$NON-NLS-1$
@@ -218,6 +219,7 @@ public class AST2UtilTests extends AST2TestBase {
 				.getInitializer()).getInitializerClause()).getTypeId(), "short int"); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testKnRC() throws Exception {
 		StringBuilder buff = new StringBuilder();
 		buff.append("int foo(x, y) char x; int y; {}\n"); //$NON-NLS-1$
@@ -232,6 +234,7 @@ public class AST2UtilTests extends AST2TestBase {
 		assertEquals(fooSignature, foo2Signature);
 	}
 
+	@Test
 	public void testParseIntegral() throws Exception {
 		assertEquals(0, ExpressionEvaluator.getNumber("0".toCharArray()));
 		assertEquals(0, ExpressionEvaluator.getNumber("0x0".toCharArray()));

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/ASTCPPSpecDefectTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/ASTCPPSpecDefectTests.java
@@ -15,21 +15,9 @@ package org.eclipse.cdt.core.parser.tests.ast2;
 
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.parser.ParserLanguage;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class ASTCPPSpecDefectTests extends AST2TestBase {
-
-	public ASTCPPSpecDefectTests() {
-	}
-
-	public ASTCPPSpecDefectTests(String name) {
-		super(name);
-	}
-
-	public static TestSuite suite() {
-		return suite(ASTCPPSpecDefectTests.class);
-	}
 
 	protected IASTTranslationUnit parseAndCheckBindings(String code) throws Exception {
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -55,6 +43,7 @@ public class ASTCPPSpecDefectTests extends AST2TestBase {
 	//	void test() {
 	//		fp(f0);
 	//	}
+	@Test
 	public void test33_ADLForOverloadSet_324842() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -64,6 +53,7 @@ public class ASTCPPSpecDefectTests extends AST2TestBase {
 	//	struct A {
 	//	  friend A operator + <>(A&);
 	//	};
+	@Test
 	public void test38_templateArgForOperator() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -72,6 +62,7 @@ public class ASTCPPSpecDefectTests extends AST2TestBase {
 	//	template <class T1, class ...Z> class S<T1, const Z&...> {}; // #2
 	//	template <class T1, class T2> class S<T1, const T2&> {};; // #3
 	//	S<int, const int&> s; // both #2 and #3 match; #3 is more specialized
+	@Test
 	public void test692_partialOrdering() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -79,6 +70,7 @@ public class ASTCPPSpecDefectTests extends AST2TestBase {
 	//	auto f(int x, int y) -> decltype(x < y ? x : y) {
 	//		return x < y ? x : y;
 	//	}
+	@Test
 	public void testUnparenthesizedConditionalExpressionInTrailingReturnType_544818() throws Exception {
 		parseAndCheckBindings();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/ASTInactiveCodeTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/ASTInactiveCodeTests.java
@@ -13,6 +13,12 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.BitSet;
 
 import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
@@ -25,25 +31,12 @@ import org.eclipse.cdt.core.dom.ast.IFunction;
 import org.eclipse.cdt.core.dom.ast.IVariable;
 import org.eclipse.cdt.core.parser.IScanner;
 import org.eclipse.cdt.core.parser.ParserLanguage;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * Testcases for inactive code in ast.
  */
 public class ASTInactiveCodeTests extends AST2TestBase {
-
-	public static TestSuite suite() {
-		return suite(ASTInactiveCodeTests.class);
-	}
-
-	public ASTInactiveCodeTests() {
-		super();
-	}
-
-	public ASTInactiveCodeTests(String name) {
-		super(name);
-	}
 
 	@Override
 	protected void configureScanner(IScanner scanner) {
@@ -67,6 +60,7 @@ public class ASTInactiveCodeTests extends AST2TestBase {
 	//	   int a6;
 	//	#endif
 	//	int a7;
+	@Test
 	public void testIfBranches() throws Exception {
 		String codeTmpl = getAboveComment();
 		for (int i = 0; i < (1 << 4); i++) {
@@ -139,6 +133,7 @@ public class ASTInactiveCodeTests extends AST2TestBase {
 	//	   int a6;
 	//	#endif
 	//	int a7;
+	@Test
 	public void testIfdefBranches() throws Exception {
 		String codeTmpl = getAboveComment();
 		for (int i = 0; i < (1 << 4); i++) {
@@ -166,6 +161,7 @@ public class ASTInactiveCodeTests extends AST2TestBase {
 	//	   int a6;
 	//	#endif
 	//	int a7;
+	@Test
 	public void testIfndefBranches() throws Exception {
 		String codeTmpl = getAboveComment();
 		for (int i = 0; i < (1 << 4); i++) {
@@ -194,6 +190,7 @@ public class ASTInactiveCodeTests extends AST2TestBase {
 	//	#endif
 	//	int a7;
 	// };
+	@Test
 	public void testStructs() throws Exception {
 		String codeTmpl = getAboveComment();
 		for (int i = 0; i < (1 << 4); i++) {
@@ -222,6 +219,7 @@ public class ASTInactiveCodeTests extends AST2TestBase {
 	//	#endif
 	//	int a7;
 	// };
+	@Test
 	public void testExternC() throws Exception {
 		String codeTmpl = getAboveComment();
 		for (int i = 0; i < (1 << 4); i++) {
@@ -247,6 +245,7 @@ public class ASTInactiveCodeTests extends AST2TestBase {
 	//	#endif
 	//	int a7;
 	// }
+	@Test
 	public void testNamespace() throws Exception {
 		String codeTmpl = getAboveComment();
 		for (int i = 0; i < (1 << 4); i++) {
@@ -260,6 +259,7 @@ public class ASTInactiveCodeTests extends AST2TestBase {
 	//    int f(TInt);
 	//    int g(value);
 	// #endif
+	@Test
 	public void testAmbiguity() throws Exception {
 		String code = getAboveComment();
 		IASTTranslationUnit tu = parseAndCheckBindings(code, ParserLanguage.CPP);
@@ -279,6 +279,7 @@ public class ASTInactiveCodeTests extends AST2TestBase {
 	//    int b; // 1
 	// #endif
 	// int b; // 2
+	@Test
 	public void testDuplicateDefinition() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, false);
@@ -307,6 +308,7 @@ public class ASTInactiveCodeTests extends AST2TestBase {
 	//   int b;
 	// };
 	// #endif
+	@Test
 	public void testInactiveClosingBrace() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, false);
@@ -332,6 +334,7 @@ public class ASTInactiveCodeTests extends AST2TestBase {
 	//      int d;
 	//   #endif
 	// };
+	@Test
 	public void testOpenBraceInActiveBranch() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, false);
@@ -362,6 +365,7 @@ public class ASTInactiveCodeTests extends AST2TestBase {
 	//    int c;
 	// #endif
 	// int d;
+	@Test
 	public void testOpenBraceInInactiveBranch() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, false);
@@ -392,6 +396,7 @@ public class ASTInactiveCodeTests extends AST2TestBase {
 	//	   #endif
 	//	 }
 	//	 #endif
+	@Test
 	public void testUnexpectedBranchesInInactiveCode() throws Exception {
 		String code = getAboveComment();
 		BindingAssertionHelper bh = new AST2AssertionHelper(code, false);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/ASTNodeSelectorTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/ASTNodeSelectorTest.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.io.IOException;
 
 import org.eclipse.cdt.core.dom.ast.IASTName;
@@ -28,33 +32,17 @@ import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.core.parser.ParserMode;
 import org.eclipse.cdt.core.parser.ScannerInfo;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.GNUCPPSourceParser;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ASTNodeSelectorTest extends AST2TestBase {
-
-	static public TestSuite suite() {
-		return suite(ASTNodeSelectorTest.class);
-	}
 
 	protected String fCode;
 	protected IASTTranslationUnit fTu;
 	protected IASTNodeSelector fSelector;
 
-	public ASTNodeSelectorTest() {
-	}
-
-	public ASTNodeSelectorTest(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-		createTranslationUnit();
-	}
-
-	protected void createTranslationUnit() throws IOException {
+	@BeforeEach
+	public void createTranslationUnit() throws IOException {
 		fCode = getContents(1)[0].toString();
 		FileContent codeReader = FileContent.create("<test-code>", fCode.toCharArray());
 		ScannerInfo scannerInfo = new ScannerInfo();
@@ -66,11 +54,6 @@ public class ASTNodeSelectorTest extends AST2TestBase {
 		fSelector = fTu.getNodeSelector(null);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-	}
-
 	private void testContainedName(int from, int to, String sig) {
 		IASTName name = fSelector.findFirstContainedName(from, to - from);
 		verify(sig, name);
@@ -78,9 +61,9 @@ public class ASTNodeSelectorTest extends AST2TestBase {
 
 	private void verify(String sig, IASTNode node) {
 		if (sig == null) {
-			assertNull("unexpexted selection: " + (node == null ? "" : node.getRawSignature()), node);
+			assertNull(node, "unexpexted selection: " + (node == null ? "" : node.getRawSignature()));
 		} else {
-			assertNotNull("unable to select " + sig, node);
+			assertNotNull(node, "unable to select " + sig);
 			if (node instanceof IASTName) {
 				assertEquals(sig, ((IASTName) node).toString());
 			} else {
@@ -124,6 +107,7 @@ public class ASTNodeSelectorTest extends AST2TestBase {
 	//
 	// #include <test>
 	// int a;
+	@Test
 	public void testInclusion() {
 		int include_start = fCode.indexOf("#include");
 		int name_start = fCode.indexOf("test");
@@ -162,6 +146,7 @@ public class ASTNodeSelectorTest extends AST2TestBase {
 	// void func() {
 	// #include EMPTY TEST_H
 	// }
+	@Test
 	public void testInclusionWithExpansions() {
 		int inclusion_start = fCode.indexOf("#include");
 		int empty_start = fCode.indexOf("EMPTY", inclusion_start);
@@ -227,6 +212,7 @@ public class ASTNodeSelectorTest extends AST2TestBase {
 	// #if  xx == 2
 	// #elif xx == 1
 	// #endif
+	@Test
 	public void testMacroInConditionalExpression() {
 		int x1 = fCode.indexOf("xx");
 		int x2 = fCode.indexOf("xx", x1 + 1);
@@ -268,6 +254,7 @@ public class ASTNodeSelectorTest extends AST2TestBase {
 	// #if !defined(xx)
 	// #elif defined(xx) == 1
 	// #endif
+	@Test
 	public void testMacroInDefinedExpression() {
 		int x1 = fCode.indexOf("xx");
 		int x2 = fCode.indexOf("xx", x1 + 1);
@@ -311,6 +298,7 @@ public class ASTNodeSelectorTest extends AST2TestBase {
 	// #ifdef xx
 	// #endif
 	// #undef xx
+	@Test
 	public void testMacroInConditional() {
 		int x1 = fCode.indexOf("xx");
 		x1 = fCode.indexOf("xx", x1 + 1);
@@ -352,6 +340,7 @@ public class ASTNodeSelectorTest extends AST2TestBase {
 	// #define IMPLICIT 1
 	// #define EXPLICIT IMPLICIT
 	// int a= EXPLICIT;
+	@Test
 	public void testUnreachableImplicitMacro() {
 		int x1 = fCode.indexOf("EXPLICIT;");
 		testContainedName(x1, fCode.length(), "EXPLICIT");
@@ -365,6 +354,7 @@ public class ASTNodeSelectorTest extends AST2TestBase {
 	// #define NESTED 1
 	// #define EXPLICIT(x) x
 	// int a= EXPLICIT(NESTED);
+	@Test
 	public void testReachableNestedMacro() {
 		int x1 = fCode.indexOf("NESTED)");
 		testContainedName(x1, fCode.length(), "NESTED");
@@ -375,6 +365,7 @@ public class ASTNodeSelectorTest extends AST2TestBase {
 	// #define id(x,y) x y
 	// id(int a, =1);
 	// id(int b=, a);
+	@Test
 	public void testImageLocations() {
 		int a1 = fCode.indexOf("a");
 		int a2 = fCode.indexOf("a", a1 + 1);
@@ -403,6 +394,7 @@ public class ASTNodeSelectorTest extends AST2TestBase {
 	// #define O
 	// #define P()
 	// P()O
+	@Test
 	public void testOrdering() {
 		int x1 = fCode.indexOf("ns::a");
 		int x2 = x1 + "ns::a".length();
@@ -434,6 +426,7 @@ public class ASTNodeSelectorTest extends AST2TestBase {
 
 	// #define MACRO void m
 	// MACRO();
+	@Test
 	public void testEnclosingAMacro() {
 		int x1 = fCode.indexOf("MACRO(");
 		int x2 = x1 + "MACRO(".length();

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AccessControlTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AccessControlTests.java
@@ -15,6 +15,9 @@
 package org.eclipse.cdt.core.parser.tests.ast2;
 
 import static org.eclipse.cdt.core.parser.tests.VisibilityAsserts.assertVisibility;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.cdt.core.dom.ast.IASTName;
 import org.eclipse.cdt.core.dom.ast.IBinding;
@@ -22,8 +25,7 @@ import org.eclipse.cdt.core.dom.ast.cpp.ICPPClassType;
 import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.AccessContext;
 import org.eclipse.cdt.internal.core.parser.ParserException;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class AccessControlTests extends AST2TestBase {
 
@@ -45,17 +47,6 @@ public class AccessControlTests extends AST2TestBase {
 			assertNotNull(binding);
 			assertFalse(AccessContext.isAccessible(binding, name));
 		}
-	}
-
-	public AccessControlTests() {
-	}
-
-	public AccessControlTests(String name) {
-		super(name);
-	}
-
-	public static TestSuite suite() {
-		return suite(AccessControlTests.class);
 	}
 
 	private AccessAssertionHelper getAssertionHelper() throws Exception {
@@ -96,6 +87,7 @@ public class AccessControlTests extends AST2TestBase {
 	//    C::E(); //3
 	//    C::F(); //3
 	//	}
+	@Test
 	public void testFriends() throws Exception {
 		AccessAssertionHelper ah = getAssertionHelper();
 		ah.assertAccessible("a; //1", 1);
@@ -125,6 +117,7 @@ public class AccessControlTests extends AST2TestBase {
 	//	void test(B x) {
 	//	  x.a = 0;
 	//	}
+	@Test
 	public void testHiddenMember() throws Exception {
 		AccessAssertionHelper ah = getAssertionHelper();
 		ah.assertNotAccessible("a = 0", 1);
@@ -142,6 +135,7 @@ public class AccessControlTests extends AST2TestBase {
 	//			}
 	//		};
 	//	};
+	@Test
 	public void testEnclosingAsNamingClass_292232() throws Exception {
 		AccessAssertionHelper ah = getAssertionHelper();
 		ah.assertAccessible("Ex a;", 2);
@@ -167,6 +161,7 @@ public class AccessControlTests extends AST2TestBase {
 	//   B* bp;
 	//   bp->mi=5;
 	// }
+	@Test
 	public void testEnclosingAsNamingClass_292232a() throws Exception {
 		AccessAssertionHelper ah = getAssertionHelper();
 		ah.assertNotAccessible("mi=3;", 2);
@@ -181,6 +176,7 @@ public class AccessControlTests extends AST2TestBase {
 	//		typedef int Waldo;
 	//	};
 	//	A::Waldo waldo;
+	@Test
 	public void testPrivateTypedef_427730() throws Exception {
 		AccessAssertionHelper ah = getAssertionHelper();
 		ah.assertNotAccessible("Waldo waldo", 5);
@@ -193,6 +189,7 @@ public class AccessControlTests extends AST2TestBase {
 	//		typedef B Waldo;
 	//	};
 	//	A::Waldo waldo;
+	@Test
 	public void testPublicTypedefForPrivateMemberClass_427730() throws Exception {
 		AccessAssertionHelper ah = getAssertionHelper();
 		ah.assertAccessible("Waldo waldo", 5);
@@ -208,6 +205,7 @@ public class AccessControlTests extends AST2TestBase {
 	//		typedef A::B Waldo;
 	//	};
 	//	C::Waldo waldo;
+	@Test
 	public void testPublicTypedefForFriendClass_427730() throws Exception {
 		AccessAssertionHelper ah = getAssertionHelper();
 		ah.assertAccessible("Waldo waldo", 5);
@@ -219,6 +217,7 @@ public class AccessControlTests extends AST2TestBase {
 	//		using AliasInner = Inner;
 	//		typedef Inner TypedefInner;
 	//	};
+	@Test
 	public void testAccessibilityForAliasedTypeInSameClass_427730() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPClassType outerClass = bh.assertNonProblem("Outer");

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/CommentTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/CommentTests.java
@@ -14,13 +14,15 @@
  ******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.eclipse.cdt.core.dom.ast.IASTComment;
 import org.eclipse.cdt.core.dom.ast.IASTFileLocation;
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.internal.core.parser.ParserException;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Guido Zgraggen
@@ -28,10 +30,7 @@ import junit.framework.TestSuite;
  */
 public class CommentTests extends AST2TestBase {
 
-	public static TestSuite suite() {
-		return suite(CommentTests.class);
-	}
-
+	@Test
 	public void testCountCommentsInHeaderFile() throws ParserException {
 		IASTTranslationUnit tu = parse(getHSource(), ParserLanguage.CPP, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
@@ -39,6 +38,7 @@ public class CommentTests extends AST2TestBase {
 		assertEquals(9, comments.length);
 	}
 
+	@Test
 	public void testCommentsInHeaderFile() throws ParserException {
 		IASTTranslationUnit tu = parse(getHSource(), ParserLanguage.CPP, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
@@ -54,6 +54,7 @@ public class CommentTests extends AST2TestBase {
 		assertEquals("//Endcomment h", new String(comments[8].getComment()));
 	}
 
+	@Test
 	public void testCountCommentsInCPPFile() throws ParserException {
 		IASTTranslationUnit tu = parse(getCppSource(), ParserLanguage.CPP, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
@@ -61,6 +62,7 @@ public class CommentTests extends AST2TestBase {
 		assertEquals(10, comments.length);
 	}
 
+	@Test
 	public void testCommentsInCPPFile() throws ParserException {
 		IASTTranslationUnit tu = parse(getCppSource(), ParserLanguage.CPP, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
@@ -77,6 +79,7 @@ public class CommentTests extends AST2TestBase {
 		assertEquals("//An integer", new String(comments[9].getComment()));
 	}
 
+	@Test
 	public void testCountCommentsInCFile() throws ParserException {
 		IASTTranslationUnit tu = parse(getCSource(), ParserLanguage.C, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
@@ -84,6 +87,7 @@ public class CommentTests extends AST2TestBase {
 		assertEquals(4, comments.length);
 	}
 
+	@Test
 	public void testCommentsInCFile() throws ParserException {
 		IASTTranslationUnit tu = parse(getCSource(), ParserLanguage.C, ScannerKind.STD, true);
 		IASTComment[] comments = tu.getComments();
@@ -203,6 +207,7 @@ public class CommentTests extends AST2TestBase {
 	// #else
 	// // comment2
 	// #endif
+	@Test
 	public void testCommentsInInactiveCode_bug183930() throws Exception {
 		CharSequence code = getContents(1)[0];
 		IASTTranslationUnit tu = parse(code.toString(), ParserLanguage.CPP, ScannerKind.STD, true);
@@ -214,6 +219,7 @@ public class CommentTests extends AST2TestBase {
 	}
 
 	// //comment
+	@Test
 	public void testCommentLocation_bug186337() throws Exception {
 		CharSequence code = getContents(1)[0];
 		IASTTranslationUnit tu = parse(code.toString(), ParserLanguage.CPP, ScannerKind.STD, true);
@@ -237,6 +243,7 @@ public class CommentTests extends AST2TestBase {
 	// #ifdef WHATEVA // TODO: ignored
 	// #endif // TODO: ignored
 	// // TODO: shows up in task list
+	@Test
 	public void testCommentInDirectives_bug192546() throws Exception {
 		CharSequence code = getContents(1)[0];
 		IASTTranslationUnit tu = parse(code.toString(), ParserLanguage.CPP, ScannerKind.STD, false);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/DOMLocationMacroTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/DOMLocationMacroTests.java
@@ -15,6 +15,13 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
 import org.eclipse.cdt.core.dom.ast.IASTDeclarator;
 import org.eclipse.cdt.core.dom.ast.IASTEqualsInitializer;
@@ -37,18 +44,13 @@ import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.dom.ast.IMacroBinding;
 import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.internal.core.parser.ParserException;
+import org.junit.jupiter.api.Test;
 
 public class DOMLocationMacroTests extends AST2TestBase {
 
 	final ParserLanguage[] languages = new ParserLanguage[] { ParserLanguage.C, ParserLanguage.CPP };
 
-	public DOMLocationMacroTests() {
-	}
-
-	public DOMLocationMacroTests(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testObjectStyleMacroExpansionSimpleDeclarator() throws Exception {
 		StringBuilder buffer = new StringBuilder("#define ABC D\n"); //$NON-NLS-1$
 		buffer.append("int ABC;"); //$NON-NLS-1$
@@ -76,6 +78,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testObjectMacroExpansionModestDeclarator() throws Exception {
 		StringBuilder buffer = new StringBuilder("#define ABC * D\n"); //$NON-NLS-1$
 		buffer.append("int ABC;"); //$NON-NLS-1$
@@ -129,6 +132,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testObjectMacroExpansionPartialDeclSpec() throws Exception {
 		StringBuilder buffer = new StringBuilder("#define XYZ const\n"); //$NON-NLS-1$
 		buffer.append("XYZ int var;"); //$NON-NLS-1$
@@ -156,6 +160,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testObjectMacroExpansionNested() throws Exception {
 		StringBuilder buffer = new StringBuilder("#define XYZ const\n"); //$NON-NLS-1$
 		buffer.append("#define PO *\n"); //$NON-NLS-1$
@@ -187,6 +192,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testObjectMacroExpansionComplex() throws Exception {
 		StringBuilder buffer = new StringBuilder("#define XYZ const\n"); //$NON-NLS-1$
 		buffer.append("#define PO *\n"); //$NON-NLS-1$
@@ -241,6 +247,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testStdioBug() throws ParserException {
 		StringBuilder buffer = new StringBuilder("#define    _PTR        void *\n"); //$NON-NLS-1$
 		buffer.append("#define __cdecl __attribute__ ((__cdecl__))\n"); //$NON-NLS-1$
@@ -283,6 +290,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		assertEquals(fromExpansion.getName().toString(), source.getName().toString());
 	}
 
+	@Test
 	public void testMacroBindings() throws Exception {
 		StringBuilder buffer = new StringBuilder("#define ABC def\n"); //$NON-NLS-1$
 		buffer.append("int ABC;\n"); //$NON-NLS-1$
@@ -319,6 +327,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testBug90978() throws Exception {
 		StringBuilder buffer = new StringBuilder("#define MACRO mm\n"); //$NON-NLS-1$
 		buffer.append("int MACRO;\n"); //$NON-NLS-1$
@@ -341,6 +350,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testBug94933() throws Exception {
 		StringBuilder buffer = new StringBuilder("#define API extern\n"); //$NON-NLS-1$
 		buffer.append("#define MYAPI API\n"); //$NON-NLS-1$
@@ -353,6 +363,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testFunctionMacroExpansionWithNameSubstitution_Bug173637() throws Exception {
 		StringBuilder buffer = new StringBuilder("#define PLUS5(x) (x+5)\n"); //$NON-NLS-1$
 		buffer.append("#define FUNCTION PLUS5 \n"); //$NON-NLS-1$
@@ -400,6 +411,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		assertEquals(length, fileLocation.getNodeLength());
 	}
 
+	@Test
 	public void testBug186257() throws Exception {
 		StringBuilder sb = new StringBuilder();
 		sb.append("typedef char STR; \n"); //$NON-NLS-1$
@@ -417,6 +429,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testArgumentExpansion() throws Exception {
 		StringBuilder sb = new StringBuilder();
 		sb.append("#define ADD(a,b, c) (a) + (b) + (c) \n"); //$NON-NLS-1$
@@ -436,6 +449,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testArgumentCapture() throws Exception {
 		StringBuilder sb = new StringBuilder();
 		sb.append("#define add(x,y) x + y \n"); //$NON-NLS-1$
@@ -452,6 +466,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testFunctionMacroNotCalled() throws Exception {
 		StringBuilder sb = new StringBuilder();
 		sb.append("#define FUNCTION(x) x \n"); //$NON-NLS-1$
@@ -468,6 +483,7 @@ public class DOMLocationMacroTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testBuildFunctionMacroName() throws Exception {
 		StringBuilder sb = new StringBuilder();
 		sb.append("#define FUN1(x) x \n"); //$NON-NLS-1$

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/DOMLocationTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/DOMLocationTests.java
@@ -14,6 +14,11 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Arrays;
 
 import org.eclipse.cdt.core.dom.ast.IASTBinaryExpression;
@@ -74,25 +79,14 @@ import org.eclipse.cdt.core.parser.IProblem;
 import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.internal.core.dom.parser.ASTNode;
 import org.eclipse.cdt.internal.core.parser.ParserException;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jcamelon
  */
 public class DOMLocationTests extends AST2TestBase {
 
-	public DOMLocationTests() {
-	}
-
-	public DOMLocationTests(String name) {
-		setName(name);
-	}
-
-	public static TestSuite suite() {
-		return suite(DOMLocationTests.class);
-	}
-
+	@Test
 	public void testBaseCase() throws ParserException {
 		for (ParserLanguage p : ParserLanguage.values()) {
 			IASTTranslationUnit tu = parse("int x;", p); //$NON-NLS-1$
@@ -113,6 +107,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testSimpleDeclaration() throws ParserException {
 		String code = "int xLen5, * yLength8, zLength16( int );"; //$NON-NLS-1$
 		for (ParserLanguage p : ParserLanguage.values()) {
@@ -148,6 +143,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testSimpleObjectStyleMacroDefinition() throws Exception {
 		String code = "/* hi */\n#define FOOT 0x01\n\n"; //$NON-NLS-1$
 		for (ParserLanguage p : ParserLanguage.values()) {
@@ -164,6 +160,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testSimpleFunctionStyleMacroDefinition() throws Exception {
 		String code = "#define FOOBAH( WOOBAH ) JOHN##WOOBAH\n\n"; //$NON-NLS-1$
 		for (ParserLanguage p : ParserLanguage.values()) {
@@ -202,6 +199,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertEquals(length, location.getNodeLength());
 	}
 
+	@Test
 	public void testBug83664() throws Exception {
 		String code = "int foo(x) int x; {\n 	return x;\n   }\n"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.C, ScannerKind.GNU);
@@ -217,6 +215,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(expression, code.indexOf("return ") + "return ".length(), 1); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testBug84343() throws Exception {
 		String code = "class A {}; int f() {\nA * b = 0;\nreturn b;}"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -228,6 +227,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(namedTypeSpec, code.indexOf("\nA") + 1, 1); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testBug84366() throws Exception {
 		String code = "enum hue { red, blue, green };"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -237,6 +237,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(enumerator, code.indexOf("red"), "red".length()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testBug84375() throws Exception {
 		String code = "class D { public: int x; };\nclass C : public virtual D {};"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -247,6 +248,7 @@ public class DOMLocationTests extends AST2TestBase {
 
 	}
 
+	@Test
 	public void testBug84357() throws Exception {
 		String code = "class X {	int a;\n};\nint X::  * pmi = &X::a;"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -256,6 +258,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(p, code.indexOf("X::  *"), "X::  *".length()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testBug84367() throws Exception {
 		String code = "void foo(   int   );"; //$NON-NLS-1$
 		for (ParserLanguage p : ParserLanguage.values()) {
@@ -267,6 +270,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testElaboratedTypeSpecifier() throws ParserException {
 		String code = "/* blah */ struct A anA; /* blah */"; //$NON-NLS-1$
 		for (ParserLanguage p : ParserLanguage.values()) {
@@ -277,6 +281,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testBug83852() throws Exception {
 		String code = "/* blah */ typedef short jc;  int x = 4;  jc myJc = (jc)x; "; //$NON-NLS-1$
 		for (ParserLanguage p : ParserLanguage.values()) {
@@ -310,6 +315,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testBug83853() throws ParserException {
 		String code = "int f() {return (1?0:1);	}"; //$NON-NLS-1$
 		for (ParserLanguage p : ParserLanguage.values()) {
@@ -324,6 +330,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testBug84374() throws Exception {
 		String code = "class P1 { public: int x; };\nclass P2 { public: int x; };\nclass B : public P1, public P2 {};\nvoid main() {\nB * b = new B();\n}"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -337,6 +344,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(newExpression, code.indexOf("new B()"), "new B()".length()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testBug83737() throws Exception {
 		String code = "void f() {  if( a == 0 ) g( a ); else if( a < 0 ) g( a >> 1 ); else if( a > 0 ) g( *(&a + 2) ); }"; //$NON-NLS-1$
 		for (ParserLanguage p : ParserLanguage.values()) {
@@ -359,6 +367,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testBug84467() throws Exception {
 		String code = "class D { };\n D d1;\n const D d2;\n void foo() {\n typeid(d1) == typeid(d2);\n }"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -374,6 +383,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(exp, code.indexOf("typeid(d2)"), "typeid(d2)".length()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testBug84576() throws Exception {
 		String code = "namespace A {\n extern \"C\" int g();\n }"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -382,6 +392,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(spec, code.indexOf("extern \"C\""), "extern \"C\" int g();".length()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
+	@Test
 	public void testSimplePreprocessorStatements() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#ifndef _APPLE_H_\n"); //$NON-NLS-1$
@@ -406,6 +417,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testBug162180() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#include <notfound.h>\n"); //$NON-NLS-1$
@@ -431,6 +443,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertFileLocation(node, code.indexOf(snip), snip.length());
 	}
 
+	@Test
 	public void testBug162180_0() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#include <notfound.h>\n"); //$NON-NLS-1$
@@ -454,6 +467,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void test162180_1() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#define xxx(!) int a\n"); // [0-20]
@@ -477,6 +491,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void test162180_2() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#define ! x\n");
@@ -495,6 +510,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void test162180_3() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#define nix(x) x\n");
@@ -514,6 +530,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void test162180_4() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#include \"\"\n");
@@ -532,6 +549,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testBug85820() throws Exception {
 		String code = "int *p = (int []){2, 4};"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.C);
@@ -540,6 +558,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(d, code.indexOf("*p = (int []){2, 4}"), "*p = (int []){2, 4}".length()); //$NON-NLS-1$//$NON-NLS-2$
 	}
 
+	@Test
 	public void testBug86323() throws Exception {
 		String code = "void f() { int i=0;	for (; i<10; i++) {	} }"; //$NON-NLS-1$
 		for (ParserLanguage p : ParserLanguage.values()) {
@@ -550,6 +569,7 @@ public class DOMLocationTests extends AST2TestBase {
 		}
 	}
 
+	@Test
 	public void testBug86698_1() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("struct C;\n"); //$NON-NLS-1$
@@ -568,6 +588,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(memInit, buffer.toString().indexOf("c(0)"), "c(0)".length()); //$NON-NLS-1$//$NON-NLS-2$
 	}
 
+	@Test
 	public void testBug86698_2() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(int);\n"); //$NON-NLS-1$
@@ -594,6 +615,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(tryblock.getCatchHandlers()[0], code.indexOf("catch"), "catch (...)\n{\n }".length());
 	}
 
+	@Test
 	public void testBug157009_1() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#ifndef A\r\n#error X\r\n#else\r\n#error Y\r\n#endif");
@@ -604,6 +626,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(problems[0], buffer.indexOf("X"), "X".length());
 	}
 
+	@Test
 	public void testBug157009_2() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("#ifndef A\n#error X\n#else\n#error Y\n#endif");
@@ -614,6 +637,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(problems[0], buffer.indexOf("X"), "X".length());
 	}
 
+	@Test
 	public void testBug171520() throws Exception {
 		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=171520
 		StringBuilder buffer = new StringBuilder();
@@ -633,6 +657,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(expr, buffer.indexOf("sizeof"), "sizeof(int)".length());
 	}
 
+	@Test
 	public void testBug120607() throws Exception {
 		// C/C++ Indexer rejects valid pre-processor directive
 		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=120607
@@ -658,6 +683,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(problems[2], code, "#invalid");
 	}
 
+	@Test
 	public void testBug527396_1() throws Exception {
 		String code = "void foo() noexcept {}"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -667,6 +693,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(declarator, code.indexOf(rawDeclarator), rawDeclarator.length());
 	}
 
+	@Test
 	public void testBug527396_2() throws Exception {
 		String code = "void foo() noexcept(false) {}"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -676,6 +703,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(declarator, code.indexOf(rawDeclarator), rawDeclarator.length());
 	}
 
+	@Test
 	public void testBug527396_3() throws Exception {
 		String code = "void foo() {}"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -685,6 +713,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(declarator, code.indexOf(rawDeclarator), rawDeclarator.length());
 	}
 
+	@Test
 	public void testBug527396_4() throws Exception {
 		String code = "void foo() noexcept;"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -694,6 +723,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(declarator, code.indexOf(rawDeclarator), rawDeclarator.length());
 	}
 
+	@Test
 	public void testBug527396_5() throws Exception {
 		String code = "void foo() noexcept(false);"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -703,6 +733,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(declarator, code.indexOf(rawDeclarator), rawDeclarator.length());
 	}
 
+	@Test
 	public void testBug527396_6() throws Exception {
 		String code = "void foo();"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -712,6 +743,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(declarator, code.indexOf(rawDeclarator), rawDeclarator.length());
 	}
 
+	@Test
 	public void testSwitchInitStatement_1() throws Exception {
 		String code = "void foo() { switch (int i = 1; i) {} }"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -722,6 +754,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(statement, code.indexOf(rawDeclarator), rawDeclarator.length());
 	}
 
+	@Test
 	public void testSwitchInitStatement_2() throws Exception {
 		String code = "void foo() { char c = 'a'; switch (; c) {} }"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -732,6 +765,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(statement, code.indexOf(rawDeclarator), rawDeclarator.length());
 	}
 
+	@Test
 	public void testIfInitStatement_1() throws Exception {
 		String code = "void foo() { if (int i = 1; i == 1) {} }"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -742,6 +776,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(statement, code.indexOf(rawDeclarator), rawDeclarator.length());
 	}
 
+	@Test
 	public void testIfInitStatement_2() throws Exception {
 		String code = "void foo() { if (; bool b = true) {} }"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -752,6 +787,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(statement, code.indexOf(rawDeclarator), rawDeclarator.length());
 	}
 
+	@Test
 	public void testConstexprIf_1() throws Exception {
 		String code = "void foo() { if constexpr (true) {} }"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -762,6 +798,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(statement, code.indexOf(rawDeclarator), rawDeclarator.length());
 	}
 
+	@Test
 	public void testConstexprIf_2() throws Exception {
 		String code = "void foo() { if constexpr (constexpr int i = 1; i == 1) {} }"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -772,6 +809,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertSoleLocation(statement, code.indexOf(rawDeclarator), rawDeclarator.length());
 	}
 
+	@Test
 	public void testConstexprIf_3() throws Exception {
 		String code = "void foo() { if constexpr (; constexpr bool b = true) {} }"; //$NON-NLS-1$
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -787,6 +825,7 @@ public class DOMLocationTests extends AST2TestBase {
 	//	int integer = one;
 	//	return integer;
 	// }
+	@Test
 	public void testRawSignature_Bug117029() throws Exception {
 		String content = getContents(1)[0].toString();
 		IASTTranslationUnit tu = parse(content, ParserLanguage.CPP);
@@ -796,6 +835,7 @@ public class DOMLocationTests extends AST2TestBase {
 		assertEquals("return integer;", compound.getStatements()[1].getRawSignature());
 	}
 
+	@Test
 	public void testTemplateIdNameLocation_Bug211444() throws Exception {
 		IASTTranslationUnit tu = parse("Foo::template test<T> bar;", ParserLanguage.CPP);
 		NameCollector col = new NameCollector();
@@ -822,6 +862,7 @@ public class DOMLocationTests extends AST2TestBase {
 	//   void func3() final override;
 	//   void func4() override final;
 	// };
+	@Test
 	public void testFunctionDeclaratorLocationContainsVirtualSpecifiers_Bug518628() throws Exception {
 		String testCode = getAboveComment();
 		BindingAssertionHelper assertionHelper = getAssertionHelper(ParserLanguage.CPP);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/DOMPreprocessorInformationTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/DOMPreprocessorInformationTest.java
@@ -15,6 +15,9 @@
  ******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.eclipse.cdt.core.dom.ast.IASTEqualsInitializer;
 import org.eclipse.cdt.core.dom.ast.IASTInitializerClause;
 import org.eclipse.cdt.core.dom.ast.IASTNodeLocation;
@@ -30,6 +33,7 @@ import org.eclipse.cdt.core.dom.ast.IASTPreprocessorStatement;
 import org.eclipse.cdt.core.dom.ast.IASTSimpleDeclaration;
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.parser.ParserLanguage;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Emanuel Graf
@@ -37,6 +41,7 @@ import org.eclipse.cdt.core.parser.ParserLanguage;
  */
 public class DOMPreprocessorInformationTest extends AST2TestBase {
 
+	@Test
 	public void testPragma() throws Exception {
 		String msg = "GCC poison printf sprintf fprintf";
 		StringBuilder buffer = new StringBuilder("#pragma " + msg + "\n"); //$NON-NLS-1$
@@ -48,6 +53,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 		assertEquals(msg, new String(pragma.getMessage()));
 	}
 
+	@Test
 	public void testElIf() throws Exception {
 		String cond = "2 == 2";
 		StringBuilder buffer = new StringBuilder("#if 1 == 2\n#elif " + cond + "\n#else\n#endif\n"); //$NON-NLS-1$
@@ -59,6 +65,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 		assertEquals(cond, new String(pragma.getCondition()));
 	}
 
+	@Test
 	public void testIf() throws Exception {
 		String cond = "2 == 2";
 		StringBuilder buffer = new StringBuilder("#if " + cond + "\n#endif\n"); //$NON-NLS-1$
@@ -70,6 +77,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 		assertEquals(cond, new String(pragma.getCondition()));
 	}
 
+	@Test
 	public void testIfDef() throws Exception {
 		String cond = "SYMBOL";
 		StringBuilder buffer = new StringBuilder("#ifdef " + cond + "\n#endif\n"); //$NON-NLS-1$
@@ -81,6 +89,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 		assertEquals(cond, new String(pragma.getCondition()));
 	}
 
+	@Test
 	public void testIfnDef() throws Exception {
 		String cond = "SYMBOL";
 		StringBuilder buffer = new StringBuilder("#ifndef " + cond + "\n#endif\n"); //$NON-NLS-1$
@@ -92,6 +101,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 		assertEquals(cond, new String(pragma.getCondition()));
 	}
 
+	@Test
 	public void testError() throws Exception {
 		String msg = "Message";
 		StringBuilder buffer = new StringBuilder("#error " + msg + "\n"); //$NON-NLS-1$
@@ -103,6 +113,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 		assertEquals(msg, new String(pragma.getMessage()));
 	}
 
+	@Test
 	public void testPragmaWithSpaces() throws Exception {
 		String msg = "GCC poison printf sprintf fprintf";
 		StringBuilder buffer = new StringBuilder("#  pragma  " + msg + " \n"); //$NON-NLS-1$
@@ -114,6 +125,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 		assertEquals(msg, new String(pragma.getMessage()));
 	}
 
+	@Test
 	public void testElIfWithSpaces() throws Exception {
 		String cond = "2 == 2";
 		StringBuilder buffer = new StringBuilder("#if 1 == 2\n#  elif  " + cond + " \n#else\n#endif\n"); //$NON-NLS-1$
@@ -125,6 +137,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 		assertEquals(cond, new String(pragma.getCondition()));
 	}
 
+	@Test
 	public void testIfWithSpaces() throws Exception {
 		String cond = "2 == 2";
 		StringBuilder buffer = new StringBuilder("#  if  " + cond + " \n#endif\n"); //$NON-NLS-1$
@@ -136,6 +149,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 		assertEquals(cond, new String(pragma.getCondition()));
 	}
 
+	@Test
 	public void testIfDefWithSpaces() throws Exception {
 		String cond = "SYMBOL";
 		StringBuilder buffer = new StringBuilder("#  ifdef  " + cond + " \n#endif\n"); //$NON-NLS-1$
@@ -147,6 +161,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 		assertEquals(cond, new String(pragma.getCondition()));
 	}
 
+	@Test
 	public void testIfnDefWithSpaces() throws Exception {
 		String cond = "SYMBOL";
 		StringBuilder buffer = new StringBuilder("#  ifndef  " + cond + "\t\n#endif\n"); //$NON-NLS-1$
@@ -158,6 +173,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 		assertEquals(cond, new String(pragma.getCondition()));
 	}
 
+	@Test
 	public void testErrorWithSpaces() throws Exception {
 		String msg = "Message";
 		StringBuilder buffer = new StringBuilder("#  error \t" + msg + " \n"); //$NON-NLS-1$
@@ -169,6 +185,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 		assertEquals(msg, new String(pragma.getMessage()));
 	}
 
+	@Test
 	public void testMacroExpansion() throws Exception {
 		StringBuilder sb = new StringBuilder();
 		sb.append("#define add(a, b) (a) + (b) \n");
@@ -191,6 +208,7 @@ public class DOMPreprocessorInformationTest extends AST2TestBase {
 	// #ifdef xxx
 	// #elif
 	// #endif
+	@Test
 	public void testElifWithoutCondition_bug185324() throws Exception {
 		CharSequence code = getContents(1)[0];
 		IASTTranslationUnit tu = parse(code.toString(), ParserLanguage.CPP, ScannerKind.STD, false);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/FaultToleranceTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/FaultToleranceTests.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.eclipse.cdt.core.dom.ast.IASTCompositeTypeSpecifier;
 import org.eclipse.cdt.core.dom.ast.IASTDeclarationStatement;
 import org.eclipse.cdt.core.dom.ast.IASTFunctionDefinition;
@@ -27,31 +29,19 @@ import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTLinkageSpecification;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTNamespaceDefinition;
 import org.eclipse.cdt.core.parser.ParserLanguage;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * Testcases related to recovery from invalid syntax.
  */
 public class FaultToleranceTests extends AST2TestBase {
 
-	public static TestSuite suite() {
-		return suite(FaultToleranceTests.class);
-	}
-
-	public FaultToleranceTests() {
-		super();
-	}
-
-	public FaultToleranceTests(String name) {
-		super(name);
-	}
-
 	// typedef int tint;
 	// struct X {
 	//    int a;
 	// }
 	// tint b;
+	@Test
 	public void testCompositeTypeWithoutSemi() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -67,6 +57,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	//    int a;
 	// } c
 	// tint b;
+	@Test
 	public void testCompositeTypeWithDtorWithoutSemi() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -82,6 +73,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	// typedef int tint;
 	// int a
 	// tint b;
+	@Test
 	public void testVariableWithoutSemi() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -96,6 +88,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	// typedef int tint;
 	// int a()
 	// tint b;
+	@Test
 	public void testPrototypeWithoutSemi() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -111,6 +104,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	//   int a= 1
 	// 	 f()
 	// }
+	@Test
 	public void testExpressionWithoutSemi_314593() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -127,6 +121,7 @@ public class FaultToleranceTests extends AST2TestBase {
 
 	// struct X {
 	//   int a;
+	@Test
 	public void testIncompleteCompositeType() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -140,6 +135,7 @@ public class FaultToleranceTests extends AST2TestBase {
 
 	// void func() {
 	//   int a;
+	@Test
 	public void testIncompleteFunctionDefinition() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -153,6 +149,7 @@ public class FaultToleranceTests extends AST2TestBase {
 
 	// namespace ns {
 	//   int a;
+	@Test
 	public void testIncompleteNamespace() throws Exception {
 		final String comment = getAboveComment();
 		IASTTranslationUnit tu = parse(comment, ParserLanguage.CPP, ScannerKind.STD, false);
@@ -164,6 +161,7 @@ public class FaultToleranceTests extends AST2TestBase {
 
 	// extern "C" {
 	//   int a;
+	@Test
 	public void testIncompleteLinkageSpec() throws Exception {
 		final String comment = getAboveComment();
 		IASTTranslationUnit tu = parse(comment, ParserLanguage.CPP, ScannerKind.STD, false);
@@ -176,6 +174,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	// void test() {
 	//    int a= offsetof(struct mystruct, singlechar);
 	// }
+	@Test
 	public void testRangeOfProblemNode_Bug238151() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -191,6 +190,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	//       return -1;
 	//    int v;
 	// }
+	@Test
 	public void testProblemInIfExpression_Bug100321() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -206,6 +206,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	// _MYMACRO_ myType foo();
 	// _MYMACRO_ myType foo() {}
 	// extern void foo2() _MYMACRO_;
+	@Test
 	public void testUndefinedMacrosInFunctionDeclarations_Bug234085() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -236,6 +237,7 @@ public class FaultToleranceTests extends AST2TestBase {
 
 	// enum _T { I J, K }; // missing comma
 	// int i;
+	@Test
 	public void testEnumProblem() throws Exception {
 		final String comment = getAboveComment();
 		for (ParserLanguage lang : ParserLanguage.values()) {
@@ -252,6 +254,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	//    enum _T { I J, K }; // missing comma
 	//    int i;
 	// };
+	@Test
 	public void testEnumError_Bug72685() throws Exception {
 		final String comment = getAboveComment();
 		IASTTranslationUnit tu = parse(comment, ParserLanguage.CPP, ScannerKind.STD, false);
@@ -268,6 +271,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	//	XX(
 	//	);
 	//	int d;
+	@Test
 	public void testErrorRecovery_273759() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), ParserLanguage.C, ScannerKind.STD, false);
 		IASTSimpleDeclaration s = getDeclaration(tu, 0);
@@ -311,6 +315,7 @@ public class FaultToleranceTests extends AST2TestBase {
 	//	    TINT* f28(TINT* p) {
 	//	    TINT* f29(TINT* p) {
 	//	    }
+	@Test
 	public void testPerformanceIssue_364108() throws Exception {
 		final String comment = getAboveComment();
 		parse(comment, ParserLanguage.CPP, ScannerKind.STD, false);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/GCCCompleteParseExtensionsTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/GCCCompleteParseExtensionsTest.java
@@ -14,6 +14,9 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.StringWriter;
 import java.io.Writer;
 
@@ -33,15 +36,9 @@ import org.eclipse.cdt.internal.core.dom.parser.c.CASTFunctionDefinition;
 import org.eclipse.cdt.internal.core.dom.parser.c.CFunction;
 import org.eclipse.cdt.internal.core.model.ASTStringUtil;
 import org.eclipse.cdt.internal.core.parser.ParserException;
+import org.junit.jupiter.api.Test;
 
 public class GCCCompleteParseExtensionsTest extends AST2TestBase {
-
-	public GCCCompleteParseExtensionsTest() {
-	}
-
-	public GCCCompleteParseExtensionsTest(String name) {
-		super(name);
-	}
 
 	private IASTTranslationUnit parseGCC(String code) throws ParserException {
 		IASTTranslationUnit tu = parse(code, ParserLanguage.C, ScannerKind.GNU, true);
@@ -67,10 +64,12 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 		return tu;
 	}
 
+	@Test
 	public void testBug39695() throws Exception {
 		parseGCC("int a = __alignof__ (int);").getDeclarations();
 	}
 
+	@Test
 	public void testBug39684() throws Exception {
 		IASTDeclaration bar = parseGCC("typeof(foo(1)) bar () { return foo(1); }").getDeclarations()[0];
 		assertTrue(bar instanceof CASTFunctionDefinition);
@@ -82,6 +81,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 		//		assertEquals(simpleTypeSpec.getType(), IASTGCCSimpleTypeSpecifier.Type.TYPEOF);
 	}
 
+	@Test
 	public void testBug39698A() throws Exception {
 		IASTDeclaration[] decls = parseGPP("int a=0; \n int b=1; \n int c = a <? b;").getDeclarations();
 		assertEquals(ASTStringUtil.getExpressionString(
@@ -90,6 +90,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 				"a <? b");
 	}
 
+	@Test
 	public void testBug39698B() throws Exception {
 		IASTDeclaration[] decls = parseGPP("int a=0; \n int b=1; \n int c = a >? b;").getDeclarations();
 		assertEquals(ASTStringUtil.getExpressionString(
@@ -98,11 +99,13 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 				"a >? b");
 	}
 
+	@Test
 	public void testPredefinedSymbol_bug69791() throws Exception {
 		parseGPP("typedef __builtin_va_list __gnuc_va_list; \n").getDeclarations();
 		parseGCC("typedef __builtin_va_list __gnuc_va_list; \n").getDeclarations();
 	}
 
+	@Test
 	public void testBug39697() throws Exception {
 		Writer writer = new StringWriter();
 		writer.write("__asm__( \"CODE\" );\n");
@@ -137,6 +140,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 				.isRestrict());
 	}
 
+	@Test
 	public void testBug73954A() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("void f(){							\n");
@@ -177,6 +181,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 		parseGCC(writer.toString());
 	}
 
+	@Test
 	public void testBug39686() throws Exception {
 		Writer code = new StringWriter();
 		code.write("__complex__ double x; // complex double\n");
@@ -188,6 +193,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 		parseGCC(code.toString());
 	}
 
+	@Test
 	public void testBug39551B() throws Exception {
 		//this used to be 99.99 * __I__, but I don't know where the __I__ came from, its not in C99, nor in GCC
 		IASTDeclaration decl = parseGCC("_Imaginary double id = 99.99 * 1i;").getDeclarations()[0];
@@ -196,6 +202,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 		//		assertTrue(((IASTSimpleTypeSpecifier)variable.getAbstractDeclaration().getTypeSpecifier()).isImaginary());
 	}
 
+	@Test
 	public void testBug39681() throws Exception {
 		Writer code = new StringWriter();
 		code.write("double\n");
@@ -207,6 +214,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 		parseGCC(code.toString());
 	}
 
+	@Test
 	public void testBug39677() throws Exception {
 		parseGPP("class B { public: B(); int a;}; B::B() : a(({ 1; })) {}");
 		Writer writer = new StringWriter();
@@ -236,6 +244,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 		parseGPP(writer.toString()); // TODO Devin raised bug 93980
 	}
 
+	@Test
 	public void testBug75401() throws Exception {
 		Writer writer = new StringWriter();
 		writer.write("#define va_list  __builtin_va_list            \n");
@@ -253,6 +262,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 		parseGPP(writer.toString());
 	}
 
+	@Test
 	public void testBug73954B() throws Exception {
 		Writer writer = new StringWriter();
 		writer.write("#define foo(x)                                            \\\n");
@@ -267,10 +277,12 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 		parseGCC(writer.toString());
 	}
 
+	@Test
 	public void testGNUExternalTemplate_bug71603() throws Exception {
 		parseGPP("template <typename T> \n class A {}; \n extern template class A<int>; \n").getDeclarations();
 	}
 
+	@Test
 	public void testBug74190_g_assert_1() throws Exception {
 		Writer writer = new StringWriter();
 		writer.write("void log( int );               \n");
@@ -285,6 +297,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 		parseGPP(writer.toString());
 	}
 
+	@Test
 	public void testBug74190_g_return_if_fail() throws Exception {
 		Writer writer = new StringWriter();
 		writer.write("void f() {                     \n");
@@ -297,6 +310,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 		parseGPP(writer.toString());
 	}
 
+	@Test
 	public void testBug95635() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("void f(){                         \n");
@@ -386,6 +400,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 	// void test() {
 	//    int a= __builtin_offsetof(struct S, m);
 	// };
+	@Test
 	public void test__builtinOffsetof_Bug265001() throws Exception {
 		// gcc with __GNUC__ >= 4 defines:
 		// #define offsetof(type, field) __builtin_offsetof(type, field)
@@ -399,6 +414,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 	// void test() {
 	//    int a= __offsetof__(1);
 	// };
+	@Test
 	public void test__offsetof__Bug265001() throws Exception {
 		// gcc with __GNUC__ < 4 defines:
 		//		#define offsetof(type, field)					\
@@ -427,12 +443,14 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 	//		b= __is_polymorphic (int);
 	//		b= __is_union (int);
 	//	}
+	@Test
 	public void testTypeTraits_Bug342683() throws Exception {
 		parseGPP(getAboveComment());
 	}
 
 	// __int128 a;
 	// unsigned __int128 b;
+	@Test
 	public void test__int128() throws Exception {
 		String code = getAboveComment();
 		parseGCC(code);
@@ -440,6 +458,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 	}
 
 	// __float128 f;
+	@Test
 	public void test__float128() throws Exception {
 		String code = getAboveComment();
 		parseGCC(code);
@@ -447,6 +466,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 	}
 
 	// _Decimal32 x;
+	@Test
 	public void test_Decimal32() throws Exception {
 		String code = getAboveComment();
 		parseGCC(code);
@@ -454,6 +474,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 	}
 
 	// _Decimal64 x;
+	@Test
 	public void test_Decimal64() throws Exception {
 		String code = getAboveComment();
 		parseGCC(code);
@@ -461,6 +482,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 	}
 
 	// _Decimal128 x;
+	@Test
 	public void test_Decimal128() throws Exception {
 		String code = getAboveComment();
 		parseGCC(code);
@@ -469,6 +491,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 
 	//	struct waldo {
 	//	} __attribute__((__aligned__((1))));
+	@Test
 	public void test__attribute__aligned_bug400204() throws Exception {
 		String code = getAboveComment();
 		parseGCC(code);
@@ -478,6 +501,7 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 	// void test() {
 	//   !__builtin_add_overflow_p(1,2,3);
 	// }
+	@Test
 	public void testIntegerOverflowBuiltin_bug271() throws Exception {
 		String code = getAboveComment();
 		parseGCC(code);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/GCCTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/GCCTests.java
@@ -17,6 +17,8 @@
  */
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.dom.ast.ICompositeType;
 import org.eclipse.cdt.core.dom.ast.IEnumeration;
@@ -28,19 +30,14 @@ import org.eclipse.cdt.core.dom.ast.IParameter;
 import org.eclipse.cdt.core.dom.ast.ITypedef;
 import org.eclipse.cdt.core.dom.ast.IVariable;
 import org.eclipse.cdt.core.parser.ParserLanguage;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author aniefer
  */
 public class GCCTests extends AST2TestBase {
 
-	public GCCTests() {
-	}
-
-	public GCCTests(String name) {
-		super(name);
-	}
-
+	@Test
 	public void testGCC20000113() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("struct x {                           \n");
@@ -87,6 +84,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, c, 4);
 	}
 
+	@Test
 	public void testGCC20000205() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("static int f(int a) {             \n");
@@ -112,6 +110,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, a, 3);
 	}
 
+	@Test
 	public void testGCC20000217() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("unsigned short int showbug(unsigned short int * a,    \n");
@@ -146,6 +145,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, y, 2);
 	}
 
+	@Test
 	public void testGCC20000224() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int loop_1 = 100;                         \n");
@@ -183,6 +183,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, counter, 3);
 	}
 
+	@Test
 	public void testGCC20000225() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int main() {                        \n");
@@ -213,6 +214,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, i, 4);
 	}
 
+	@Test
 	public void testGCC20000227() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("static const unsigned char f[] = \"\\0\\377\";        \n");
@@ -239,6 +241,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, g, 5);
 	}
 
+	@Test
 	public void testGCC20000313() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("unsigned int buggy(unsigned int *param) {             \n");
@@ -279,6 +282,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, borrow2, 2);
 	}
 
+	@Test
 	public void testGCC20000314_1() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int main() {                                       \n");
@@ -302,6 +306,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, winds, 6);
 	}
 
+	@Test
 	public void testGCC20000314_2() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("typedef unsigned long long uint64;                \n");
@@ -336,6 +341,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, f, 2);
 	}
 
+	@Test
 	public void testGCC20000403() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("extern unsigned long aa[], bb[];                                   \n");
@@ -384,6 +390,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, b2, 3);
 	}
 
+	@Test
 	public void testGCC20000412_1() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("short int i = -1;                                               \n");
@@ -414,6 +421,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, wordptr, 2);
 	}
 
+	@Test
 	public void testGCC20000412_2() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(int a, int *y) {                   \n");
@@ -443,6 +451,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, x, 2);
 	}
 
+	@Test
 	public void testGCC20000412_3() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("typedef struct {                         \n");
@@ -491,6 +500,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, py, 3);
 	}
 
+	@Test
 	public void testGCC20000412_4() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("void f(int i, int j, int radius, int width, int N) { \n");
@@ -546,6 +556,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, i2, 5);
 	}
 
+	@Test
 	public void testGCC20000412_5() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int main(void) {                                        \n");
@@ -572,6 +583,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, lastglob, 3);
 	}
 
+	@Test
 	public void testGCC20000419() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("struct foo { int a, b, c; };                          \n");
@@ -621,6 +633,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, f, 2);
 	}
 
+	@Test
 	public void testGCC20000503() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("unsigned long sub(int a) {                          \n");
@@ -642,6 +655,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, a, 3);
 	}
 
+	@Test
 	public void testGCC20000511() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("int f(int value, int expect) {                      \n");
@@ -696,6 +710,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, e, 15);
 	}
 
+	@Test
 	public void testGCC20000603() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("struct s1 { double d; };                                \n");
@@ -736,6 +751,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, a, 4);
 	}
 
+	@Test
 	public void testGCC20000605_2() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("struct F { int i; };                                    \n");
@@ -775,6 +791,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, y, 3);
 	}
 
+	@Test
 	public void testGCC20000605_3() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("struct F { int x; int y; };                             \n");
@@ -812,6 +829,7 @@ public class GCCTests extends AST2TestBase {
 		assertInstances(collector, die, 2);
 	}
 
+	@Test
 	public void testGCCenum_2() throws Exception {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("enum foo { FOO, BAR };                                  \n");

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/ImageLocationTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/ImageLocationTests.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.eclipse.cdt.core.dom.ast.ASTVisitor;
 import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
 import org.eclipse.cdt.core.dom.ast.IASTImageLocation;
@@ -20,8 +23,7 @@ import org.eclipse.cdt.core.dom.ast.IASTName;
 import org.eclipse.cdt.core.dom.ast.IASTNode;
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.parser.ParserLanguage;
-
-import junit.framework.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jcamelon
@@ -32,18 +34,8 @@ public class ImageLocationTests extends AST2TestBase {
 	private static final int MACRO = IASTImageLocation.MACRO_DEFINITION;
 	private static final int MACRO_ARG = IASTImageLocation.ARGUMENT_TO_MACRO_EXPANSION;
 
-	public static Test suite() {
-		return suite(ImageLocationTests.class);
-	}
-
-	public ImageLocationTests() {
-	}
-
-	public ImageLocationTests(String name) {
-		setName(name);
-	}
-
 	// int a;
+	@Test
 	public void testFileLocation() throws Exception {
 		String code = getContents(1)[0].toString();
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -58,6 +50,7 @@ public class ImageLocationTests extends AST2TestBase {
 	// #define F() result2
 	// int M;
 	// int F();
+	@Test
 	public void testMacroLocation() throws Exception {
 		String code = getContents(1)[0].toString();
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -76,6 +69,7 @@ public class ImageLocationTests extends AST2TestBase {
 	// #define M result
 	// #define F() M
 	// int F();
+	@Test
 	public void testIndirectMacroLocation() throws Exception {
 		String code = getContents(1)[0].toString();
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);
@@ -90,6 +84,7 @@ public class ImageLocationTests extends AST2TestBase {
 	// #define F(x) x
 	// int F(result2);
 	// int F(M);
+	@Test
 	public void testMacroArgumentLocation() throws Exception {
 		String code = getContents(1)[0].toString();
 		IASTTranslationUnit tu = parse(code, ParserLanguage.CPP);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/LanguageExtensionsTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/LanguageExtensionsTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import org.eclipse.cdt.core.dom.ast.IASTDeclaration;
 import org.eclipse.cdt.core.dom.ast.IASTExpressionList;
 import org.eclipse.cdt.core.dom.ast.IASTFunctionDeclarator;
@@ -41,8 +44,7 @@ import org.eclipse.cdt.internal.core.dom.parser.c.GNUCSourceParser;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.GNUCPPSourceParser;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.CPPVisitor;
 import org.eclipse.cdt.internal.core.parser.scanner.CPreprocessor;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * Testcases for non-gnu language extensions.
@@ -52,18 +54,6 @@ public class LanguageExtensionsTest extends AST2TestBase {
 	protected static final int SIZEOF_EXTENSION = 0x1;
 	protected static final int FUNCTION_STYLE_ASM = 0x2;
 	protected static final int SLASH_PERCENT_COMMENT = 0x4;
-
-	public static TestSuite suite() {
-		return suite(LanguageExtensionsTest.class);
-	}
-
-	public LanguageExtensionsTest() {
-		super();
-	}
-
-	public LanguageExtensionsTest(String name) {
-		super(name);
-	}
 
 	private IASTTranslationUnit parse(ISourceCodeParser parser) {
 		IASTTranslationUnit tu = parser.parse();
@@ -131,6 +121,7 @@ public class LanguageExtensionsTest extends AST2TestBase {
 
 	// parclass ExampleClass {
 	// };
+	@Test
 	public void testPOP_parclass() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), POPCPPScannerExtensionConfiguration.getInstance(),
 				POPCPPParserExtensionConfiguration.getInstance());
@@ -140,6 +131,7 @@ public class LanguageExtensionsTest extends AST2TestBase {
 	// parclass Table {
 	//    void sort([in, out, size=n] int *data, int n);
 	// };
+	@Test
 	public void testPOP_marshallingData() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), POPCPPScannerExtensionConfiguration.getInstance(),
 				POPCPPParserExtensionConfiguration.getInstance());
@@ -154,6 +146,7 @@ public class LanguageExtensionsTest extends AST2TestBase {
 	//    		od.memory(100,60);
 	//    		od.protocol("socket http"); };
 	//    };
+	@Test
 	public void testPOP_objectDescriptor() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), POPCPPScannerExtensionConfiguration.getInstance(),
 				POPCPPParserExtensionConfiguration.getInstance());
@@ -164,6 +157,7 @@ public class LanguageExtensionsTest extends AST2TestBase {
 
 	// @pack(Stack, Queue, List)
 	// int a();
+	@Test
 	public void testPOP_packDirective() throws Exception {
 		IASTTranslationUnit tu = parse(getAboveComment(), POPCPPScannerExtensionConfiguration.getInstance(),
 				POPCPPParserExtensionConfiguration.getInstance());
@@ -175,6 +169,7 @@ public class LanguageExtensionsTest extends AST2TestBase {
 	// sizeof(int, 1);
 	// sizeof(int, 2, 2);
 	// }
+	@Test
 	public void testSizeofExtension() throws Exception {
 		IASTTranslationUnit tu = parseCWithExtension(getAboveComment(), SIZEOF_EXTENSION);
 		IASTFunctionDefinition fdef = getDeclaration(tu, 0);
@@ -207,6 +202,7 @@ public class LanguageExtensionsTest extends AST2TestBase {
 	//  asm a4() {
 	//     assembler code here
 	//  }
+	@Test
 	public void testFunctionStyleAssembler() throws Exception {
 		IASTTranslationUnit tu = parseCWithExtension(getAboveComment(), FUNCTION_STYLE_ASM);
 		IASTFunctionDefinition fdef = getDeclaration(tu, 0);
@@ -223,6 +219,7 @@ public class LanguageExtensionsTest extends AST2TestBase {
 
 	// /% a comment %/
 	// int a;
+	@Test
 	public void testSlashPercentComment() throws Exception {
 		IASTTranslationUnit tu = parseCWithExtension(getAboveComment(), SLASH_PERCENT_COMMENT);
 

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/SemanticTestBase.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/SemanticTestBase.java
@@ -10,6 +10,13 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.lang.reflect.Field;
 
 import org.eclipse.cdt.core.dom.ast.ASTTypeUtil;
@@ -26,7 +33,7 @@ import org.eclipse.cdt.core.dom.ast.IProblemBinding;
 import org.eclipse.cdt.core.dom.ast.IProblemType;
 import org.eclipse.cdt.core.dom.ast.IType;
 import org.eclipse.cdt.core.dom.ast.IVariable;
-import org.eclipse.cdt.core.testplugin.util.BaseTestCase;
+import org.eclipse.cdt.core.testplugin.util.BaseTestCase5;
 import org.eclipse.cdt.internal.core.dom.parser.ASTNode;
 import org.eclipse.cdt.internal.core.dom.parser.SizeofCalculator;
 import org.eclipse.cdt.internal.core.dom.parser.SizeofCalculator.SizeAndAlignment;
@@ -35,20 +42,13 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.CPPSemantics;
 /**
  * Common base class for AST2 and index tests.
  */
-public abstract class SemanticTestBase extends BaseTestCase {
-	public SemanticTestBase() {
-		super();
-	}
-
-	public SemanticTestBase(String name) {
-		super(name);
-	}
+public abstract class SemanticTestBase extends BaseTestCase5 {
 
 	protected static void assertSameType(IType expected, IType actual) {
 		assertNotNull(expected);
 		assertNotNull(actual);
-		assertTrue("Expected same types, but the types were: '" + ASTTypeUtil.getType(expected, false) + "' and '"
-				+ ASTTypeUtil.getType(actual, false) + "'", expected.isSameType(actual));
+		assertTrue(expected.isSameType(actual), "Expected same types, but the types were: '"
+				+ ASTTypeUtil.getType(expected, false) + "' and '" + ASTTypeUtil.getType(actual, false) + "'");
 	}
 
 	protected static void assertType(IVariable variable, IType expectedType) {
@@ -81,7 +81,7 @@ public abstract class SemanticTestBase extends BaseTestCase {
 			if (len <= 0)
 				len = section.length() + len;
 			IBinding binding = binding(section, len);
-			assertTrue("Non-ProblemBinding for name: " + section.substring(0, len), binding instanceof IProblemBinding);
+			assertTrue(binding instanceof IProblemBinding, "Non-ProblemBinding for name: " + section.substring(0, len));
 			return (IProblemBinding) binding;
 		}
 
@@ -93,7 +93,7 @@ public abstract class SemanticTestBase extends BaseTestCase {
 
 		public IProblemBinding assertProblem(String context, String name) {
 			IBinding binding = binding(context, name);
-			assertTrue("Non-ProblemBinding for name: " + name, binding instanceof IProblemBinding);
+			assertTrue(binding instanceof IProblemBinding, "Non-ProblemBinding for name: " + name);
 			return (IProblemBinding) binding;
 		}
 
@@ -167,7 +167,7 @@ public abstract class SemanticTestBase extends BaseTestCase {
 		public IASTImplicitName assertImplicitName(String section, int len, Class<?> bindingClass) {
 			IASTName name = findImplicitName(section, len);
 			final String selection = section.substring(0, len);
-			assertNotNull("Did not find \"" + selection + "\"", name);
+			assertNotNull(name, "Did not find \"" + selection + "\"");
 
 			assertInstance(name, IASTImplicitName.class);
 			IASTImplicitNameOwner owner = (IASTImplicitNameOwner) name.getParent();
@@ -195,7 +195,7 @@ public abstract class SemanticTestBase extends BaseTestCase {
 		public void assertNoImplicitName(String section, int len) {
 			IASTName name = findImplicitName(section, len);
 			final String selection = section.substring(0, len);
-			assertNull("found name \"" + selection + "\"", name);
+			assertNull(name, "found name \"" + selection + "\"");
 		}
 
 		public IASTImplicitName[] getImplicitNames(String section) {
@@ -225,7 +225,7 @@ public abstract class SemanticTestBase extends BaseTestCase {
 
 		public IASTName findName(String section, int len) {
 			final int offset = contents.indexOf(section);
-			assertTrue("Section \"" + section + "\" not found", offset >= 0);
+			assertTrue(offset >= 0, "Section \"" + section + "\" not found");
 			IASTNodeSelector selector = tu.getNodeSelector(null);
 			return selector.findName(offset, len);
 		}
@@ -235,9 +235,9 @@ public abstract class SemanticTestBase extends BaseTestCase {
 				context = contents;
 			}
 			int offset = contents.indexOf(context);
-			assertTrue("Context \"" + context + "\" not found", offset >= 0);
+			assertTrue(offset >= 0, "Context \"" + context + "\" not found");
 			int nameOffset = context.indexOf(name);
-			assertTrue("Name \"" + name + "\" not found", nameOffset >= 0);
+			assertTrue(nameOffset >= 0, "Name \"" + name + "\" not found");
 			IASTNodeSelector selector = tu.getNodeSelector(null);
 			return selector.findName(offset + nameOffset, name.length());
 		}
@@ -258,9 +258,9 @@ public abstract class SemanticTestBase extends BaseTestCase {
 				context = contents;
 			}
 			int offset = contents.indexOf(context);
-			assertTrue("Context \"" + context + "\" not found", offset >= 0);
+			assertTrue(offset >= 0, "Context \"" + context + "\" not found");
 			int nodeOffset = context.indexOf(nodeText);
-			assertTrue("Node \"" + nodeText + "\" not found", nodeOffset >= 0);
+			assertTrue(nodeOffset >= 0, "Node \"" + nodeText + "\" not found");
 			IASTNodeSelector selector = tu.getNodeSelector(null);
 			IASTNode node = selector.findNode(offset + nodeOffset, nodeText.length());
 			return assertType(node, cs);
@@ -292,7 +292,7 @@ public abstract class SemanticTestBase extends BaseTestCase {
 			if (len <= 0)
 				len += section.length();
 			IBinding binding = binding(section, len);
-			assertTrue("ProblemBinding for name: " + section.substring(0, len), !(binding instanceof IProblemBinding));
+			assertTrue(!(binding instanceof IProblemBinding), "ProblemBinding for name: " + section.substring(0, len));
 			return assertType(binding, cs);
 		}
 
@@ -302,7 +302,7 @@ public abstract class SemanticTestBase extends BaseTestCase {
 
 		public <T extends IBinding> T assertNonProblem(String context, String name, Class... cs) {
 			IBinding binding = binding(context, name);
-			assertTrue("ProblemBinding for name: " + name, !(binding instanceof IProblemBinding));
+			assertTrue(!(binding instanceof IProblemBinding), "ProblemBinding for name: " + name);
 			return assertType(binding, cs);
 		}
 
@@ -318,7 +318,7 @@ public abstract class SemanticTestBase extends BaseTestCase {
 
 		public void assertVariableValue(String variableName, long expectedValue) {
 			IVariable var = assertNonProblem(variableName);
-			BaseTestCase.assertVariableValue(var, expectedValue);
+			BaseTestCase5.assertVariableValue(var, expectedValue);
 		}
 
 		public <T, U extends T> U assertType(T obj, Class... cs) {
@@ -331,22 +331,22 @@ public abstract class SemanticTestBase extends BaseTestCase {
 		private IBinding binding(String section, int len) {
 			IASTName astName = findName(section, len);
 			final String selection = section.substring(0, len);
-			assertNotNull("No AST name for \"" + selection + "\"", astName);
+			assertNotNull(astName, "No AST name for \"" + selection + "\"");
 			assertEquals(selection, astName.getRawSignature());
 
 			IBinding binding = astName.resolveBinding();
-			assertNotNull("No binding for " + astName.getRawSignature(), binding);
+			assertNotNull(binding, "No binding for " + astName.getRawSignature());
 
 			return astName.resolveBinding();
 		}
 
 		private IBinding binding(String context, String name) {
 			IASTName astName = findName(context, name);
-			assertNotNull("No AST name for \"" + name + "\"", astName);
+			assertNotNull(astName, "No AST name for \"" + name + "\"");
 			assertEquals(name, astName.getRawSignature());
 
 			IBinding binding = astName.resolveBinding();
-			assertNotNull("No binding for " + astName.getRawSignature(), binding);
+			assertNotNull(binding, "No binding for " + astName.getRawSignature());
 
 			return astName.resolveBinding();
 		}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/SemanticsTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/SemanticsTests.java
@@ -13,24 +13,20 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPClassType;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPMethod;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.SemanticUtil;
+import org.junit.jupiter.api.Test;
 
 /**
  * Directly tests parts of the semantics package
  */
 public class SemanticsTests extends AST2TestBase {
-
-	public SemanticsTests() {
-	}
-
-	public SemanticsTests(String name) {
-		super(name);
-	}
 
 	//	class A {};
 	//	class B {};
@@ -92,6 +88,7 @@ public class SemanticsTests extends AST2TestBase {
 	//      operator A(); // conversion
 	//      operator B(); // conversion
 	//	};
+	@Test
 	public void testConversionOperators() throws Exception {
 		// Test getDeclaredConversionOperators()
 		BindingAssertionHelper ba = new AST2AssertionHelper(getAboveComment(), true);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/TaskParserTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/TaskParserTest.java
@@ -14,19 +14,17 @@
 
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.internal.core.pdom.indexer.TodoTaskParser;
 import org.eclipse.cdt.internal.core.pdom.indexer.TodoTaskParser.Task;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class TaskParserTest extends AST2TestBase {
 
-	public static TestSuite suite() {
-		return suite(TaskParserTest.class);
-	}
-
+	@Test
 	public void testTaskParser() throws Exception {
 		final char[][] taskTags = new char[][] { "TODO".toCharArray(), "TODO(my name):".toCharArray(),
 				"FIXME".toCharArray() };

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/TypeTraitsTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/TypeTraitsTests.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 
 import org.eclipse.cdt.core.dom.ast.IType;
@@ -22,8 +25,7 @@ import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.core.parser.ScannerInfo;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.TypeTraits;
 import org.eclipse.cdt.internal.core.parser.ParserException;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for ClassTypeHelper class.
@@ -31,22 +33,6 @@ import junit.framework.TestSuite;
 public class TypeTraitsTests extends AST2TestBase {
 
 	private boolean fUseClang = false;
-
-	public TypeTraitsTests() {
-	}
-
-	public TypeTraitsTests(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void tearDown() throws Exception {
-		fUseClang = false;
-	}
-
-	public static TestSuite suite() {
-		return suite(TypeTraitsTests.class);
-	}
 
 	protected BindingAssertionHelper getAssertionHelper() throws ParserException, IOException {
 		String code = getAboveComment();
@@ -79,6 +65,7 @@ public class TypeTraitsTests extends AST2TestBase {
 	//	public:
 	//	  A a;
 	//	};
+	@Test
 	public void testHasTrivialCopyCtor() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPClassType classA = helper.assertNonProblemOnFirstIdentifier("A {");
@@ -107,6 +94,7 @@ public class TypeTraitsTests extends AST2TestBase {
 	//	public:
 	//	  A a;
 	//	};
+	@Test
 	public void testHasTrivialDestructor() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPClassType classA = helper.assertNonProblemOnFirstIdentifier("A {");
@@ -148,6 +136,7 @@ public class TypeTraitsTests extends AST2TestBase {
 	//	typedef A* I;
 	//
 	//	typedef A J[0];
+	@Test
 	public void testIsEmpty() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPClassType classA = helper.assertNonProblemOnFirstIdentifier("A {");
@@ -188,6 +177,7 @@ public class TypeTraitsTests extends AST2TestBase {
 	//
 	//	class C : public A {
 	//	};
+	@Test
 	public void testIsPolymorphic() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPClassType classA = helper.assertNonProblemOnFirstIdentifier("A {");
@@ -235,6 +225,7 @@ public class TypeTraitsTests extends AST2TestBase {
 	//	struct H {
 	//	  int& a;
 	//	};
+	@Test
 	public void testIsStandardLayout() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPClassType classA = helper.assertNonProblemOnFirstIdentifier("A {");
@@ -293,6 +284,7 @@ public class TypeTraitsTests extends AST2TestBase {
 	//	struct I {
 	//	  virtual void m();
 	//	};
+	@Test
 	public void testIsTrivial() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPClassType classA = helper.assertNonProblemOnFirstIdentifier("A {");
@@ -329,6 +321,7 @@ public class TypeTraitsTests extends AST2TestBase {
 	//		G();
 	//		G(const G&);
 	//	} g;
+	@Test
 	public void testIsTriviallyCopyable() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IVariable a = helper.assertNonProblemOnFirstIdentifier("a;");
@@ -383,6 +376,7 @@ public class TypeTraitsTests extends AST2TestBase {
 	//	    Test<__is_function(Foo)>::false_var;
 	//	    return 0;
 	//	}
+	@Test
 	public void testIsFunction() throws Exception {
 		fUseClang = true;
 		parseAndCheckBindings(getAboveComment(), ParserLanguage.CPP);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/VariableReadWriteFlagsTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/VariableReadWriteFlagsTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.io.IOException;
 import java.util.Optional;
 
@@ -22,8 +25,7 @@ import org.eclipse.cdt.internal.core.dom.parser.c.CVariableReadWriteFlags;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.CPPVariableReadWriteFlags;
 import org.eclipse.cdt.internal.core.parser.ParserException;
 import org.eclipse.cdt.internal.core.pdom.dom.PDOMName;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for CPPVariableReadWriteFlags and CVariableReadWriteFlags classes.
@@ -79,17 +81,6 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 		}
 	}
 
-	public VariableReadWriteFlagsTest() {
-	}
-
-	public VariableReadWriteFlagsTest(String name) {
-		super(name);
-	}
-
-	public static TestSuite suite() {
-		return suite(VariableReadWriteFlagsTest.class);
-	}
-
 	protected AssertionHelper getCAssertionHelper() throws ParserException, IOException {
 		String code = getAboveComment();
 		return new AssertionHelper(code, false);
@@ -110,6 +101,7 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 	//	  a *= 3;
 	//	  return a + 1;
 	//	}
+	@Test
 	public void testSimpleAccess() throws Exception {
 		AssertionHelper a = getCPPAssertionHelper();
 		a.assertReadWriteFlags("a = 2", "a", WRITE);
@@ -120,6 +112,7 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 	//	auto test(int a) {
 	//	  return a <=> 1;
 	//	}
+	@Test
 	public void testThreeWayComparisonAccess() throws Exception {
 		AssertionHelper a = getCPP20AssertionHelper();
 		a.assertReadWriteFlags("a <=> 1", "a", READ);
@@ -143,6 +136,7 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 	//	template<typename T> void foo(T p) {
 	//	  T f;
 	//	}
+	@Test
 	public void testVariableDeclaration() throws Exception {
 		AssertionHelper a = getCPPAssertionHelper();
 		a.assertReadWriteFlags("int a", "a", 0);
@@ -160,6 +154,7 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 	//	  (&a)->x = 1;
 	//	  ap->x = 1;
 	//	};
+	@Test
 	public void testFieldAccess() throws Exception {
 		AssertionHelper a = getCPPAssertionHelper();
 		a.assertReadWriteFlags("a.x", "a", WRITE);
@@ -177,6 +172,7 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 	//	  f(&a, b);
 	//	  g(&a, b, c);
 	//	};
+	@Test
 	public void testFunctionCall() throws Exception {
 		AssertionHelper a = getCPPAssertionHelper();
 		a.assertReadWriteFlags("f(&a, b)", "a");
@@ -200,6 +196,7 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 	//	  A* y = new A(&a, b, c);
 	//	  A z(&a, b, c);
 	//	};
+	@Test
 	public void testConstructorCall_393068() throws Exception {
 		AssertionHelper a = getCPPAssertionHelper();
 		a.assertReadWriteFlags("= A(&a, b)", "a");
@@ -233,6 +230,7 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 	//	  ap->m();
 	//	  (*ap).m();
 	//	};
+	@Test
 	public void testMethodCall() throws Exception {
 		AssertionHelper a = getCPPAssertionHelper();
 		a.assertReadWriteFlags("a.m()", "a", READ | WRITE);
@@ -250,6 +248,7 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 	//		variadic(waldo);
 	//		variadic(&waldo);
 	//	}
+	@Test
 	public void testVariadicFunctionCall_452416() throws Exception {
 		AssertionHelper a = getCPPAssertionHelper();
 		a.assertReadWriteFlags("variadic(waldo)", "waldo", READ);
@@ -264,6 +263,7 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 	//		a = arr[0];
 	//		return arr[0];
 	//	}
+	@Test
 	public void testArraySubscript() throws Exception {
 		AssertionHelper a = getCPPAssertionHelper();
 		a.assertReadWriteFlags("arr[0];", "arr", READ);
@@ -279,6 +279,7 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 	//         decltype(v) o = 14;
 	//     }
 	//  };
+	@Test
 	public void testDeclType() throws Exception {
 		AssertionHelper a = getCPPAssertionHelper();
 		a.assertReadWriteFlags("decltype(v) o = 14;", "v", READ);
@@ -295,6 +296,7 @@ public class VariableReadWriteFlagsTest extends AST2TestBase {
 	//  	  g(s, field);
 	//	}
 	//};
+	@Test
 	public void testDependentType() throws Exception {
 		AssertionHelper a = getCPPAssertionHelper();
 		a.assertReadWriteFlags("g(s, field);", "field");

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/GenericLambdaIndexTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/GenericLambdaIndexTests.java
@@ -10,9 +10,12 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import org.eclipse.cdt.core.dom.ast.IFunction;
 import org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes;
 import org.eclipse.cdt.internal.index.tests.IndexBindingResolutionTestBase;
+import org.junit.jupiter.api.Test;
 
 /**
  * Index tests for C++14 generic lambdas.
@@ -26,6 +29,7 @@ public class GenericLambdaIndexTests extends IndexBindingResolutionTestBase {
 
 	//	auto three = Identity(3);
 	//	auto hello = Identity("hello");
+	@Test
 	public void testBasicCall() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("three", CommonCPPTypes.int_);
@@ -47,6 +51,7 @@ public class GenericLambdaIndexTests extends IndexBindingResolutionTestBase {
 	//		g(Identity);   // error: ambiguous
 	//		h(Identity);   // ok: calls #1
 	//	}
+	@Test
 	public void testConversionToFunctionPointer() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertNonProblem("f1(Id", "f1");
@@ -76,6 +81,7 @@ public class GenericLambdaIndexTests extends IndexBindingResolutionTestBase {
 	//	    waldo(foo(L(42, 'x')));
 	//	    waldo(bar(L(42, 'x', 42.0f)));
 	//	}
+	@Test
 	public void testVariadicAutoParameter() throws Exception {
 		checkBindings();
 	}
@@ -105,6 +111,7 @@ public class GenericLambdaIndexTests extends IndexBindingResolutionTestBase {
 	//	int main() {
 	//		waldo(q());
 	//	}
+	@Test
 	public void testNestedGenericLambdas() throws Exception {
 		checkBindings();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/GenericLambdaTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/GenericLambdaTests.java
@@ -10,9 +10,12 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import org.eclipse.cdt.core.dom.ast.IFunction;
 import org.eclipse.cdt.core.parser.tests.ast2.AST2CPPTestBase;
 import org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes;
+import org.junit.jupiter.api.Test;
 
 /**
  * AST tests for C++14 generic lambdas.
@@ -21,6 +24,7 @@ public class GenericLambdaTests extends AST2CPPTestBase {
 	//	auto Identity = [](auto a){ return a; };
 	//	auto three = Identity(3);
 	//	auto hello = Identity("hello");
+	@Test
 	public void testBasicCall() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("three", CommonCPPTypes.int_);
@@ -43,6 +47,7 @@ public class GenericLambdaTests extends AST2CPPTestBase {
 	//		h(Identity);   // ok: calls #1
 	//		j([](auto* a) -> auto& { return *a; });  // ok
 	//	}
+	@Test
 	public void testConversionToFunctionPointer() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertNonProblem("f1(Id", "f1");
@@ -73,6 +78,7 @@ public class GenericLambdaTests extends AST2CPPTestBase {
 	//	    waldo(foo(L(42, 'x')));
 	//	    waldo(bar(L(42, 'x', 42.0f)));
 	//	}
+	@Test
 	public void testVariadicAutoParameter() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -101,6 +107,7 @@ public class GenericLambdaTests extends AST2CPPTestBase {
 	//	int main() {
 	//		waldo(q());
 	//	}
+	@Test
 	public void testNestedGenericLambdas() throws Exception {
 		parseAndCheckBindings();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/InitCaptureTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/InitCaptureTests.java
@@ -16,6 +16,7 @@ package org.eclipse.cdt.core.parser.tests.ast2.cxx14;
 
 import org.eclipse.cdt.core.parser.tests.ast2.AST2CPPTestBase;
 import org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes;
+import org.junit.jupiter.api.Test;
 
 /**
  * AST tests for C++14 lambda init captures.
@@ -25,6 +26,7 @@ public class InitCaptureTests extends AST2CPPTestBase {
 	// int main() {
 	// 	[var1 { 3 }] { }();
 	// }
+	@Test
 	public void testLambdaInitCaptures_413527_1a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -33,6 +35,7 @@ public class InitCaptureTests extends AST2CPPTestBase {
 	// 	int var2 {};
 	// 	[var1 { 3 }, var2] { }();
 	// }
+	@Test
 	public void testLambdaInitCaptures_413527_1b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -41,6 +44,7 @@ public class InitCaptureTests extends AST2CPPTestBase {
 	// 	int var2 {};
 	// 	[var1 { 3 }, var2] { }();
 	// }
+	@Test
 	public void testLambdaInitCaptures_413527_1c() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("var2", CommonCPPTypes.int_);
@@ -50,6 +54,7 @@ public class InitCaptureTests extends AST2CPPTestBase {
 	// int main() {
 	// 	[var1(3)] { }();
 	// }
+	@Test
 	public void testLambdaInitCaptures_413527_2a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -58,6 +63,7 @@ public class InitCaptureTests extends AST2CPPTestBase {
 	// 	int var2 { };
 	// 	[var1(3), var2] { }();
 	// }
+	@Test
 	public void testLambdaInitCaptures_413527_2b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -66,6 +72,7 @@ public class InitCaptureTests extends AST2CPPTestBase {
 	// 	int var2 { };
 	// 	[var1(3), var2] { }();
 	// }
+	@Test
 	public void testLambdaInitCaptures_413527_2c() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("var2", CommonCPPTypes.int_);
@@ -76,6 +83,7 @@ public class InitCaptureTests extends AST2CPPTestBase {
 	// 	int var2 { };
 	// 	[var1( { 3, 3 } ), var2] { }();
 	// }
+	@Test
 	public void testLambdaInitCaptures_413527_2d() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("var2", CommonCPPTypes.int_);
@@ -86,6 +94,7 @@ public class InitCaptureTests extends AST2CPPTestBase {
 	// int main() {
 	// 	[var1 = 3] { }();
 	// }
+	@Test
 	public void testLambdaInitCaptures_413527_3a() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -94,6 +103,7 @@ public class InitCaptureTests extends AST2CPPTestBase {
 	// 	int var2 { };
 	// 	[var1 = 3, var2] { }();
 	// }
+	@Test
 	public void testLambdaInitCaptures_413527_3b() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -102,6 +112,7 @@ public class InitCaptureTests extends AST2CPPTestBase {
 	// 	int var2 { };
 	// 	[var1 = 3, var2] { }();
 	// }
+	@Test
 	public void testLambdaInitCaptures_413527_3c() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("var2", CommonCPPTypes.int_);
@@ -116,6 +127,7 @@ public class InitCaptureTests extends AST2CPPTestBase {
 	// 	int var2 { };
 	// 	[var1 = { 3, 4 }, var2] { }();
 	// }
+	@Test
 	public void testLambdaInitCaptures_413527_3d() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("var2", CommonCPPTypes.int_);
@@ -128,6 +140,7 @@ public class InitCaptureTests extends AST2CPPTestBase {
 	// 		auto var3 = var1;
 	// 	}();
 	// }
+	@Test
 	public void testLambdaInitCaptures_413527_4a() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -140,6 +153,7 @@ public class InitCaptureTests extends AST2CPPTestBase {
 	// 		var1++;
 	// 	}();
 	// }
+	@Test
 	public void testLambdaInitCaptures_413527_4b() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/ReturnTypeDeductionIndexTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/ReturnTypeDeductionIndexTests.java
@@ -12,6 +12,7 @@ package org.eclipse.cdt.core.parser.tests.ast2.cxx14;
 
 import org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes;
 import org.eclipse.cdt.internal.index.tests.IndexBindingResolutionTestBase;
+import org.junit.jupiter.api.Test;
 
 public class ReturnTypeDeductionIndexTests extends IndexBindingResolutionTestBase {
 	public ReturnTypeDeductionIndexTests() {
@@ -24,6 +25,7 @@ public class ReturnTypeDeductionIndexTests extends IndexBindingResolutionTestBas
 	//	auto A::f() { return 42; }
 
 	//	auto waldo = A().f();
+	@Test
 	public void testOutOfLineMethod1() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("waldo", CommonCPPTypes.int_);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/ReturnTypeDeductionTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/ReturnTypeDeductionTests.java
@@ -10,6 +10,10 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import org.eclipse.cdt.core.dom.ast.IProblemType;
 import org.eclipse.cdt.core.dom.ast.IType;
 import org.eclipse.cdt.core.dom.ast.ITypedef;
@@ -20,6 +24,7 @@ import org.eclipse.cdt.core.dom.ast.cpp.ICPPVariable;
 import org.eclipse.cdt.core.parser.tests.ast2.AST2CPPTestBase;
 import org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPClosureType;
+import org.junit.jupiter.api.Test;
 
 public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	private IType getReturnType(String functionName) throws Exception {
@@ -58,6 +63,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	}
 
 	//	auto f() { return 42; }
+	@Test
 	public void testSingleReturn() throws Exception {
 		assertReturnType("f", CommonCPPTypes.int_);
 	}
@@ -68,6 +74,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//		else
 	//			return 0;
 	//	}
+	@Test
 	public void testMultipleReturnsSameType() throws Exception {
 		assertReturnType("f", CommonCPPTypes.int_);
 	}
@@ -79,6 +86,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//		else
 	//			return s;
 	//	}
+	@Test
 	public void testMultipleReturnsDifferingByConst() throws Exception {
 		assertReturnTypeValid("f");
 	}
@@ -89,6 +97,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//		else
 	//			return 0.0;
 	//	}
+	@Test
 	public void testMultipleReturnsDifferentTypes() throws Exception {
 		assertReturnTypeProblem("f");
 	}
@@ -96,6 +105,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//	auto f() {
 	//		return f();
 	//	}
+	@Test
 	public void testFullyRecursiveFunction() throws Exception {
 		assertReturnTypeProblem("f");
 	}
@@ -106,6 +116,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//		else
 	//			return sum(i - 1) + i;
 	//	}
+	@Test
 	public void testPartiallyRecursiveFunction() throws Exception {
 		assertReturnType("sum", CommonCPPTypes.int_);
 	}
@@ -115,6 +126,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//		return t;
 	//	}
 	//	typedef decltype(f(1)) fint_t;
+	@Test
 	public void testFunctionTemplate() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ITypedef t = bh.assertNonProblem("fint_t");
@@ -124,6 +136,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//	template <typename T> auto f(T t) { return t; }
 	//	template <typename T> auto f(T* t) { return *t; }
 	//	void g() { int (*p)(int*) = &f; }
+	@Test
 	public void testAddressOfFunction() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper();
 		ICPPFunctionTemplate f2 = bh.assertNonProblem("f(T*", 1);
@@ -137,6 +150,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//	auto&& f3() { return 42; }
 	//	const auto& f4() { return A::i; }
 	//	const auto&& f5() { return 42; }
+	@Test
 	public void testAutoRef() throws Exception {
 		assertReturnType("f1", CommonCPPTypes.referenceToInt);
 		assertReturnType("f2", CommonCPPTypes.referenceToInt);
@@ -148,6 +162,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//	struct A { static int i; };
 	//	auto* f1() { return &A::i; }
 	//	const auto* f2() { return &A::i; }
+	@Test
 	public void testAutoPointer() throws Exception {
 		assertReturnType("f1", CommonCPPTypes.pointerToInt);
 		assertReturnType("f2", CommonCPPTypes.pointerToConstInt);
@@ -156,6 +171,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//	auto f1() {}
 	//	auto& f2() {}
 	//	auto* f3() {}
+	@Test
 	public void testVoidFunction() throws Exception {
 		assertReturnType("f1", CommonCPPTypes.void_);
 		assertReturnTypeProblem("f2");
@@ -171,6 +187,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//	auto f6() -> const auto&& { return 42; }
 	//	auto f7() -> auto* { return &A::i; }
 	//	auto f8() -> const auto* { return &A::i; }
+	@Test
 	public void testAutoInTrailingReturnType() throws Exception {
 		assertReturnType("f1", CommonCPPTypes.int_);
 		assertReturnType("f2", CommonCPPTypes.referenceToInt);
@@ -187,6 +204,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//      auto f2 = []() -> auto& { return i; };
 	//      auto f3 = []() -> auto&& { return i; };
 	//      auto f4 = []() -> auto&& { return 42; };
+	@Test
 	public void testAutoInLambdaReturnType() throws Exception {
 		assertLambdaReturnType("f1", CommonCPPTypes.int_);
 		assertLambdaReturnType("f2", CommonCPPTypes.referenceToInt);
@@ -201,6 +219,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//		else
 	//			return s;
 	//	};
+	@Test
 	public void testLambdaWithMultipleReturnsDifferingByConst() throws Exception {
 		assertLambdaReturnTypeValid("f");
 	}
@@ -209,12 +228,14 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//		virtual auto f() { return 42; }
 	//		virtual decltype(auto) g() { return 42; }
 	//	};
+	@Test
 	public void testVirtualAutoFunction() throws Exception {
 		assertReturnTypeProblem("f");
 		assertReturnTypeProblem("g");
 	}
 
 	//	auto f() { return {1, 2, 3}; }
+	@Test
 	public void testInitializerList() throws Exception {
 		assertReturnTypeProblem("f");
 	}
@@ -241,6 +262,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 
 	//	decltype(auto) f() { return 42; }
 	//	decltype(auto) g(int* arg) { return *arg; }
+	@Test
 	public void testDecltypeAuto() throws Exception {
 		assertReturnType("f", CommonCPPTypes.int_);
 		assertReturnType("g", CommonCPPTypes.referenceToInt);
@@ -250,6 +272,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//	auto g(int* arg) -> decltype(auto) { return *arg; }
 	// 	auto L1 = []() -> decltype(auto) { return 42; };
 	//	auto L2 = [](int* arg) -> decltype(auto) { return *arg; };
+	@Test
 	public void testDecltypeAutoInTrailingReturnType() throws Exception {
 		assertReturnType("f", CommonCPPTypes.int_);
 		assertReturnType("g", CommonCPPTypes.referenceToInt);
@@ -262,6 +285,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//	decltype(auto)* g() { return &i; }
 	//	auto f2() -> decltype(auto)& { return i; }
 	//	auto g2() -> decltype(auto)* { return &i; }
+	@Test
 	public void testDecltypeAutoWithDecoration() throws Exception {
 		assertReturnTypeProblem("f");
 		assertReturnTypeProblem("g");
@@ -271,6 +295,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 
 	//	auto f();
 	//	auto waldo = f();
+	@Test
 	public void testUseWithoutDefinition() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableTypeProblem("waldo");
@@ -279,6 +304,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//	auto f();
 	//	auto f() { return 42; }
 	//	auto waldo = f();
+	@Test
 	public void testUseAfterDefinition() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("waldo", CommonCPPTypes.int_);
@@ -296,6 +322,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 
 	//	auto f() { return 42; }
 	//	int f();
+	@Test
 	public void testRedeclaration() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		ICPPFunction autoFunction = helper.assertNonProblem("auto f", "f");
@@ -310,6 +337,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//	};
 	//	auto A::f() { return 42; }
 	//	auto waldo = A().f();
+	@Test
 	public void testOutOfLineMethod() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("waldo", CommonCPPTypes.int_);
@@ -319,6 +347,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//     decltype(auto) f() { return (var); }
 	//     int var{};
 	// };
+	@Test
 	public void testParenthesizedIdIsLValueReference_520117() throws Exception {
 		assertReturnType("f", CommonCPPTypes.referenceToInt);
 	}
@@ -328,6 +357,7 @@ public class ReturnTypeDeductionTests extends AST2CPPTestBase {
 	//	decltype(auto) f() {
 	//	    return (s{}.v);
 	//	}
+	@Test
 	public void testParenthesizedXValueIsRValueReference_520117() throws Exception {
 		assertReturnType("f", CommonCPPTypes.rvalueReferenceToInt);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/VariableTemplateTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/VariableTemplateTests.java
@@ -14,6 +14,10 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.eclipse.cdt.core.dom.ast.IType;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTVisibilityLabel;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPField;
@@ -29,16 +33,12 @@ import org.eclipse.cdt.core.parser.tests.ast2.AST2CPPTestBase;
 import org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPClassInstance;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPFieldTemplateSpecialization;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class VariableTemplateTests extends AST2CPPTestBase {
 
-	public static TestSuite suite() {
-		return suite(VariableTemplateTests.class);
-	}
-
 	// template<typename T> constexpr T pi = T(3);
+	@Test
 	public void testVariableTemplate() throws Exception {
 		parseAndCheckBindings();
 
@@ -52,6 +52,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	// struct S {
 	//   template<typename T> static constexpr T pi = T(3);
 	// };
+	@Test
 	public void testFieldTemplate() throws Exception {
 		parseAndCheckBindings();
 
@@ -65,6 +66,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 
 	// template<typename T> const T c;
 	// template<typename T> const T c = T{};
+	@Test
 	public void testVariableTemplateDeclaration() throws Exception {
 		parseAndCheckBindings();
 
@@ -80,6 +82,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	//   template<typename T> static const T c;
 	// };
 	// template<typename T> const T S::c = T{};
+	@Test
 	public void testFieldTemplateDeclaration() throws Exception {
 		parseAndCheckBindings();
 
@@ -95,6 +98,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	//
 	// int foo() { return pi<int>/*1*/; }
 	// int bar() { return pi<int>/*2*/; }
+	@Test
 	public void testVariableTemplateUse() throws Exception {
 		parseAndCheckBindings();
 
@@ -115,6 +119,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	// };
 	//
 	// int foo() { return S::pi<int>; }
+	@Test
 	public void testFieldTemplateUse() throws Exception {
 		parseAndCheckBindings();
 
@@ -132,6 +137,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	// template<> constexpr float pi<float> = 4;
 	//
 	// float f(){ return pi<float>; }
+	@Test
 	public void testVariableTemplateSpecialization() throws Exception {
 		parseAndCheckBindings();
 
@@ -154,6 +160,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	// template<> constexpr int S::pi<int> = 4;
 	//
 	// float f(){ return S::pi<int>; }
+	@Test
 	public void testFieldTemplateSpecialization() throws Exception {
 		parseAndCheckBindings();
 
@@ -174,6 +181,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	// template<typename T, int I> T c = T(I);
 	// template<int I> float c<float, I> = float(I+1);
 	// float f() { return c<float, 100>; }
+	@Test
 	public void testVariableTemplatePartialSpecialization() throws Exception {
 		parseAndCheckBindings();
 
@@ -194,6 +202,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	// };
 	// template<int I> constexpr float S::c<float, I> = float(I+1);
 	// float f() { return S::c<float, 100>; }
+	@Test
 	public void testFieldTemplatePartialSpecialization() throws Exception {
 		parseAndCheckBindings();
 
@@ -213,6 +222,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	// template constexpr int pi<int>;
 	//
 	// int f(){ return pi<int>; }
+	@Test
 	public void testVariableTemplateInstantiation() throws Exception {
 		parseAndCheckBindings();
 
@@ -236,6 +246,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	// template constexpr double S::pi<double>;
 	//
 	// double f(){ return S::pi<double>; }
+	@Test
 	public void testFieldTemplateInstantiation() throws Exception {
 		parseAndCheckBindings();
 
@@ -260,6 +271,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	// template<typename T> struct Vec{ T t; };
 	//
 	// void f(){ once<Vec, int>; }
+	@Test
 	public void testVariableTemplateWithTemplateTemplateParameter() throws Exception {
 		parseAndCheckBindings();
 
@@ -280,6 +292,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	// template<typename T> struct Vec{ T t; };
 	//
 	// void f(){ S<Vec>::once<int>; }
+	@Test
 	public void testFieldTemplateInTemplate() throws Exception {
 		parseAndCheckBindings();
 
@@ -300,6 +313,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	//   auto a = Size<>;
 	//   auto b = Size<int, float, double>;
 	// }
+	@Test
 	public void testVariableTemplatePack() throws Exception {
 		parseAndCheckBindings();
 
@@ -333,6 +347,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	//	void bar() {
 	//		auto waldo = foo<int>();
 	//	}
+	@Test
 	public void test_bug494216() throws Exception {
 		parseAndCheckBindings();
 
@@ -356,6 +371,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	//
 	//	constexpr bool waldo1 = type_in_pack<int, int, char>;
 	//	constexpr bool waldo2 = type_in_pack<int, float, char>;
+	@Test
 	public void testStackOverflow_513429() throws Exception {
 		parseAndCheckBindings();
 
@@ -370,6 +386,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	//	auto L = []{ return R{}; };
 	//
 	//	decltype(L<int>()) waldo;
+	@Test
 	public void testLambdaValue_517670() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableType("waldo", CommonCPPTypes.int_);
@@ -404,6 +421,7 @@ public class VariableTemplateTests extends AST2CPPTestBase {
 	//	int main() {
 	//	  function<void> func(0);
 	//	}
+	@Test
 	public void testVariableInstanceInImplicitName() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/ArrayTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/ArrayTests.java
@@ -11,26 +11,18 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class ArrayTests extends TestBase {
 	public static class NonIndexingTests extends ArrayTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends ArrayTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -40,6 +32,7 @@ public abstract class ArrayTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testInitializationOfMultiDimensionalArrays() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -51,6 +44,7 @@ public abstract class ArrayTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testAssignmentOfArrays() throws Exception {
 		assertEvaluationEquals(4);
 	}
@@ -62,6 +56,7 @@ public abstract class ArrayTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testAssignmentOfMultiDimensionalArrays() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -72,6 +67,7 @@ public abstract class ArrayTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testGlobalArrayAccessValue() throws Exception {
 		assertEvaluationEquals(1);
 	}
@@ -86,6 +82,7 @@ public abstract class ArrayTests extends TestBase {
 	// }
 
 	// constexpr auto x = f();
+	@Test
 	public void testReferenceToArrayCell() throws Exception {
 		assertEvaluationEquals(25);
 	}
@@ -97,6 +94,7 @@ public abstract class ArrayTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerDereferencingOnArrayName() throws Exception {
 		assertEvaluationEquals(4);
 	}
@@ -116,6 +114,7 @@ public abstract class ArrayTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerToArrayReturnedFromMemberFunction1() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -136,6 +135,7 @@ public abstract class ArrayTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerToArrayReturnedFromMemberFunction2() throws Exception {
 		assertEvaluationEquals(9);
 	}
@@ -164,6 +164,7 @@ public abstract class ArrayTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerToArrayReturnedFromMemberFunction3() throws Exception {
 		assertEvaluationEquals(32);
 	}
@@ -175,6 +176,7 @@ public abstract class ArrayTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testReferenceToArray1() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -187,6 +189,7 @@ public abstract class ArrayTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testReferenceToArray2() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -201,6 +204,7 @@ public abstract class ArrayTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testReferenceToArray3() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -213,6 +217,7 @@ public abstract class ArrayTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerArithmeticsOnMultidimensionalArray() throws Exception {
 		assertEvaluationEquals(8);
 	}
@@ -227,6 +232,7 @@ public abstract class ArrayTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPassArrayToFunctionAsPointerAndModifyCell() throws Exception {
 		assertEvaluationEquals(1337);
 	}
@@ -241,6 +247,7 @@ public abstract class ArrayTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPassMultiDimensionalArrayToFunctionAsPointerAndModifyCell() throws Exception {
 		assertEvaluationEquals(1337);
 	}
@@ -251,6 +258,7 @@ public abstract class ArrayTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testInitializationOfArrays() throws Exception {
 		assertEvaluationEquals(3);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/BinaryExpressionTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/BinaryExpressionTests.java
@@ -11,26 +11,18 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class BinaryExpressionTests extends TestBase {
 	public static class NonIndexingTests extends BinaryExpressionTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends BinaryExpressionTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -40,6 +32,7 @@ public abstract class BinaryExpressionTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testSimpleBooleanValues() throws Exception {
 		assertEvaluationEquals(false);
 	}
@@ -51,6 +44,7 @@ public abstract class BinaryExpressionTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testAssignmentReturnsLValue() throws Exception {
 		assertEvaluationEquals(4);
 	}
@@ -62,6 +56,7 @@ public abstract class BinaryExpressionTests extends TestBase {
 	// }
 
 	// constexpr int x = addTwice(2, 5);
+	@Test
 	public void testBinaryExpressionSequence() throws Exception {
 		assertEvaluationEquals(12);
 	}
@@ -75,6 +70,7 @@ public abstract class BinaryExpressionTests extends TestBase {
 	//	constexpr BooleanConvertible variable{true};
 
 	//	constexpr bool actual = variable && variable;
+	@Test
 	public void testContextualConversionInAnd_506972() throws Exception {
 		assertEvaluationEquals(true);
 	}
@@ -88,6 +84,7 @@ public abstract class BinaryExpressionTests extends TestBase {
 	//	constexpr BooleanConvertible variable{true};
 
 	//	constexpr bool actual = variable || variable;
+	@Test
 	public void testContextualConversionInOr_506972() throws Exception {
 		assertEvaluationEquals(true);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/BinaryOperatorOverloadingTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/BinaryOperatorOverloadingTests.java
@@ -11,26 +11,18 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class BinaryOperatorOverloadingTests extends TestBase {
 	public static class NonIndexingTests extends BinaryOperatorOverloadingTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends BinaryOperatorOverloadingTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -51,6 +43,7 @@ public abstract class BinaryOperatorOverloadingTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testOverloadedPlusOperatorAsMemberFunction() throws Exception {
 		assertEvaluationEquals(12);
 	}
@@ -71,6 +64,7 @@ public abstract class BinaryOperatorOverloadingTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testOverloadedMultiplicationOperatorAsMemberFunction() throws Exception {
 		assertEvaluationEquals(12);
 	}
@@ -91,6 +85,7 @@ public abstract class BinaryOperatorOverloadingTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testOverloadedPlusOperatorAsNonMemberFunction() throws Exception {
 		assertEvaluationEquals(14);
 	}
@@ -112,6 +107,7 @@ public abstract class BinaryOperatorOverloadingTests extends TestBase {
 	//	}
 
 	//  constexpr int x = f();
+	@Test
 	public void testOverloadedOperatorPlusComplex1() throws Exception {
 		assertEvaluationEquals(24);
 	}
@@ -133,6 +129,7 @@ public abstract class BinaryOperatorOverloadingTests extends TestBase {
 	//	}
 
 	//  constexpr int x = f();
+	@Test
 	public void testOverloadedOperatorPlusComplex2() throws Exception {
 		assertEvaluationEquals(24);
 	}
@@ -153,6 +150,7 @@ public abstract class BinaryOperatorOverloadingTests extends TestBase {
 	//	}
 
 	//  constexpr int x = f();
+	@Test
 	public void testOverloadedOperatorPlusComplex3() throws Exception {
 		assertEvaluationEquals(24);
 	}
@@ -172,6 +170,7 @@ public abstract class BinaryOperatorOverloadingTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testOverloadedOperatorEquals() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -195,6 +194,7 @@ public abstract class BinaryOperatorOverloadingTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testOverloadedOperatorAssign() throws Exception {
 		assertEvaluationEquals(10);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/CStringValueTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/CStringValueTests.java
@@ -11,16 +11,12 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class CStringValueTests extends TestBase {
 	public static class NonIndexingTests extends CStringValueTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
-		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
 		}
 	}
 
@@ -28,13 +24,10 @@ public abstract class CStringValueTests extends TestBase {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
 		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
-		}
 	}
 
 	//	constexpr auto x = "Hello, World!";
+	@Test
 	public void testWithoutPrefix() throws Exception {
 		assertEvaluationEquals("Hello, World!");
 	}
@@ -42,26 +35,31 @@ public abstract class CStringValueTests extends TestBase {
 	//	constexpr auto y = "Hello, World!";
 
 	//	constexpr auto x = y;
+	@Test
 	public void testStringAssignment() throws Exception {
 		assertEvaluationEquals("Hello, World!");
 	}
 
 	//	constexpr auto x = L"Hello, World!";
+	@Test
 	public void testLPrefix() throws Exception {
 		assertEvaluationEquals("Hello, World!");
 	}
 
 	//	constexpr auto x = u8"Hello, World!";
+	@Test
 	public void testu8Prefix() throws Exception {
 		assertEvaluationEquals("Hello, World!");
 	}
 
 	//	constexpr auto x = u"Hello, World!";
+	@Test
 	public void testuPrefix() throws Exception {
 		assertEvaluationEquals("Hello, World!");
 	}
 
 	//	constexpr auto x = U"Hello, World!";
+	@Test
 	public void testUPrefix() throws Exception {
 		assertEvaluationEquals("Hello, World!");
 	}
@@ -69,12 +67,14 @@ public abstract class CStringValueTests extends TestBase {
 	//constexpr auto x = R"(This is
 	//a "raw" \n\n
 	//	literal\0end)";
+	@Test
 	public void testRawStringLiteral() throws Exception {
 		assertEvaluationEquals("This is\na \"raw\" \\n\\n\n\tliteral\\0end");
 	}
 
 	//constexpr auto x = R"ab(This is)"
 	//a "raw" literal)ab";
+	@Test
 	public void testRawStringLiteralWithDelimiter() throws Exception {
 		assertEvaluationEquals("This is)\"\na \"raw\" literal");
 	}
@@ -82,11 +82,13 @@ public abstract class CStringValueTests extends TestBase {
 	//	constexpr auto x = "line 1\n"
 	//						"line 2\n"
 	//						"line 3";
+	@Test
 	public void testCStringLiteralConcatenation() throws Exception {
 		assertEvaluationEquals("line 1\nline 2\nline 3");
 	}
 
 	//	constexpr auto x = "PI = \u03C0";
+	@Test
 	public void test16bitUnicodeEscapeSequence() throws Exception {
 		assertEvaluationEquals("PI = \u03C0");
 	}
@@ -105,6 +107,7 @@ public abstract class CStringValueTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testCStringParam() throws Exception {
 		assertEvaluationEquals(5);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/ClassTemplateTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/ClassTemplateTests.java
@@ -11,26 +11,18 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class ClassTemplateTests extends TestBase {
 	public static class NonIndexingTests extends ClassTemplateTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends ClassTemplateTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -48,6 +40,7 @@ public abstract class ClassTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testInstantiationOfClassTemplate() throws Exception {
 		assertEvaluationEquals(25);
 	}
@@ -65,6 +58,7 @@ public abstract class ClassTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testInstantiationOfClassTemplateWithNontypeTemplateParameter1() throws Exception {
 		assertEvaluationEquals(35);
 	}
@@ -83,6 +77,7 @@ public abstract class ClassTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testInstantiationOfClassTemplateWithNontypeTemplateParameter2() throws Exception {
 		assertEvaluationEquals(35);
 	}
@@ -103,6 +98,7 @@ public abstract class ClassTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testAliasTemplate1() throws Exception {
 		assertEvaluationEquals(17);
 	}
@@ -122,6 +118,7 @@ public abstract class ClassTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testInstantiationOfBaseClassTemplate1() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -141,6 +138,7 @@ public abstract class ClassTemplateTests extends TestBase {
 	//		return s.get();
 	//	}
 	//	constexpr int x = f();
+	@Test
 	public void testInstantiationOfBaseClassTemplate2() throws Exception {
 		assertEvaluationEquals(30);
 	}
@@ -157,6 +155,7 @@ public abstract class ClassTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testTemplateArgumentInMemberInitializerList() throws Exception {
 		assertEvaluationEquals(10);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/ConstructorTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/ConstructorTests.java
@@ -12,17 +12,12 @@
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
 import org.eclipse.cdt.internal.core.dom.parser.IntegralValue;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class ConstructorTests extends TestBase {
 	public static class NonIndexingTests extends ConstructorTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
-		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
 		}
 	}
 
@@ -30,18 +25,10 @@ public abstract class ConstructorTests extends TestBase {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
 		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
-		}
 	}
 
 	public ConstructorTests() {
 		setStrategy(new NonIndexingTestStrategy());
-	}
-
-	public static TestSuite suite() {
-		return suite(NonIndexingTests.class);
 	}
 
 	//	struct S {
@@ -54,6 +41,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testConstexprConstructorChainInitializers() throws Exception {
 		assertEvaluationEquals(25);
 	}
@@ -68,6 +56,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testConstexprConstructorConstructorBody() throws Exception {
 		assertEvaluationEquals(26);
 	}
@@ -82,6 +71,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testConstexprConstructorCopyConstruction() throws Exception {
 		assertEvaluationEquals(26);
 	}
@@ -96,6 +86,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr auto var = f();
+	@Test
 	public void testIdempotence() throws Exception {
 		// Querying a value a second time should produce the same result.
 		assertEvaluationEquals(26);
@@ -112,6 +103,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testConstexprConstructorDefaultConstruction() throws Exception {
 		assertEvaluationEquals(7);
 	}
@@ -130,6 +122,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testConstexprConstructorInheritance() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -144,6 +137,7 @@ public abstract class ConstructorTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testInitializationOfCompositeValues() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -162,6 +156,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testNestedConstructorCall() throws Exception {
 		assertEvaluationEquals(4);
 	}
@@ -179,6 +174,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(S{});
+	@Test
 	public void testImplicitConstructorOfLiteralTypeWithImplicitDestructorIsConstexpr() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -197,6 +193,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(S{});
+	@Test
 	public void testImplicitConstructorOfLiteralTypeWithDefaultedDestructorIsConstexpr() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -215,6 +212,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(S{});
+	@Test
 	public void testImplicitConstructorOfLiteralTypeWithUserDefinedDestructorIsNotConstexpr() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -228,6 +226,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(S{});
+	@Test
 	public void testImplicitConstructorOfAggregateTypeIsConstexpr() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -242,6 +241,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(S{});
+	@Test
 	public void testUserDefinedDefaultConstructorIsNotConstexpr() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -257,6 +257,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testCtorCall() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -275,6 +276,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testArgumentEvaluation() throws Exception {
 		assertEvaluationEquals(50);
 	}
@@ -292,6 +294,7 @@ public abstract class ConstructorTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testInitializationOfNestedCompositeValues() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -307,6 +310,7 @@ public abstract class ConstructorTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testAssignmentOfCompositeValues() throws Exception {
 		assertEvaluationEquals(9);
 	}
@@ -326,6 +330,7 @@ public abstract class ConstructorTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testAssignmentOfNestedCompositeValues() throws Exception {
 		assertEvaluationEquals(7);
 	}
@@ -340,6 +345,7 @@ public abstract class ConstructorTests extends TestBase {
 	// }
 
 	// constexpr auto x = f();
+	@Test
 	public void testStructDefaultInitialization() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -354,6 +360,7 @@ public abstract class ConstructorTests extends TestBase {
 	// }
 
 	// constexpr auto x = f();
+	@Test
 	public void testStructDefaultInitializationOverride() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -372,6 +379,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testNestedStructDefaultInitialization() throws Exception {
 		assertEvaluationEquals(8);
 	}
@@ -390,6 +398,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f().getY();
+	@Test
 	public void testSimpleTypeConstructorExpression2() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -400,6 +409,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	constexpr S s{1,5};
 
 	//	constexpr int x = s.y;
+	@Test
 	public void testInitialValueOfComposite() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -415,6 +425,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testCtorInitializerList() throws Exception {
 		assertEvaluationEquals(12);
 	}
@@ -430,6 +441,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testCtorConstructorInitializer() throws Exception {
 		assertEvaluationEquals(12);
 	}
@@ -445,6 +457,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testCtorEqualsInitializer() throws Exception {
 		assertEvaluationEquals(12);
 	}
@@ -460,6 +473,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testCtorImplicitConversion() throws Exception {
 		assertEvaluationEquals(12);
 	}
@@ -476,6 +490,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testCtorLvalueCopyConstruction() throws Exception {
 		assertEvaluationEquals(12);
 	}
@@ -491,6 +506,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testCtorRvalueCopyConstruction() throws Exception {
 		assertEvaluationEquals(12);
 	}
@@ -510,6 +526,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testNestedStructDefaultInitializationOverride() throws Exception {
 		assertEvaluationEquals(22);
 	}
@@ -520,6 +537,7 @@ public abstract class ConstructorTests extends TestBase {
 	// };
 
 	// constexpr auto x = T(2).member;
+	@Test
 	public void testFundamentalTypeDirectInitializationWithParenthesis() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -536,6 +554,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testInheritedMemberVariable1() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -556,6 +575,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testInheritedMemberVariable2() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -572,6 +592,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testOrderOfFieldInitialization() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -582,6 +603,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	constexpr S waldo{23};
 
 	//	constexpr int x = waldo.value;
+	@Test
 	public void testDirectInitializedVariable_510151() throws Exception {
 		assertEvaluationEquals(23);
 	}
@@ -592,6 +614,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	constexpr S waldo{};
 
 	//	constexpr int x = waldo.value;
+	@Test
 	public void testDirectDefaultInitializedVariable_510151() throws Exception {
 		assertEvaluationEquals(42);
 	}
@@ -602,6 +625,7 @@ public abstract class ConstructorTests extends TestBase {
 	//	constexpr S waldo;
 
 	//	constexpr int x = waldo.value;
+	@Test
 	public void testDefaultInitializedVariable_510151() throws Exception {
 		assertEvaluationEquals(42);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/DoWhileStatementTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/DoWhileStatementTests.java
@@ -12,27 +12,18 @@
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
 import org.eclipse.cdt.internal.core.dom.parser.IntegralValue;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class DoWhileStatementTests extends TestBase {
 	public static class NonIndexingTests extends DoWhileStatementTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends DoWhileStatementTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -47,6 +38,7 @@ public abstract class DoWhileStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f(10);
+	@Test
 	public void testDoWhile() throws Exception {
 		assertEvaluationEquals(55);
 	}
@@ -60,6 +52,7 @@ public abstract class DoWhileStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testDoWhileInfiniteLoop() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -73,6 +66,7 @@ public abstract class DoWhileStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testDoWhileReturn() throws Exception {
 		assertEvaluationEquals(42);
 	}
@@ -86,6 +80,7 @@ public abstract class DoWhileStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(10);
+	@Test
 	public void testDoWhileWithNonCompoundBodyStatement() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -99,6 +94,7 @@ public abstract class DoWhileStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(10);
+	@Test
 	public void testDoWhileWithReturnInNonCompoundBodyStatement() throws Exception {
 		assertEvaluationEquals(42);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/FloatingPointValueTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/FloatingPointValueTests.java
@@ -11,7 +11,7 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class FloatingPointValueTests extends TestBase {
 	public static class NonIndexingTests extends FloatingPointValueTests {
@@ -19,47 +19,46 @@ public abstract class FloatingPointValueTests extends TestBase {
 			setStrategy(new NonIndexingTestStrategy());
 		}
 
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends FloatingPointValueTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
 		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
-		}
 	}
 
 	// 	constexpr auto x = 2.5;
+	@Test
 	public void testDoubleLiteral() throws Exception {
 		assertEvaluationEquals(2.5);
 	}
 
 	//	constexpr auto x = -2.5;
+	@Test
 	public void testNegativeDoubleLiteral() throws Exception {
 		assertEvaluationEquals(-2.5);
 	}
 
 	//  constexpr auto x = .5f;
+	@Test
 	public void testFloatLiteral() throws Exception {
 		assertEvaluationEquals(0.5);
 	}
 
 	//	constexpr auto x = 2.l;
+	@Test
 	public void testLongDoubleLiteral() throws Exception {
 		assertEvaluationEquals(2.0);
 	}
 
 	//	constexpr auto x = 123.456e-67;
+	@Test
 	public void testDoubleLiteralWithScientificNotation() throws Exception {
 		assertEvaluationEquals(123.456e-67);
 	}
 
 	//	constexpr auto x = .1E4f;
+	@Test
 	public void testFloatLiteralWithScientificNotation() throws Exception {
 		assertEvaluationEquals(.1E4f);
 	}
@@ -71,6 +70,7 @@ public abstract class FloatingPointValueTests extends TestBase {
 	//	}
 
 	//	constexpr double x = f();
+	@Test
 	public void testBinaryOperationsWithFloatingPointNumbers() throws Exception {
 		assertEvaluationEquals(22.7);
 	}
@@ -82,6 +82,7 @@ public abstract class FloatingPointValueTests extends TestBase {
 	//	}
 
 	//	constexpr bool x = f();
+	@Test
 	public void testComparisonBetweenFloatingPointValueAndIntegralValue1() throws Exception {
 		assertEvaluationEquals(true);
 	}
@@ -93,11 +94,13 @@ public abstract class FloatingPointValueTests extends TestBase {
 	//	}
 
 	//	constexpr bool x = f();
+	@Test
 	public void testComparisonBetweenFloatingPointValueAndIntegralValue2() throws Exception {
 		assertEvaluationEquals(false);
 	}
 
 	//	constexpr auto x = float{} + float();
+	@Test
 	public void testFloatDefaultValue() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -108,11 +111,13 @@ public abstract class FloatingPointValueTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testFloatValueInitialization() throws Exception {
 		assertEvaluationEquals(0);
 	}
 
 	//	constexpr auto x = double{} + double();
+	@Test
 	public void testDoubleDefaultValue() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -123,6 +128,7 @@ public abstract class FloatingPointValueTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testDoubleValueInitialization() throws Exception {
 		assertEvaluationEquals(0);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/ForStatementTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/ForStatementTests.java
@@ -12,27 +12,18 @@
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
 import org.eclipse.cdt.internal.core.dom.parser.IntegralValue;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class ForStatementTests extends TestBase {
 	public static class NonIndexingTests extends ForStatementTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends ForStatementTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -45,6 +36,7 @@ public abstract class ForStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f(10);
+	@Test
 	public void testSimpleIndexBasedForLoop() throws Exception {
 		assertEvaluationEquals(55);
 	}
@@ -59,6 +51,7 @@ public abstract class ForStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f(10);
+	@Test
 	public void testReturnInIndexBasedForLoop() throws Exception {
 		assertEvaluationEquals(42);
 	}
@@ -72,6 +65,7 @@ public abstract class ForStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f(10);
+	@Test
 	public void testInfiniteLoopInIndexBasedForLoop() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -86,6 +80,7 @@ public abstract class ForStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f(10);
+	@Test
 	public void testIndexBasedForLoopWithEmptyInitializationStatement() throws Exception {
 		assertEvaluationEquals(45);
 	}
@@ -99,6 +94,7 @@ public abstract class ForStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f(10);
+	@Test
 	public void testIndexBasedForLoopWithEmptyIterationSequence() throws Exception {
 		assertEvaluationEquals(45);
 	}
@@ -111,6 +107,7 @@ public abstract class ForStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f(10);
+	@Test
 	public void testIndexBasedForLoopWithNonCompoundBodyStatement() throws Exception {
 		assertEvaluationEquals(55);
 	}
@@ -123,6 +120,7 @@ public abstract class ForStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f(10);
+	@Test
 	public void testIndexBasedForLoopWithReturnInNonCompoundBodyStatement() throws Exception {
 		assertEvaluationEquals(42);
 	}
@@ -138,6 +136,7 @@ public abstract class ForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testIndexBasedForLoopWithContinueStatement() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -155,6 +154,7 @@ public abstract class ForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testIndexBasedForLoopWithNestedContinueStatement() throws Exception {
 		assertEvaluationEquals(30);
 	}
@@ -172,6 +172,7 @@ public abstract class ForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testIndexBasedForLoopWithNestedBreakStatement() throws Exception {
 		assertEvaluationEquals(15);
 	}
@@ -188,6 +189,7 @@ public abstract class ForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testDeclarationInForStatementCondition1() throws Exception {
 		assertEvaluationEquals(30);
 	}
@@ -203,6 +205,7 @@ public abstract class ForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testInfiniteForLoop() throws Exception {
 		assertEvaluationEquals(12);
 	}
@@ -214,6 +217,7 @@ public abstract class ForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = fac(5);
+	@Test
 	public void testForLoopWithNullStatementAsBody() throws Exception {
 		assertEvaluationEquals(120);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/FunctionTemplateTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/FunctionTemplateTests.java
@@ -11,26 +11,18 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class FunctionTemplateTests extends TestBase {
 	public static class NonIndexingTests extends FunctionTemplateTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends FunctionTemplateTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -40,6 +32,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = add(5.5, 6.3);
+	@Test
 	public void testImplicitTemplateInstantiation() throws Exception {
 		assertEvaluationEquals(11.8);
 	}
@@ -57,6 +50,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f<Integer>();
+	@Test
 	public void testExplicitTemplateInstantiation() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -68,6 +62,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f<5>();
+	@Test
 	public void testTemplateWithNonTypeTemplateParameter() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -82,6 +77,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = sum(1,2,3,4,5);
+	@Test
 	public void testVariadicTemplate() throws Exception {
 		assertEvaluationEquals(15);
 	}
@@ -92,6 +88,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = count(1,2,3,4,5);
+	@Test
 	public void testParameterPackSizeof() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -116,6 +113,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = fac(Integer{5});
+	@Test
 	public void testTemplateInstantiationOfForLoop() throws Exception {
 		assertEvaluationEquals(120);
 	}
@@ -141,6 +139,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(Integer{10});
+	@Test
 	public void testTemplateInstantiationOfDoWhileLoop() throws Exception {
 		assertEvaluationEquals(55);
 	}
@@ -152,6 +151,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = add(5.5, 6.3);
+	@Test
 	public void testNullStatementInFunctionTemplate() throws Exception {
 		assertEvaluationEquals(11.8);
 	}
@@ -178,6 +178,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = fac(Integer{5});
+	@Test
 	public void testTemplateInstantiationOfWhileLoop() throws Exception {
 		assertEvaluationEquals(120);
 	}
@@ -191,6 +192,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = div(11.5, 2.0);
+	@Test
 	public void testTemplateInstantiationOfIfStatement() throws Exception {
 		assertEvaluationEquals(5.75);
 	}
@@ -203,6 +205,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = count(1, 0.5, 3.4, 5, 2.2);
+	@Test
 	public void testVariadicTemplateWithVaryingTypes() throws Exception {
 		assertEvaluationEquals(14);
 	}
@@ -217,6 +220,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr long long x = sum(1,2,3,4,5);
+	@Test
 	public void testExpansionOfVariadicTemplateParameterIntoInitializerList() throws Exception {
 		assertEvaluationEquals(15);
 	}
@@ -231,6 +235,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr long long x = sum(1,2,3,4,5);
+	@Test
 	public void testExpressionInVariadicTemplateParameterExpansion1() throws Exception {
 		assertEvaluationEquals(30);
 	}
@@ -247,6 +252,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = sumOfPrimes(0, 4, 9, 11, 19);
+	@Test
 	public void testExpressionInVariadicTemplateParameterExpansion2() throws Exception {
 		assertEvaluationEquals(150);
 	}
@@ -266,6 +272,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = sumOfPrimes(index_sequence<0, 4, 9, 11, 19>{});
+	@Test
 	public void testIndexSequence1() throws Exception {
 		assertEvaluationEquals(150);
 	}
@@ -280,6 +287,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testFunctionTemplateWithArrayParameter1() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -297,6 +305,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testFunctionTemplateWithArrayParameter2() throws Exception {
 		assertEvaluationEquals(8);
 	}
@@ -314,6 +323,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f<10>();
+	@Test
 	public void testInstantiationOfConstructorInFunctionTemplate1() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -331,6 +341,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//		return n.isFloatingPoint();
 	//	}
 	//	constexpr bool x = f<double>();
+	@Test
 	public void testInstantiationOfConstructorInFunctionTemplate2() throws Exception {
 		assertEvaluationEquals(true);
 	}
@@ -356,6 +367,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f<9,2>();
+	@Test
 	public void testInstantiationOfSwitchStatement() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -369,6 +381,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f<int>();
+	@Test
 	public void testInstantiationOfTypedefDeclaration() throws Exception {
 		assertEvaluationEquals(25);
 	}
@@ -382,6 +395,7 @@ public abstract class FunctionTemplateTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f<int>();
+	@Test
 	public void testInstantiationOfAliasDeclaration() throws Exception {
 		assertEvaluationEquals(25);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/FunctionTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/FunctionTests.java
@@ -11,33 +11,26 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import org.eclipse.cdt.core.dom.ast.IASTFunctionCallExpression;
 import org.eclipse.cdt.core.dom.ast.IASTIdExpression;
 import org.eclipse.cdt.core.dom.ast.IASTInitializerClause;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPFunction;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPFunction;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPExecution;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class FunctionTests extends TestBase {
 	public static class NonIndexingTests extends FunctionTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends FunctionTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -53,6 +46,7 @@ public abstract class FunctionTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testAccessMemberOfCompositeParameter() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -60,6 +54,7 @@ public abstract class FunctionTests extends TestBase {
 	// constexpr int function(int n) { return n > 0 ? n + function(n-1) : n; }
 
 	// constexpr int x = function(10);
+	@Test
 	public void testRecursion() throws Exception {
 		assertEvaluationEquals(55);
 	}
@@ -74,6 +69,7 @@ public abstract class FunctionTests extends TestBase {
 	// }
 
 	// constexpr int x = function();
+	@Test
 	public void testEvaluationOfConstexprFunctionCalls() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -91,6 +87,7 @@ public abstract class FunctionTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testFunctionReturnValueIsCopiedAndNotReferenced() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -105,6 +102,7 @@ public abstract class FunctionTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testPassingIntByValue() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -119,6 +117,7 @@ public abstract class FunctionTests extends TestBase {
 	// }
 
 	//	constexpr auto x = f();
+	@Test
 	public void testPassingIntByReference1() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -134,6 +133,7 @@ public abstract class FunctionTests extends TestBase {
 	// }
 
 	// constexpr auto x = f();
+	@Test
 	public void testPassingIntByReference2() throws Exception {
 		assertEvaluationEquals(7);
 	}
@@ -151,6 +151,7 @@ public abstract class FunctionTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPassingCompositeByValue() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -166,6 +167,7 @@ public abstract class FunctionTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testPassingCompositeByReference() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -179,6 +181,7 @@ public abstract class FunctionTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testPointerReturnValue() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -192,6 +195,7 @@ public abstract class FunctionTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testReferenceReturnValue() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -208,6 +212,7 @@ public abstract class FunctionTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testSideEffectsOnArrayParameter() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -221,6 +226,7 @@ public abstract class FunctionTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(10);
+	@Test
 	public void testBlockScopeValueLookup1() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -233,6 +239,7 @@ public abstract class FunctionTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(10);
+	@Test
 	public void testBlockScopeValueLookup2() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -241,6 +248,7 @@ public abstract class FunctionTests extends TestBase {
 	//	constexpr int almost = sizeof(foo());
 
 	//	constexpr int x = almost;
+	@Test
 	public void testSizeofCallToRegularFunction() throws Exception {
 		assertEvaluationEquals(1);
 	}
@@ -250,6 +258,7 @@ public abstract class FunctionTests extends TestBase {
 	//	}
 
 	//	int x = f();
+	@Test
 	public void testNonConstexprFunctionDoesntStoreBodyExecution() throws Exception {
 		IASTInitializerClause clause = getLastDeclarationInitializer();
 		IASTFunctionCallExpression funcExpr = (IASTFunctionCallExpression) clause;
@@ -272,12 +281,14 @@ public abstract class FunctionTests extends TestBase {
 	//	    .m(1).m(2).m(3).m(4).m(5).m(6).m(7).m(8).m(9).m(10)
 	//	    .m(11).m(12).m(13).m(14).m(15).m(16).m(17).m(18).m(19).m(20)
 	//	    .m(21).m(22).m(23).m(24).m(25).m(26).m(27).m(28).m(29).m(30);
+	@Test
 	public void testLongCallChain_505606() throws Exception {
 	}
 
 	// auto f = []() constexpr -> int {return 58;};
 
 	// constexpr int x = f();
+	@Test
 	public void testLambdaExpression_560483() throws Exception {
 		assertEvaluationEquals(58);
 	}
@@ -287,6 +298,7 @@ public abstract class FunctionTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testLambdaExpression2_560483() throws Exception {
 		assertEvaluationEquals(58);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/IfStatementTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/IfStatementTests.java
@@ -11,26 +11,18 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class IfStatementTests extends TestBase {
 	public static class NonIndexingTests extends IfStatementTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends IfStatementTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -42,6 +34,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSimpleIfTrueBranch() throws Exception {
 		assertEvaluationEquals(1);
 	}
@@ -54,6 +47,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSimpleIfFalseBranch() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -67,6 +61,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testIfElseTrueBranch() throws Exception {
 		assertEvaluationEquals(1);
 	}
@@ -80,6 +75,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSimpleIfElseFalseBranch() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -95,6 +91,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testNestedIfTrueBranch() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -110,6 +107,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testNestedIfFalseBranch() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -121,6 +119,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testIfStatementWithNonCompoundThenClause() throws Exception {
 		assertEvaluationEquals(1);
 	}
@@ -133,6 +132,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testIfStatementWithNonCompoundElseClause() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -148,6 +148,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testIfStatementWithNonReturnClauses() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -162,6 +163,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testIfStatementWithNonReturnClausesAndNonCompoundElseClause() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -175,6 +177,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(1);
+	@Test
 	public void testDeclarationInIfStatementCondition1() throws Exception {
 		assertEvaluationEquals(7);
 	}
@@ -188,6 +191,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(0);
+	@Test
 	public void testDeclarationInIfStatementCondition2() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -204,6 +208,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(1);
+	@Test
 	public void testDeclarationInIfStatementCondition3() throws Exception {
 		assertEvaluationEquals(7);
 	}
@@ -220,6 +225,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(1);
+	@Test
 	public void testInitStatementInIfStatementCondition1() throws Exception {
 		assertEvaluationEquals(7);
 	}
@@ -236,6 +242,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(1);
+	@Test
 	public void testInitStatementInIfStatementCondition2() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -252,6 +259,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testInitStatementInIfStatementCondition3() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -269,6 +277,7 @@ public abstract class IfStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(1);
+	@Test
 	public void testEmptyInitStatementInIfStatementCondition1() throws Exception {
 		assertEvaluationEquals(7);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/IntegralValueTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/IntegralValueTests.java
@@ -13,17 +13,13 @@ package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
 import org.eclipse.cdt.core.testplugin.TestScannerProvider;
 import org.eclipse.cdt.internal.core.dom.parser.IntegralValue;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class IntegralValueTests extends TestBase {
 	public static class NonIndexingTests extends IntegralValueTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
-		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
 		}
 	}
 
@@ -31,23 +27,21 @@ public abstract class IntegralValueTests extends TestBase {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
 		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
-		}
 	}
 
 	@Override
-	protected void setUp() throws Exception {
+	@BeforeEach
+	protected void setUpStrategy() throws Exception {
 		TestScannerProvider.sDefinedSymbols.put("__SIZEOF_SHORT__", "2");
 		TestScannerProvider.sDefinedSymbols.put("__SIZEOF_INT__", "4");
 		TestScannerProvider.sDefinedSymbols.put("__SIZEOF_LONG__", "8");
 		TestScannerProvider.sDefinedSymbols.put("__SIZEOF_LONG_LONG__", "8");
 		TestScannerProvider.sDefinedSymbols.put("__SIZEOF_POINTER__", "8");
-		super.setUp();
+		super.setUpStrategy();
 	}
 
 	//	constexpr auto x = int{} + int();
+	@Test
 	public void testIntDefaultValue() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -58,11 +52,13 @@ public abstract class IntegralValueTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testIntValueInitialization() throws Exception {
 		assertEvaluationEquals(0);
 	}
 
 	//	constexpr auto x = long{} + long();
+	@Test
 	public void testLongDefaultValue() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -73,11 +69,13 @@ public abstract class IntegralValueTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testLongValueInitialization() throws Exception {
 		assertEvaluationEquals(0);
 	}
 
 	//	constexpr auto x = short{} + short();
+	@Test
 	public void testShortDefaultValue() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -88,11 +86,13 @@ public abstract class IntegralValueTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testShortValueInitialization() throws Exception {
 		assertEvaluationEquals(0);
 	}
 
 	//	constexpr auto x = bool{} + bool();
+	@Test
 	public void testBooleanDefaulValue() throws Exception {
 		assertEvaluationEquals(false);
 	}
@@ -103,11 +103,13 @@ public abstract class IntegralValueTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testBoolValueInitialization() throws Exception {
 		assertEvaluationEquals(0);
 	}
 
 	//	constexpr auto x = char{} + char();
+	@Test
 	public void testCharDefaultValue() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -118,6 +120,7 @@ public abstract class IntegralValueTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testCharValueInitialization() throws Exception {
 		assertEvaluationEquals('c');
 	}
@@ -128,6 +131,7 @@ public abstract class IntegralValueTests extends TestBase {
 	// }
 
 	// constexpr int x = mul(2, 5);
+	@Test
 	public void testDeclarationWithEqualsInitializerInSequence() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -139,6 +143,7 @@ public abstract class IntegralValueTests extends TestBase {
 	// }
 
 	// constexpr int x = mul(2, 5);
+	@Test
 	public void testDeclarationWithDefaultInitializationInSequence() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -150,6 +155,7 @@ public abstract class IntegralValueTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testDirectInitializationOnFundamentalTypes() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -160,6 +166,7 @@ public abstract class IntegralValueTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testUseOfUninitializedVariableIsError() throws Exception {
 		assertEvaluationEquals(IntegralValue.UNKNOWN);
 	}
@@ -170,6 +177,7 @@ public abstract class IntegralValueTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testDeclarationWithMultipleDeclarators() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -181,6 +189,7 @@ public abstract class IntegralValueTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSimpleTypeConstructionInitializerList() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -192,6 +201,7 @@ public abstract class IntegralValueTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSimpleTypeConstructionConstructorInitializer() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -203,6 +213,7 @@ public abstract class IntegralValueTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSimpleTypeConstructionEqualsInitializer1() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -214,6 +225,7 @@ public abstract class IntegralValueTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSimpleTypeConstructionEqualsInitializer2() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -226,6 +238,7 @@ public abstract class IntegralValueTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testCopyInitialization() throws Exception {
 		assertEvaluationEquals(7);
 	}
@@ -237,6 +250,7 @@ public abstract class IntegralValueTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testMultipleDeclaratorsInOneDeclaration() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -246,6 +260,7 @@ public abstract class IntegralValueTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSimpleTypeConstructorExpression1() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -257,6 +272,7 @@ public abstract class IntegralValueTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testSideEffects2() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -264,6 +280,7 @@ public abstract class IntegralValueTests extends TestBase {
 	//  constexpr int x = 2;
 
 	//	constexpr int y = x * 4;
+	@Test
 	public void testAccessGlobalVariableFromGlobalConstexpr() throws Exception {
 		assertEvaluationEquals(8);
 	}
@@ -272,91 +289,109 @@ public abstract class IntegralValueTests extends TestBase {
 	//  constexpr int f() { return x * 4; }
 
 	//	constexpr int y = f();
+	@Test
 	public void testAccessGlobalVariableFromConstexprFunction() throws Exception {
 		assertEvaluationEquals(8);
 	}
 
 	//	constexpr int x = 0x2a;
+	@Test
 	public void testHexLiteral() throws Exception {
 		assertEvaluationEquals(42);
 	}
 
 	// constexpr int x = __builtin_ffs(0) + __builtin_ffs(16);
+	@Test
 	public void testBuiltinFfs() throws Exception {
 		assertEvaluationEquals(5);
 	}
 
 	// constexpr int x = __builtin_ffs(0x100000000);
+	@Test
 	public void testBuiltinFfsNarrowing() throws Exception {
 		assertEvaluationEquals(0);
 	}
 
 	// constexpr int x = __builtin_ffsl(0x100000000);
+	@Test
 	public void testBuiltinFfsl() throws Exception {
 		assertEvaluationEquals(33);
 	}
 
 	// constexpr int x = __builtin_ctz(16);
+	@Test
 	public void testBuiltinCtz() throws Exception {
 		assertEvaluationEquals(4);
 	}
 
 	// constexpr int x = __builtin_popcount(128 + 32 + 8 + 4 + 2);
+	@Test
 	public void testBuiltinPopcount() throws Exception {
 		assertEvaluationEquals(5);
 	}
 
 	// constexpr int x = __builtin_popcountl(0x80000001);
+	@Test
 	public void testBuiltinPopcountHighBitSet() throws Exception {
 		assertEvaluationEquals(2);
 	}
 
 	// constexpr int x = __builtin_popcountl(0x8000000000000001);
+	@Test
 	public void testBuiltinPopcountlHighBitSet() throws Exception {
 		assertEvaluationEquals(2);
 	}
 
 	// constexpr int x = __builtin_popcountll(0x8000000000000001);
+	@Test
 	public void testBuiltinPopcountllHighBitSet() throws Exception {
 		assertEvaluationEquals(2);
 	}
 
 	// constexpr int x = __builtin_parity(128 + 32 + 8 + 4 + 2) + __builtin_parity(64) + __builtin_parity(0);
+	@Test
 	public void testBuiltinParity() throws Exception {
 		assertEvaluationEquals(2);
 	}
 
 	// constexpr int x = __builtin_abs(700) + __builtin_abs(50);
+	@Test
 	public void testBuiltinAbs() throws Exception {
 		assertEvaluationEquals(750);
 	}
 
 	// constexpr int x = __builtin_abs(-1);
+	@Test
 	public void testBuiltinAbsNegativeInput() throws Exception {
 		assertEvaluationEquals(1);
 	}
 
 	// constexpr int x = __builtin_abs(0xFFFFFFFF);
+	@Test
 	public void testBuiltinAbsNarrowing() throws Exception {
 		assertEvaluationEquals(1);
 	}
 
 	// constexpr int x = __builtin_clrsb(0xFFFFFFFF);
+	@Test
 	public void testBuiltinClrsb() throws Exception {
 		assertEvaluationEquals(31);
 	}
 
 	// constexpr int x = __builtin_clrsb(555);
+	@Test
 	public void testBuiltinClrsbPositive() throws Exception {
 		assertEvaluationEquals(21);
 	}
 
 	// constexpr int x = __builtin_clz(0x8000);
+	@Test
 	public void testBuiltinClz() throws Exception {
 		assertEvaluationEquals(16);
 	}
 
 	// constexpr int x = __builtin_clz(-17);
+	@Test
 	public void testBuiltinClzNegative() throws Exception {
 		assertEvaluationEquals(0);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/MemberFunctionTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/MemberFunctionTests.java
@@ -11,26 +11,18 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class MemberFunctionTests extends TestBase {
 	public static class NonIndexingTests extends MemberFunctionTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends MemberFunctionTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -46,6 +38,7 @@ public abstract class MemberFunctionTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testMemberFunctionCall() throws Exception {
 		assertEvaluationEquals(4);
 	}
@@ -63,6 +56,7 @@ public abstract class MemberFunctionTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testMemberFunctionWithImplicitThis() throws Exception {
 		assertEvaluationEquals(8);
 	}
@@ -81,6 +75,7 @@ public abstract class MemberFunctionTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testExternallyDefinedMemberFunction() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -100,6 +95,7 @@ public abstract class MemberFunctionTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPlusEqualsWithinMemberFunction() throws Exception {
 		assertEvaluationEquals(50);
 	}
@@ -116,6 +112,7 @@ public abstract class MemberFunctionTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testMemberAccessThroughThisPointer() throws Exception {
 		assertEvaluationEquals(40);
 	}
@@ -137,6 +134,7 @@ public abstract class MemberFunctionTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testNestedMemberFunctionCallsWithImplicitThis() throws Exception {
 		assertEvaluationEquals(8);
 	}
@@ -155,6 +153,7 @@ public abstract class MemberFunctionTests extends TestBase {
 	//	constexpr int f() { return s.getY(); }
 
 	//	constexpr int x = f();
+	@Test
 	public void testGlobalMemberFunctionCallFromConstexprFunction() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -171,6 +170,7 @@ public abstract class MemberFunctionTests extends TestBase {
 	//	constexpr S s{3, 5};
 
 	//	constexpr int x = s.getY();
+	@Test
 	public void testGlobalMemberFunctionCallFromGlobalConstexpr() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -191,6 +191,7 @@ public abstract class MemberFunctionTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testManualAddMemberFunction() throws Exception {
 		assertEvaluationEquals(15);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/MemberVariableTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/MemberVariableTests.java
@@ -11,26 +11,18 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class MemberVariableTests extends TestBase {
 	public static class NonIndexingTests extends MemberVariableTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends MemberVariableTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -42,6 +34,7 @@ public abstract class MemberVariableTests extends TestBase {
 	// }
 
 	//	constexpr auto x = f();
+	@Test
 	public void testIncrementOnCompositeValues() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -55,6 +48,7 @@ public abstract class MemberVariableTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testMemberAccessWithConstObject() throws Exception {
 		assertEvaluationEquals(7);
 	}
@@ -66,6 +60,7 @@ public abstract class MemberVariableTests extends TestBase {
 	//  constexpr int f() { return s.y; }
 
 	//	constexpr auto x = f();
+	@Test
 	public void testGlobalMemberAccessFromConstexprFunction() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -76,6 +71,7 @@ public abstract class MemberVariableTests extends TestBase {
 	//	constexpr S s{5, 6};
 
 	//	constexpr auto x = s.y;
+	@Test
 	public void testGlobalMemberAccessFromGlobalConstexpr() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -94,6 +90,7 @@ public abstract class MemberVariableTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testFieldDependsOnOtherField() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -112,6 +109,7 @@ public abstract class MemberVariableTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testMemberInitializationWithoutUserDefinedCtor() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -124,6 +122,7 @@ public abstract class MemberVariableTests extends TestBase {
 	//    }
 
 	//    constexpr int x = f();
+	@Test
 	public void testAccessOfStaticField() throws Exception {
 		assertEvaluationEquals(5);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/PointerTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/PointerTests.java
@@ -12,27 +12,18 @@
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
 import org.eclipse.cdt.internal.core.dom.parser.IntegralValue;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class PointerTests extends TestBase {
 	public static class NonIndexingTests extends PointerTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends PointerTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -44,6 +35,7 @@ public abstract class PointerTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testPointerArithmeticsPostFixIncr() throws Exception {
 		assertEvaluationEquals(7);
 	}
@@ -57,6 +49,7 @@ public abstract class PointerTests extends TestBase {
 	// }
 
 	// constexpr int x = f();
+	@Test
 	public void testPointerArithmeticsPostFixDecr() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -69,6 +62,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testDereferencingOfPointerToInvalidMemoryShouldFail() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -80,6 +74,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerArithmeticInDeclaration() throws Exception {
 		assertEvaluationEquals(7);
 	}
@@ -92,6 +87,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSubtractionOfPointersToSameArrayShouldYieldDistance() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -104,6 +100,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerAddition() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -116,6 +113,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerAdditionAndAssignment() throws Exception {
 		assertEvaluationEquals(7);
 	}
@@ -128,6 +126,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerSubtraction() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -140,6 +139,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerSubtractionAndAssignment() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -152,6 +152,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerDeclarationFromPointer() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -165,6 +166,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointersHaveSeparatePositions() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -177,6 +179,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerAdditionInDeclaration() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -189,6 +192,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerSubtractionInDeclaration() throws Exception {
 		assertEvaluationEquals(7);
 	}
@@ -201,6 +205,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testDereferencingOnePastTheEndPointerIsInvalid() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -214,6 +219,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testDereferencingIncrementedOnePastTheEndAndThenDecrementedBackInRageAgainPointerIsValid()
 			throws Exception {
 		assertEvaluationEquals(11);
@@ -228,6 +234,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testDereferencingIncrementedTWOPastTheEndAndThenDecrementedBackInRageAgainPointerIsInvalid()
 			throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
@@ -241,6 +248,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerWithNegativePositionIsInvalid() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -254,6 +262,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerThatOnceHasNegativePositionStaysInvalid() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -265,6 +274,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerDeclaredOnePastTheEndIsInvalid() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -277,6 +287,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerDeclaredOnePastTheEndAndThenDecrementedBackInRageAgainIsValid() throws Exception {
 		assertEvaluationEquals(11);
 	}
@@ -289,6 +300,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerDeclaredTwoPastTheEndAndThenDecrementedBackInRageAgainStaysInvalid() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -300,6 +312,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerDeclaredWithNegativePositionIsInvalid() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -312,6 +325,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPointerDelcaredWithNegativePositionStaysInvalid() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -325,6 +339,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testPointerAssignment() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -337,6 +352,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testPointerValueAssignment() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -352,6 +368,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testPointerToStructMember() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -364,6 +381,7 @@ public abstract class PointerTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testPointer() throws Exception {
 		assertEvaluationEquals(6);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/RangeBasedForStatementTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/RangeBasedForStatementTests.java
@@ -12,27 +12,18 @@
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
 import org.eclipse.cdt.internal.core.dom.parser.IntegralValue;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class RangeBasedForStatementTests extends TestBase {
 	public static class NonIndexingTests extends RangeBasedForStatementTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends RangeBasedForStatementTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -46,6 +37,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSimpleRangeBasedForLoop() throws Exception {
 		assertEvaluationEquals(26);
 	}
@@ -60,6 +52,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testReturnInRangeBasedForLoop() throws Exception {
 		assertEvaluationEquals(42);
 	}
@@ -77,6 +70,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testRangeBasedForLoopReferences() throws Exception {
 		assertEvaluationEquals(30);
 	}
@@ -97,6 +91,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPassReferenceObtainedFromRangeBasedForLoopToFunctionAndModify() throws Exception {
 		assertEvaluationEquals(30);
 	}
@@ -110,6 +105,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testRangeBasedForLoopWithNonCompoundBodyStatement() throws Exception {
 		assertEvaluationEquals(26);
 	}
@@ -123,6 +119,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testRangeBasedForLoopWithReturnInNonCompoundBodyStatement() throws Exception {
 		assertEvaluationEquals(42);
 	}
@@ -144,6 +141,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testRangeBasedForLoopOverCustomType() throws Exception {
 		assertEvaluationEquals(15);
 	}
@@ -172,6 +170,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testRangeBasedForLoopThatModifiesElementsInCustomType() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -196,6 +195,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testRangeBasedForLoopOverNonConstRangeChoosesNonConstBeginEnd() throws Exception {
 		assertEvaluationEquals(15);
 	}
@@ -220,6 +220,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testRangeBasedForLoopOverConstRangeChoosesConstBeginEnd() throws Exception {
 		assertEvaluationEquals(40);
 	}
@@ -245,6 +246,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testRangeBasedForLoopOverConstRefRangeChoosesConstBeginEnd() throws Exception {
 		assertEvaluationEquals(40);
 	}
@@ -266,6 +268,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testRangeBasedForLoopOverCustomTypeWithInvalidBeginMemberFunction() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -287,6 +290,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testRangeBasedForLoopOverCustomTypeWithBeginMemberFunctionWithDefaultParameterValue() throws Exception {
 		assertEvaluationEquals(15);
 	}
@@ -312,6 +316,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testDoesArgumentDependentLookupIfBeginEndMemberFunctionsDontExist() throws Exception {
 		assertEvaluationEquals(15);
 	}
@@ -340,6 +345,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testChoosesMemberFunctionsOverFreeFunctions() throws Exception {
 		assertEvaluationEquals(40);
 	}
@@ -365,6 +371,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testDoesntMixMemberFunctionsAndFreeFunctions() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -393,6 +400,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testWorksWithBeginEndTemplates() throws Exception {
 		assertEvaluationEquals(15);
 	}
@@ -406,6 +414,7 @@ public abstract class RangeBasedForStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testRangeBasedForLoopOverInitializerList() throws Exception {
 		assertEvaluationEquals(15);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/ReferenceTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/ReferenceTests.java
@@ -11,26 +11,18 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class ReferenceTests extends TestBase {
 	public static class NonIndexingTests extends ReferenceTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends ReferenceTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -42,6 +34,7 @@ public abstract class ReferenceTests extends TestBase {
 	//	}
 
 	// constexpr int x = f();
+	@Test
 	public void testSideEffectsOnReferences() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -54,6 +47,7 @@ public abstract class ReferenceTests extends TestBase {
 	//	}
 
 	// constexpr int x = f();
+	@Test
 	public void testAssignmentsOnReferences() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -67,6 +61,7 @@ public abstract class ReferenceTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testSideEffectsOnNestedReferences() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -80,6 +75,7 @@ public abstract class ReferenceTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testAssignmentOnNestedReferences() throws Exception {
 		assertEvaluationEquals(2);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/StructuredBindingTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/StructuredBindingTests.java
@@ -11,26 +11,18 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class StructuredBindingTests extends TestBase {
 	public static class NonIndexingTests extends StructuredBindingTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends StructuredBindingTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -41,6 +33,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testBindingFirstElementOfArray() throws Exception {
 		assertEvaluationEquals(8);
 	}
@@ -52,6 +45,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testBindingSecondElementOfArray() throws Exception {
 		assertEvaluationEquals(9);
 	}
@@ -63,6 +57,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testBindingOutOfBoundElementOfArray() throws Exception {
 		assertEvaluationProblem();
 	}
@@ -77,6 +72,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testBindingFirstMemberOfObject() throws Exception {
 		assertEvaluationEquals(42);
 	}
@@ -91,6 +87,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testBindingSecondMemberOfObject() throws Exception {
 		assertEvaluationEquals(5.0);
 	}
@@ -103,6 +100,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	auto [inherited] = s;
 
 	//	auto x = inherited;
+	@Test
 	public void testBindingInheritedMember() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -116,6 +114,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testBindingOutOfBoundElementOfObject() throws Exception {
 		assertEvaluationProblem();
 	}
@@ -126,6 +125,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = f();
+	@Test
 	public void testUninitializedStructuredBinding() throws Exception {
 		assertEvaluationProblem();
 	}
@@ -163,6 +163,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = foo();
+	@Test
 	public void testBindingOutOfTupleLikeObjectWithMemberGet() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -200,6 +201,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = foo();
+	@Test
 	public void testBindingOutOfTupleLikeObjectWithFreeGet() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -237,6 +239,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = foo();
+	@Test
 	public void testBindingOutOfTupleLikeObjectWithTooFewElements() throws Exception {
 		assertEvaluationProblem();
 	}
@@ -274,6 +277,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = foo();
+	@Test
 	public void testBindingOutOfTupleLikeObjectWithTooManyElements() throws Exception {
 		assertEvaluationProblem();
 	}
@@ -311,6 +315,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = foo();
+	@Test
 	public void testBindingOutOfTupleLikeValueMemberIsStaticConst() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -348,6 +353,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = foo();
+	@Test
 	public void testBindingOutOfTupleLikeValueMemberIsNonConstexpr() throws Exception {
 		assertEvaluationProblem();
 	}
@@ -385,6 +391,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = foo();
+	@Test
 	public void testBindingOutOfTupleLikeValueMemberIsNonStatic() throws Exception {
 		assertEvaluationProblem();
 	}
@@ -422,6 +429,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = foo();
+	@Test
 	public void testBindingOutOfTupleLikeValueMemberIsNonIntegral() throws Exception {
 		assertEvaluationProblem();
 	}
@@ -462,6 +470,7 @@ public abstract class StructuredBindingTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = foo();
+	@Test
 	public void testBindingOutOfTupleLikeValueMemberWithNonConstexprInitialization() throws Exception {
 		assertEvaluationProblem();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/SwitchStatementTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/SwitchStatementTests.java
@@ -11,26 +11,18 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class SwitchStatementTests extends TestBase {
 	public static class NonIndexingTests extends SwitchStatementTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends SwitchStatementTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -47,6 +39,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSwitchFirstCase() throws Exception {
 		assertEvaluationEquals(1);
 	}
@@ -64,6 +57,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSwitchMiddleCase() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -81,6 +75,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSwitchDefault() throws Exception {
 		assertEvaluationEquals(-1);
 	}
@@ -97,6 +92,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSwitchFallThrough() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -112,6 +108,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSwitchWithOnlyOneClause1() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -127,6 +124,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSwitchWithOnlyOneClause2() throws Exception {
 		assertEvaluationEquals(9);
 	}
@@ -148,6 +146,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSwitchBreak() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -167,6 +166,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSwitchNoMatchingCaseAndNoDefault() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -194,6 +194,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSwitchCaseConstants() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -215,6 +216,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(5);
+	@Test
 	public void testDeclarationInSwitchStatementController() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -232,6 +234,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(BLUE);
+	@Test
 	public void testSwitchOnEnumValue() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -253,6 +256,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testSwitchWithNestedContinueStatement() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -274,6 +278,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(5);
+	@Test
 	public void testDeclarationInSwitchInitStatement() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -295,6 +300,7 @@ public abstract class SwitchStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(5);
+	@Test
 	public void testDeclarationInSwitchStatementControllerEmptyInit() throws Exception {
 		assertEvaluationEquals(3);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/TestBase.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/TestBase.java
@@ -11,6 +11,11 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/TypeAliasTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/TypeAliasTests.java
@@ -11,16 +11,12 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class TypeAliasTests extends TestBase {
 	public static class NonIndexingTests extends TypeAliasTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
-		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
 		}
 	}
 
@@ -29,9 +25,6 @@ public abstract class TypeAliasTests extends TestBase {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
 		}
 
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
-		}
 	}
 
 	//	constexpr int f() {
@@ -42,6 +35,7 @@ public abstract class TypeAliasTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testTypedefDeclaration() throws Exception {
 		assertEvaluationEquals(25);
 	}
@@ -54,6 +48,7 @@ public abstract class TypeAliasTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testAliasDeclaration() throws Exception {
 		assertEvaluationEquals(25);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/UnaryExpressionTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/UnaryExpressionTests.java
@@ -11,26 +11,18 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class UnaryExpressionTests extends TestBase {
 	public static class NonIndexingTests extends UnaryExpressionTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends UnaryExpressionTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -41,6 +33,7 @@ public abstract class UnaryExpressionTests extends TestBase {
 	// }
 
 	// constexpr int x = doubleIncrement(0);
+	@Test
 	public void testSimpleSequence() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -53,6 +46,7 @@ public abstract class UnaryExpressionTests extends TestBase {
 	// }
 
 	// constexpr int x = function();
+	@Test
 	public void testAssignmentWithPostfixIncrSideEffects() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -65,6 +59,7 @@ public abstract class UnaryExpressionTests extends TestBase {
 	// }
 
 	// constexpr int x = function();
+	@Test
 	public void testAssignmentWithPostfixDecrSideEffects() throws Exception {
 		assertEvaluationEquals(-2);
 	}
@@ -77,6 +72,7 @@ public abstract class UnaryExpressionTests extends TestBase {
 	// }
 
 	// constexpr int x = function();
+	@Test
 	public void testAssignmentWithPrefixDecrSideEffects() throws Exception {
 		assertEvaluationEquals(-2);
 	}
@@ -89,6 +85,7 @@ public abstract class UnaryExpressionTests extends TestBase {
 	// }
 
 	// constexpr int x = function();
+	@Test
 	public void testAssignmentWithPrefixIncrSideEffects() throws Exception {
 		assertEvaluationEquals(2);
 	}
@@ -99,6 +96,7 @@ public abstract class UnaryExpressionTests extends TestBase {
 	// }
 
 	// constexpr int x = function();
+	@Test
 	public void testPostfixIncrSemantics() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -109,6 +107,7 @@ public abstract class UnaryExpressionTests extends TestBase {
 	// }
 
 	// constexpr int x = function();
+	@Test
 	public void testPostfixDecrSemantics() throws Exception {
 		assertEvaluationEquals(0);
 	}
@@ -119,6 +118,7 @@ public abstract class UnaryExpressionTests extends TestBase {
 	// }
 
 	// constexpr int x = function();
+	@Test
 	public void testPrefixIncrSemantics() throws Exception {
 		assertEvaluationEquals(1);
 	}
@@ -129,6 +129,7 @@ public abstract class UnaryExpressionTests extends TestBase {
 	// }
 
 	// constexpr int x = function();
+	@Test
 	public void testPrefixDecrSemantics() throws Exception {
 		assertEvaluationEquals(-1);
 	}
@@ -140,6 +141,7 @@ public abstract class UnaryExpressionTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPrefixIncrementReturnsLvalue() throws Exception {
 		assertEvaluationEquals(4);
 	}
@@ -153,6 +155,7 @@ public abstract class UnaryExpressionTests extends TestBase {
 	//	constexpr BooleanConvertible variable{true};
 
 	//	constexpr bool actual = !variable;
+	@Test
 	public void testContextualConversionInNot_506972() throws Exception {
 		assertEvaluationEquals(false);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/UnaryOperatorOverloadingTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/UnaryOperatorOverloadingTests.java
@@ -11,26 +11,18 @@
 *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class UnaryOperatorOverloadingTests extends TestBase {
 	public static class NonIndexingTests extends UnaryOperatorOverloadingTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends UnaryOperatorOverloadingTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -53,6 +45,7 @@ public abstract class UnaryOperatorOverloadingTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPrefixIncrementAsMemberFunction() throws Exception {
 		assertEvaluationEquals(6);
 	}
@@ -80,6 +73,7 @@ public abstract class UnaryOperatorOverloadingTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f();
+	@Test
 	public void testPrefixIncrementAsNonMemberFunction() throws Exception {
 		assertEvaluationEquals(6);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/UserDefinedLiteralTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/UserDefinedLiteralTests.java
@@ -12,27 +12,18 @@
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
 import org.eclipse.cdt.internal.core.dom.parser.IntegralValue;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class UserDefinedLiteralTests extends TestBase {
 	public static class NonIndexingTests extends UserDefinedLiteralTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends UserDefinedLiteralTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -41,6 +32,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = 25_min;
+	@Test
 	public void testUserDefinedIntegerLiteral() throws Exception {
 		assertEvaluationEquals(1500);
 	}
@@ -56,6 +48,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = "HAllO"_capitals;
+	@Test
 	public void testUserDefinedStringLiteral() throws Exception {
 		assertEvaluationEquals(3);
 	}
@@ -74,6 +67,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = 'a'_v;
+	@Test
 	public void testUserDefinedCharacterLiteral() throws Exception {
 		assertEvaluationEquals(true);
 	}
@@ -83,6 +77,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = 100.0_deg;
+	@Test
 	public void testUserDefinedFloatingPointLiteral() throws Exception {
 		assertEvaluationEquals(1.74533);
 	}
@@ -96,6 +91,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr auto x = 20000_l;
+	@Test
 	public void testFallbackToRawLiteralOperator() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -106,6 +102,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr int x = 123.20_l;
+	@Test
 	public void testRawLiteralOperatorTemplate() throws Exception {
 		assertEvaluationEquals(5);
 	}
@@ -118,6 +115,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr int x = 120_l;
+	@Test
 	public void testChoosesCookedLiteralOverRawLiteralOperatorIfAvailable() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -131,6 +129,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr int x = 120_l;
+	@Test
 	public void testChoosesCookedLiteralOverRawLiteralTemplateIfAvailable() throws Exception {
 		assertEvaluationEquals(10);
 	}
@@ -143,6 +142,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr int x = 120_l;
+	@Test
 	public void testFallsBackToRawLiteralOperatorIfParameterTypeDoesntMatchUnsignedLongLong() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -156,6 +156,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr int x = 120_l;
+	@Test
 	public void testFallsBackToRawLiteralOperatorTemplateIfParameterTypeDoesntMatchUnsignedLongLong() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -168,6 +169,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr int x = 120.0_l;
+	@Test
 	public void testFallsBackToRawLiteralOperatorIfParameterTypeDoesntMatchLongDouble() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -181,6 +183,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr int x = 120.0_l;
+	@Test
 	public void testFallsBackToRawLiteralOperatorTemplateIfParameterTypeDoesntMatchLongDouble() throws Exception {
 		assertEvaluationEquals(20);
 	}
@@ -190,6 +193,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr int x = "hello"_l;
+	@Test
 	public void testIgnoresRawLiteralOperatorForUserDefinedStringLiterals() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -200,6 +204,7 @@ public abstract class UserDefinedLiteralTests extends TestBase {
 	//	}
 
 	//	constexpr int x = "hello"_l;
+	@Test
 	public void testIgnoresRawLiteralOperatorTemplateForUserDefinedStringLiterals() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/WhileStatementTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx14/constexpr/WhileStatementTests.java
@@ -12,27 +12,18 @@
 package org.eclipse.cdt.core.parser.tests.ast2.cxx14.constexpr;
 
 import org.eclipse.cdt.internal.core.dom.parser.IntegralValue;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class WhileStatementTests extends TestBase {
 	public static class NonIndexingTests extends WhileStatementTests {
 		public NonIndexingTests() {
 			setStrategy(new NonIndexingTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(NonIndexingTests.class);
-		}
 	}
 
 	public static class SingleProjectTests extends WhileStatementTests {
 		public SingleProjectTests() {
 			setStrategy(new SinglePDOMTestStrategy(true, false));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTests.class);
 		}
 	}
 
@@ -46,6 +37,7 @@ public abstract class WhileStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f(10);
+	@Test
 	public void testWhileLoopWithConditionalExpression() throws Exception {
 		assertEvaluationEquals(55);
 	}
@@ -60,6 +52,7 @@ public abstract class WhileStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f(10);
+	@Test
 	public void testEvalShouldAbortOnWhileWitInfiniteLoop() throws Exception {
 		assertEvaluationEquals(IntegralValue.ERROR);
 	}
@@ -74,6 +67,7 @@ public abstract class WhileStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f(10);
+	@Test
 	public void testReturnInWhileStatement() throws Exception {
 		assertEvaluationEquals(42);
 	}
@@ -86,6 +80,7 @@ public abstract class WhileStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f(10);
+	@Test
 	public void testWhileLoopWithNonCompoundBodyStatement() throws Exception {
 		assertEvaluationEquals(55);
 	}
@@ -98,6 +93,7 @@ public abstract class WhileStatementTests extends TestBase {
 	// }
 
 	// constexpr int x = f(10);
+	@Test
 	public void testWhileLoopWithReturnInNonCompoundBodyStatement() throws Exception {
 		assertEvaluationEquals(42);
 	}
@@ -114,6 +110,7 @@ public abstract class WhileStatementTests extends TestBase {
 	//	}
 
 	//	constexpr int x = f(4);
+	@Test
 	public void testDeclarationInWhileStatementCondition1() throws Exception {
 		assertEvaluationEquals(30);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/CXX17ExtensionsTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/CXX17ExtensionsTests.java
@@ -9,15 +9,9 @@
 package org.eclipse.cdt.core.parser.tests.ast2.cxx17;
 
 import org.eclipse.cdt.core.parser.tests.ast2.AST2CPPTestBase;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class CXX17ExtensionsTests extends AST2CPPTestBase {
-
-	public static TestSuite suite() {
-		return suite(CXX17ExtensionsTests.class);
-	}
-
 	//	struct Base {
 	//		  int foo;
 	//		};
@@ -28,6 +22,7 @@ public class CXX17ExtensionsTests extends AST2CPPTestBase {
 	//		int main() {
 	//		  MyStruct test = { {0}, 9 };
 	//		}
+	@Test
 	public void testAggregateInitializationOfBaseClass_549367() throws Exception {
 		parseAndCheckImplicitNameBindings();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/DeductionGuideTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/DeductionGuideTest.java
@@ -16,6 +16,7 @@ package org.eclipse.cdt.core.parser.tests.ast2.cxx17;
 import static org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes.char_;
 import static org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes.double_;
 import static org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes.int_;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.cdt.core.dom.ast.IPointerType;
 import org.eclipse.cdt.core.dom.ast.IProblemType;
@@ -23,6 +24,7 @@ import org.eclipse.cdt.core.dom.ast.IType;
 import org.eclipse.cdt.core.dom.ast.IVariable;
 import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.core.parser.tests.ast2.AST2CPPTestBase;
+import org.junit.jupiter.api.Test;
 
 /**
  * AST tests for C++17 deduction guides.
@@ -52,6 +54,7 @@ public class DeductionGuideTest extends AST2CPPTestBase {
 	//    S init{ddouble};
 	//    S convert(ddouble);
 	//  }
+	@Test
 	public void testDeductionGuideBasic() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper(ParserLanguage.CPP, ScannerKind.STD);
 		assertType(bh.assertNonProblem("dchar = S", 5), char_);
@@ -84,6 +87,7 @@ public class DeductionGuideTest extends AST2CPPTestBase {
 	//    double dv = S<double>(1).value;
 	//    int iv = S(1).value;
 	//  }
+	@Test
 	public void testDeductionGuideWithDefaultTemplateArg() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper(ParserLanguage.CPP, ScannerKind.STD);
 		assertType(bh.assertNonProblem("dchar = S", 5), char_);
@@ -106,6 +110,7 @@ public class DeductionGuideTest extends AST2CPPTestBase {
 	//    S init{ddouble};
 	//    S convert(ddouble);
 	//  }
+	@Test
 	public void testDeductionGuideWithTemplateDeclaration() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper(ParserLanguage.CPP, ScannerKind.STD);
 
@@ -130,6 +135,7 @@ public class DeductionGuideTest extends AST2CPPTestBase {
 	//
 	//  UniquePtr dp{new auto(2.0)};
 	//  auto da = dp;
+	@Test
 	public void testMinimal() throws Exception {
 		parseAndCheckBindings(ScannerKind.STD);
 	}
@@ -145,6 +151,7 @@ public class DeductionGuideTest extends AST2CPPTestBase {
 	//  S() -> S<int>;
 	//
 	//  S s2;
+	@Test
 	public void testDeduceFromEmptyInitializer() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper(ParserLanguage.CPP, ScannerKind.STD);
 		IVariable varSInt = bh.assertNonProblem("sInt", 4);
@@ -164,6 +171,7 @@ public class DeductionGuideTest extends AST2CPPTestBase {
 	//  S(int i) -> S<double>;
 	//
 	//  auto v = S(1);
+	@Test
 	public void testViaFunctionSetFromConstructors() throws Exception {
 		parseAndCheckBindings(ScannerKind.STD);
 	}
@@ -171,6 +179,7 @@ public class DeductionGuideTest extends AST2CPPTestBase {
 	//  template<class T> struct S{};
 	//
 	//  S* pointer;
+	@Test
 	public void testNoDeductionForPointer() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper(ParserLanguage.CPP, ScannerKind.STD);
 		IType pointedType = ((IPointerType) ((IVariable) bh.assertNonProblem("pointer")).getType()).getType();
@@ -181,6 +190,7 @@ public class DeductionGuideTest extends AST2CPPTestBase {
 	//  template<class T> struct S;
 	//
 	//  S* pointer;
+	@Test
 	public void testNoDeductionForPointerNoDefinition() throws Exception {
 		BindingAssertionHelper bh = getAssertionHelper(ParserLanguage.CPP, ScannerKind.STD);
 		IType pointedType = ((IPointerType) ((IVariable) bh.assertNonProblem("pointer")).getType()).getType();

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/FoldExpressionTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/FoldExpressionTests.java
@@ -22,6 +22,7 @@ import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTFoldExpression;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTTemplateDeclaration;
 import org.eclipse.cdt.core.parser.tests.ast2.AST2CPPTestBase;
+import org.junit.jupiter.api.Test;
 
 /**
  * AST tests for C++17 fold expressions.
@@ -46,6 +47,7 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//	static constexpr auto val2 = f2(1, 2., "12");
 	//	static constexpr auto val3 = f3(1, 2., "123");
 	//	static constexpr auto val4 = f4(1, 2., "1234");
+	@Test
 	public void testFoldExpression1() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -70,6 +72,7 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//	static constexpr auto val3 = f3();
 	//	static constexpr auto val41 = f4(false);
 	//	static constexpr auto val42 = f4(true);
+	@Test
 	public void testFoldExpression2() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -87,6 +90,7 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//    ((... + tp) + ... + sp);
 	//    (sp + ... + tp);
 	//  }
+	@Test
 	public void testFoldExpressionNested() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -107,6 +111,7 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//	    ostream<char> out;
 	//	    out << (... + vals) << endl;
 	//	}
+	@Test
 	public void testFoldExpressionInBinaryExpression() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -115,6 +120,7 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//  void sum(T... vals) {
 	//      bar(... + vals);
 	//  }
+	@Test
 	public void testFoldExpressionRecognition1() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.STD, false);
@@ -127,6 +133,7 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//  void sum(T... vals) {
 	//      ... + vals;
 	//  }
+	@Test
 	public void testFoldExpressionRecognition2() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.STD, false);
@@ -140,6 +147,7 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//      (++vals + ...);
 	//      ((2*vals) + ...);
 	//  }
+	@Test
 	public void testFoldExpressionRecognitionSuccess() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.STD, false);
@@ -166,6 +174,7 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//      (1 * 2 + ... + vals);
 	//      (...);
 	//  }
+	@Test
 	public void testFoldExpressionErrors() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.STD, false);
@@ -180,6 +189,7 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//  void f(T... vals) {
 	//      (... <=> vals);
 	//  }
+	@Test
 	public void testFoldExpressionDisallowedOpToken() throws Exception {
 		final String code = getAboveComment();
 		IASTTranslationUnit tu = parse(code, CPP, ScannerKind.STDCPP20, false);
@@ -202,6 +212,7 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//  };
 	//
 	//  constexpr bool result = fold_condition<int, double>::value;
+	@Test
 	public void testFoldExpressionInClassTemplateArguments() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("result", 1);
@@ -219,6 +230,7 @@ public class FoldExpressionTests extends AST2CPPTestBase {
 	//  };
 	//
 	//  constexpr bool result = fold_condition<int, double>::value;
+	@Test
 	public void testFoldExpressionInVariableTemplateArguments() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		helper.assertVariableValue("result", 1);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/LambdaExpressionTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/LambdaExpressionTests.java
@@ -15,6 +15,7 @@
 package org.eclipse.cdt.core.parser.tests.ast2.cxx17;
 
 import org.eclipse.cdt.core.parser.tests.ast2.AST2CPPTestBase;
+import org.junit.jupiter.api.Test;
 
 /**
  * AST tests for C++17 lambda changes.
@@ -25,6 +26,7 @@ public class LambdaExpressionTests extends AST2CPPTestBase {
 	// 		[*this] { }();
 	// 	}
 	// };
+	@Test
 	public void testLambdaCaptures_535196_1() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -36,6 +38,7 @@ public class LambdaExpressionTests extends AST2CPPTestBase {
 	// 		[*this] { bar(); }();
 	// 	}
 	// };
+	@Test
 	public void testLambdaCaptures_535196_2() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -47,6 +50,7 @@ public class LambdaExpressionTests extends AST2CPPTestBase {
 	// 		[m = 3, *this] { bar(m); }();
 	// 	}
 	// };
+	@Test
 	public void testLambdaCaptures_535196_3() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -55,6 +59,7 @@ public class LambdaExpressionTests extends AST2CPPTestBase {
 	//	auto f = []() constexpr {return 2;};
 	//	return 0;
 	//}
+	@Test
 	public void testLambdaConstexpr_560483() throws Exception {
 		parseAndCheckBindings();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/StructuredBindingIndexTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/StructuredBindingIndexTests.java
@@ -21,6 +21,7 @@ import static org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes.int_;
 import org.eclipse.cdt.core.dom.ast.IType;
 import org.eclipse.cdt.core.dom.ast.IVariable;
 import org.eclipse.cdt.internal.index.tests.IndexBindingResolutionTestBase;
+import org.junit.jupiter.api.Test;
 
 public class StructuredBindingIndexTests extends IndexBindingResolutionTestBase {
 	public StructuredBindingIndexTests() {
@@ -32,6 +33,7 @@ public class StructuredBindingIndexTests extends IndexBindingResolutionTestBase 
 	//} s{};
 
 	//auto [z] = s;
+	@Test
 	public void testLocalStructuredBindingFromMemberOfBasicType() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -44,6 +46,7 @@ public class StructuredBindingIndexTests extends IndexBindingResolutionTestBase 
 	//auto [z] = s;
 
 	//auto x = z;
+	@Test
 	public void testExternalStructuredBindingFromMemberOfBasicType() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -58,6 +61,7 @@ public class StructuredBindingIndexTests extends IndexBindingResolutionTestBase 
 
 	//auto [z] = s;
 	//T localT{};
+	@Test
 	public void testLocalStructuredBindingFromMemberOfUserDefinedType() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -79,6 +83,7 @@ public class StructuredBindingIndexTests extends IndexBindingResolutionTestBase 
 
 	//auto x = z;
 	//T localT{};
+	@Test
 	public void testExternalStructuredBindingFromMemberOfUserDefinedType() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -106,6 +111,7 @@ public class StructuredBindingIndexTests extends IndexBindingResolutionTestBase 
 
 	//auto [t, i, d, c] = s;
 	//T localT{};
+	@Test
 	public void testMultipleVariablesInStructuredBindingFromMembers() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -135,6 +141,7 @@ public class StructuredBindingIndexTests extends IndexBindingResolutionTestBase 
 
 	//auto [t, i, d, c] = s;
 	//T localT{};
+	@Test
 	public void testMultipleVariablesDeepBaseStructure() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -156,6 +163,7 @@ public class StructuredBindingIndexTests extends IndexBindingResolutionTestBase 
 	//} s{};
 
 	//auto [i, d] = s;
+	@Test
 	public void testStaticFieldsAreNotConsidered() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -184,6 +192,7 @@ public class StructuredBindingIndexTests extends IndexBindingResolutionTestBase 
 	//}
 
 	//auto [f, s, t] = std::array<int, 3>{1, 2, 3};
+	@Test
 	public void testStandardArray() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -230,6 +239,7 @@ public class StructuredBindingIndexTests extends IndexBindingResolutionTestBase 
 	//}
 
 	//auto [a, b] = std::pair<int, double>{42, 3.14};
+	@Test
 	public void testRecursiveTupleElement() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -267,6 +277,7 @@ public class StructuredBindingIndexTests extends IndexBindingResolutionTestBase 
 	//    auto sum = firstX + secondX;
 	//  }
 	//}
+	@Test
 	public void testStandardArrayInLoop() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 
@@ -286,6 +297,7 @@ public class StructuredBindingIndexTests extends IndexBindingResolutionTestBase 
 	//void X::fun() {
 	//  auto [f, s] = *this;
 	//}
+	@Test
 	public void testBindStarThis() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/StructuredBindingTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/StructuredBindingTests.java
@@ -26,6 +26,8 @@ import static org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes.referenceToI
 import static org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes.rvalueReferenceTo;
 import static org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes.rvalueReferenceToInt;
 import static org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes.volatileOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.eclipse.cdt.core.dom.ast.IASTImplicitName;
 import org.eclipse.cdt.core.dom.ast.IBinding;
@@ -38,6 +40,7 @@ import org.eclipse.cdt.internal.core.dom.parser.FloatingPointValue;
 import org.eclipse.cdt.internal.core.dom.parser.IntegralValue;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPStructuredBindingComposite;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPEvaluation;
+import org.junit.jupiter.api.Test;
 
 public class StructuredBindingTests extends AST2CPPTestBase {
 
@@ -48,6 +51,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//auto [f1, s1] = S{1, 2};
 	//auto f2 = f1;
 	//auto s2 = s1;
+	@Test
 	public void testFromTemporary() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -69,6 +73,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//  return {1, 2};
 	//}
 	//auto [f, s] = createS();
+	@Test
 	public void testFromReturnValue() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -85,6 +90,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//  return {1, 2};
 	//}
 	//auto [f, s]{createS()};
+	@Test
 	public void testBracedInitialization() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -101,6 +107,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//  return {1, 2};
 	//}
 	//auto [f, s](createS());
+	@Test
 	public void testCopyInitialization() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -117,6 +124,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//  char fifth;
 	//};
 	//auto [f, s, t, fo, fif] = S{1, 2, 1.5f, 3.1415, '*'};
+	@Test
 	public void testWithManyInitializers() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -135,6 +143,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//  static double sd;
 	//};
 	//auto [b] = Sub{1};
+	@Test
 	public void testWithBaseClass() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -145,6 +154,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//auto f() -> int(&)[2];
 	//auto [x, y] = f();
 	//auto & [xr, yr] = f();
+	@Test
 	public void testStandardExample1() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -159,6 +169,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//};
 	//S createS();
 	//auto const [x, y] = createS();
+	@Test
 	public void testStandardExample2() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -169,6 +180,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 
 	//int arr[]{1, 2, 3};
 	//auto [f, s, t] = arr;
+	@Test
 	public void testFromArray() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -182,6 +194,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//  int i;
 	//} s{};
 	//auto && [f] = s;
+	@Test
 	public void testForwardingReferenceWithLvalue() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -193,6 +206,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//  int i;
 	//} s{};
 	//auto && [f] = static_cast<S&&>(s);
+	@Test
 	public void testForwardingReferenceWithXvalue() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -204,6 +218,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//  int i;
 	//};
 	//auto && [f] = S{};
+	@Test
 	public void testForwardingReferenceWithRvalue() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -221,6 +236,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//  struct tuple_size;
 	//}
 	//auto [f, s] = S{};
+	@Test
 	public void testUnspecializedTupleSizeTemplate() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -270,6 +286,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//  };
 	//}
 	//auto [f, s] = S{};
+	@Test
 	public void testFromTupleLikeDecompositionWithMemberGet() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -319,6 +336,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//  };
 	//}
 	//auto [f, s] = S{};
+	@Test
 	public void testFromTupleLikeDecompositionWithInheritedTupleElementType() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -348,6 +366,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//S volatile sVolatile{1};
 	//auto & [lrefLVolatilearg] = sVolatile;
 	//auto && [frefLVolatilearg] = sVolatile;
+	@Test
 	public void testResultingTypes() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -382,6 +401,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//    return field2;
 	//  }
 	//};
+	@Test
 	public void testThisDecomposition() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -398,6 +418,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//  return S{1, 2.0};
 	//}
 	//auto [f, s] = createS();
+	@Test
 	public void testIVariablePropertiesOfImplicitNameForInitializer() throws Exception {
 		parseAndCheckBindings();
 		BindingAssertionHelper helper = getAssertionHelper();
@@ -419,6 +440,7 @@ public class StructuredBindingTests extends AST2CPPTestBase {
 	//void f() {
 	//  auto& [x] = x.y;
 	//}
+	@Test
 	public void testInvalidReferenceToIntroducedName() throws Exception {
 		BindingAssertionHelper ba = getAssertionHelper();
 		ba.assertProblem("x.y;", 1);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/TemplateAutoIndexTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/TemplateAutoIndexTests.java
@@ -13,9 +13,12 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.ast2.cxx17;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.eclipse.cdt.core.dom.ast.IType;
 import org.eclipse.cdt.core.dom.ast.IVariable;
 import org.eclipse.cdt.internal.index.tests.IndexBindingResolutionTestBase;
+import org.junit.jupiter.api.Test;
 
 public class TemplateAutoIndexTests extends IndexBindingResolutionTestBase {
 	public TemplateAutoIndexTests() {
@@ -43,6 +46,7 @@ public class TemplateAutoIndexTests extends IndexBindingResolutionTestBase {
 	//
 	//	using A = call_helper<&Something::foo>::type;
 	//	auto waldo = A::call();
+	@Test
 	public void testTemplateAutoIndex() throws Exception {
 		BindingAssertionHelper helper = getAssertionHelper();
 		IVariable variable = helper.assertNonProblem("waldo");

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/TemplateAutoTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/TemplateAutoTests.java
@@ -14,14 +14,9 @@
 package org.eclipse.cdt.core.parser.tests.ast2.cxx17;
 
 import org.eclipse.cdt.core.parser.tests.ast2.AST2CPPTestBase;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class TemplateAutoTests extends AST2CPPTestBase {
-
-	public static TestSuite suite() {
-		return suite(TemplateAutoTests.class);
-	}
 
 	//	template<auto F>
 	//	struct C {
@@ -33,6 +28,7 @@ public class TemplateAutoTests extends AST2CPPTestBase {
 	//	}
 	//
 	//	using A = C<&foo>::T;
+	@Test
 	public void testTemplateNontypeParameterTypeDeductionParsing_519361() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -47,6 +43,7 @@ public class TemplateAutoTests extends AST2CPPTestBase {
 	//		using T = decltype(F);
 	//		using H = Helper<T>;
 	//	};
+	@Test
 	public void testTemplateNontypeParameterTypeDeductionParsing_519361_2() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -72,6 +69,7 @@ public class TemplateAutoTests extends AST2CPPTestBase {
 	//		using A = call_helper<&Something::foo>::type;
 	//		A::call();
 	//	}
+	@Test
 	public void testTemplateNontypeParameterTypeDeductionParsing_519361_3() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -105,6 +103,7 @@ public class TemplateAutoTests extends AST2CPPTestBase {
 	//	    int foo;
 	//	};
 	//	typedef M<W<&B::foo>::type> M2; // typedef #2
+	@Test
 	public void testInstantiationCacheConflict_553141() throws Exception {
 		parseAndCheckBindings();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/TemplateTemplateTypenameTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx17/TemplateTemplateTypenameTests.java
@@ -14,18 +14,14 @@
 package org.eclipse.cdt.core.parser.tests.ast2.cxx17;
 
 import org.eclipse.cdt.core.parser.tests.ast2.AST2CPPTestBase;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class TemplateTemplateTypenameTests extends AST2CPPTestBase {
-
-	public static TestSuite suite() {
-		return suite(TemplateTemplateTypenameTests.class);
-	}
 
 	// template<template<typename> typename T>
 	// void f(T<int> param) {
 	// }
+	@Test
 	public void testFunctionTemplateWithTemplateTemplateParameterWithTypenameInsteadOfClass_537217() throws Exception {
 		parseAndCheckBindings();
 	}
@@ -34,6 +30,7 @@ public class TemplateTemplateTypenameTests extends AST2CPPTestBase {
 	// class C {
 	//     U<int> mem;
 	// };
+	@Test
 	public void testClassTemplateWithTemplateTemplateParameterWithTypenameInsteadOfClass_537217() throws Exception {
 		parseAndCheckBindings();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx20/CXX20CharacterTypes.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx20/CXX20CharacterTypes.java
@@ -15,22 +15,19 @@ import org.eclipse.cdt.core.parser.tests.ast2.AST2CPPTestBase;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPBasicType;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPPointerType;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPQualifierType;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class CXX20CharacterTypes extends AST2CPPTestBase {
 
-	public static TestSuite suite() {
-		return suite(CXX20CharacterTypes.class);
-	}
-
 	//	char  test_char;
 	//	char8_t  test_char8_t;
+	@Test
 	public void testCxx20CharacterTypes() throws Exception {
 		parseAndCheckBindings(ScannerKind.STDCPP20);
 	}
 
 	// auto u8 = u8"";
+	@Test
 	public void testStringLiteralPrefixChar8t() throws Exception {
 		IType eChar8 = createStringType(Kind.eChar8);
 

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx20/ConceptsTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/cxx20/ConceptsTests.java
@@ -14,6 +14,7 @@
 package org.eclipse.cdt.core.parser.tests.ast2.cxx20;
 
 import org.eclipse.cdt.core.parser.tests.ast2.AST2CPPTestBase;
+import org.junit.jupiter.api.Test;
 
 /**
  * AST tests for C++20 requires expressions.
@@ -29,6 +30,7 @@ public class ConceptsTests extends AST2CPPTestBase {
 	//  concept C = requires {
 	//      true;
 	//  };
+	@Test
 	public void testConceptDefinitionExpressions() throws Exception {
 		parseAndCheckBindings(ScannerKind.STDCPP20);
 	}
@@ -43,6 +45,7 @@ public class ConceptsTests extends AST2CPPTestBase {
 	//
 	//  template<typename T>
 	//  void z() requires true && false;
+	@Test
 	public void testFunctionDeclarationTrailingRequiresClauseTrue() throws Exception {
 		parseAndCheckBindings(ScannerKind.STDCPP20);
 	}
@@ -62,6 +65,7 @@ public class ConceptsTests extends AST2CPPTestBase {
 	//
 	//  template<typename T>
 	//  void x_abc() requires A<T> || B<T> && C<T> {}
+	@Test
 	public void testFunctionDefinitionTrailingRequiresClause() throws Exception {
 		parseAndCheckBindings(ScannerKind.STDCPP20);
 	}
@@ -76,6 +80,7 @@ public class ConceptsTests extends AST2CPPTestBase {
 	//  template<typename T>
 	//  requires A<T> || B<T> && C<T>
 	//  void x() {}
+	@Test
 	public void testTemplateHeadRequiresClause() throws Exception {
 		parseAndCheckBindings(ScannerKind.STDCPP20);
 	}
@@ -83,12 +88,14 @@ public class ConceptsTests extends AST2CPPTestBase {
 	//  template<typename T>
 	//  requires requires { true; }
 	//  void x() {}
+	@Test
 	public void testTemplateHeadAdHocRequiresExpression() throws Exception {
 		parseAndCheckBindings(ScannerKind.STDCPP20);
 	}
 
 	//  template<typename T>
 	//  constexpr bool value = requires () { true; };
+	@Test
 	public void testInitializerRequiresExpression() throws Exception {
 		parseAndCheckBindings(ScannerKind.STDCPP20);
 	}
@@ -101,6 +108,7 @@ public class ConceptsTests extends AST2CPPTestBase {
 	//			return false;
 	//		}
 	//	}
+	@Test
 	public void testConstexprIfRequiresExpression() throws Exception {
 		parseAndCheckBindings(ScannerKind.STDCPP20);
 	}
@@ -116,6 +124,7 @@ public class ConceptsTests extends AST2CPPTestBase {
 	//  void f_a(U a_u);
 	//  template<A U1, B U2, C U3>
 	//  void f_abc(U1 a_u1, U2 b_u2, U3 c_u3);
+	@Test
 	public void testTemplateArgumentTypeConstraint() throws Exception {
 		parseAndCheckBindings(ScannerKind.STDCPP20);
 	}
@@ -133,6 +142,7 @@ public class ConceptsTests extends AST2CPPTestBase {
 	//
 	//  template<A U1, Outer::B U2, Outer::Inner::C U3>
 	//  void f_abc(U1 a_u1, U2 b_u2, U3 c_u3);
+	@Test
 	public void testTemplateArgumentTypeConstraintFromNamespace() throws Exception {
 		parseAndCheckBindings(ScannerKind.STDCPP20);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/scannerinfo/ExtendedScannerInfoSerializerDeserializerTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/scannerinfo/ExtendedScannerInfoSerializerDeserializerTest.java
@@ -11,10 +11,10 @@
 
 package org.eclipse.cdt.core.parser.tests.scannerinfo;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Map;
 

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexBindingResolutionTestBase.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexBindingResolutionTestBase.java
@@ -17,6 +17,12 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.index.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -59,6 +65,8 @@ import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.osgi.framework.Bundle;
 
 /**
@@ -79,16 +87,14 @@ public abstract class IndexBindingResolutionTestBase extends SemanticTestBase {
 		this.strategy = strategy;
 	}
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@BeforeEach
+	protected void setUpStrategy() throws Exception {
 		strategy.setUp();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@AfterEach
+	protected void tearDowntrategy() throws Exception {
 		strategy.tearDown();
-		super.tearDown();
 	}
 
 	protected IASTName findName(String section, int offset, int len, boolean preferImplicitName) {
@@ -159,13 +165,13 @@ public abstract class IndexBindingResolutionTestBase extends SemanticTestBase {
 			len += section.length() - offset;
 
 		IASTName name = findName(section, offset, len);
-		assertNotNull("Name not found for \"" + section + "\"", name);
+		assertNotNull(name, "Name not found for \"" + section + "\"");
 		assertEquals(section.substring(0, len), name.getRawSignature());
 
 		IBinding binding = name.resolveBinding();
-		assertNotNull("No binding for " + name.getRawSignature(), binding);
-		assertFalse("Binding is a ProblemBinding for name \"" + name.getRawSignature() + "\"",
-				IProblemBinding.class.isAssignableFrom(name.resolveBinding().getClass()));
+		assertNotNull(binding, "No binding for " + name.getRawSignature());
+		assertFalse(IProblemBinding.class.isAssignableFrom(name.resolveBinding().getClass()),
+				"Binding is a ProblemBinding for name \"" + name.getRawSignature() + "\"");
 		assertInstance(binding, clazz, cs);
 		return clazz.cast(binding);
 	}
@@ -194,13 +200,13 @@ public abstract class IndexBindingResolutionTestBase extends SemanticTestBase {
 			len += section.length() - offset;
 
 		IASTName name = findImplicitName(section, offset, len);
-		assertNotNull("Name not found for \"" + section + "\"", name);
+		assertNotNull(name, "Name not found for \"" + section + "\"");
 		assertEquals(section.substring(offset, offset + len), name.getRawSignature());
 
 		IBinding binding = name.resolveBinding();
-		assertNotNull("No binding for " + name.getRawSignature(), binding);
-		assertFalse("Binding is a ProblemBinding for name \"" + name.getRawSignature() + "\"",
-				IProblemBinding.class.isAssignableFrom(name.resolveBinding().getClass()));
+		assertNotNull(binding, "No binding for " + name.getRawSignature());
+		assertFalse(IProblemBinding.class.isAssignableFrom(name.resolveBinding().getClass()),
+				"Binding is a ProblemBinding for name \"" + name.getRawSignature() + "\"");
 		assertInstance(binding, clazz, cs);
 		return clazz.cast(binding);
 	}
@@ -224,13 +230,13 @@ public abstract class IndexBindingResolutionTestBase extends SemanticTestBase {
 			len += section.length() - offset;
 
 		IASTName name = findName(section, offset, len);
-		assertNotNull("Name not found for \"" + section + "\"", name);
+		assertNotNull(name, "Name not found for \"" + section + "\"");
 		assertEquals(section.substring(offset, offset + len), name.getRawSignature());
 
 		IBinding binding = name.resolveBinding();
-		assertNotNull("No binding for " + name.getRawSignature(), binding);
-		assertFalse("Binding is a ProblemBinding for name \"" + name.getRawSignature() + "\"",
-				IProblemBinding.class.isAssignableFrom(name.resolveBinding().getClass()));
+		assertNotNull(binding, "No binding for " + name.getRawSignature());
+		assertFalse(IProblemBinding.class.isAssignableFrom(name.resolveBinding().getClass()),
+				"Binding is a ProblemBinding for name \"" + name.getRawSignature() + "\"");
 		return (T) binding;
 	}
 
@@ -252,13 +258,13 @@ public abstract class IndexBindingResolutionTestBase extends SemanticTestBase {
 			len += section.length();
 
 		IASTName name = findImplicitName(section, 0, len);
-		assertNotNull("Name not found for \"" + section + "\"", name);
+		assertNotNull(name, "Name not found for \"" + section + "\"");
 		assertEquals(section.substring(0, len), name.getRawSignature());
 
 		IBinding binding = name.resolveBinding();
-		assertNotNull("No binding for " + name.getRawSignature(), binding);
-		assertFalse("Binding is a ProblemBinding for name \"" + name.getRawSignature() + "\"",
-				IProblemBinding.class.isAssignableFrom(name.resolveBinding().getClass()));
+		assertNotNull(binding, "No binding for " + name.getRawSignature());
+		assertFalse(IProblemBinding.class.isAssignableFrom(name.resolveBinding().getClass()),
+				"Binding is a ProblemBinding for name \"" + name.getRawSignature() + "\"");
 		return (T) binding;
 	}
 
@@ -270,13 +276,13 @@ public abstract class IndexBindingResolutionTestBase extends SemanticTestBase {
 	 */
 	protected IBinding getProblemFromASTName(String section, int len) {
 		IASTName name = findName(section, 0, len);
-		assertNotNull("Name not found for \"" + section + "\"", name);
+		assertNotNull(name, "Name not found for \"" + section + "\"");
 		assertEquals(section.substring(0, len), name.getRawSignature());
 
 		IBinding binding = name.resolveBinding();
-		assertNotNull("No binding for " + name.getRawSignature(), binding);
-		assertTrue("Binding is not a ProblemBinding for name \"" + name.getRawSignature() + "\"",
-				IProblemBinding.class.isAssignableFrom(name.resolveBinding().getClass()));
+		assertNotNull(binding, "No binding for " + name.getRawSignature());
+		assertTrue(IProblemBinding.class.isAssignableFrom(name.resolveBinding().getClass()),
+				"Binding is not a ProblemBinding for name \"" + name.getRawSignature() + "\"");
 		return name.resolveBinding();
 	}
 
@@ -319,15 +325,6 @@ public abstract class IndexBindingResolutionTestBase extends SemanticTestBase {
 		assertTrue(ICPPClassType.class.isInstance((ft.getParameterTypes()[index])));
 		assertEquals(compositeTypeKey, ((ICPPClassType) ft.getParameterTypes()[index]).getKey());
 		assertEquals(qn, ASTTypeUtil.getQualifiedName((ICPPClassType) ft.getParameterTypes()[index]));
-	}
-
-	protected static <T> T assertInstance(Object o, Class<T> clazz, Class... cs) {
-		assertNotNull("Expected " + clazz.getName() + " but got null", o);
-		assertTrue("Expected " + clazz.getName() + " but got " + o.getClass().getName(), clazz.isInstance(o));
-		for (Class c : cs) {
-			assertTrue("Expected " + clazz.getName() + " but got " + o.getClass().getName(), c.isInstance(o));
-		}
-		return clazz.cast(o);
 	}
 
 	protected String readTaggedComment(final String tag) throws IOException {
@@ -1002,7 +999,7 @@ public abstract class IndexBindingResolutionTestBase extends SemanticTestBase {
 	protected static void assertSameType(IType first, IType second) {
 		assertNotNull(first);
 		assertNotNull(second);
-		assertTrue("Expected types to be the same, but first was: '" + first.toString() + "' and second was: '" + second
-				+ "'", first.isSameType(second));
+		assertTrue(first.isSameType(second), "Expected types to be the same, but first was: '" + first.toString()
+				+ "' and second was: '" + second + "'");
 	}
 }

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexBugsTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexBugsTests.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.index.tests;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCBindingResolutionBugsTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCBindingResolutionBugsTest.java
@@ -15,6 +15,10 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.index.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.eclipse.cdt.core.dom.ast.DOMException;
 import org.eclipse.cdt.core.dom.ast.IBasicType;
 import org.eclipse.cdt.core.dom.ast.IBinding;
@@ -30,8 +34,7 @@ import org.eclipse.cdt.core.dom.ast.ITypedef;
 import org.eclipse.cdt.core.dom.ast.IVariable;
 import org.eclipse.cdt.core.dom.ast.c.ICCompositeTypeScope;
 import org.eclipse.cdt.core.index.IIndexBinding;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * For testing PDOM binding resolution
@@ -42,25 +45,12 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 		public SingleProjectTest() {
 			setStrategy(new SinglePDOMTestStrategy(false));
 		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTest.class);
-		}
 	}
 
 	public static class ProjectWithDepProjTest extends IndexCBindingResolutionBugsTest {
 		public ProjectWithDepProjTest() {
 			setStrategy(new ReferencedProject(false));
 		}
-
-		public static TestSuite suite() {
-			return suite(ProjectWithDepProjTest.class);
-		}
-	}
-
-	public static void addTests(TestSuite suite) {
-		suite.addTest(SingleProjectTest.suite());
-		suite.addTest(ProjectWithDepProjTest.suite());
 	}
 
 	// #include <stdio.h>
@@ -79,6 +69,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	//	    }
 	//	    return 0;
 	//	}
+	@Test
 	public void testBug175267() throws DOMException {
 		IBinding b0 = getBindingFromASTName("func1()", 5);
 		assertTrue(b0 instanceof IFunction);
@@ -97,6 +88,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	//	int main(void) {
 	//      void* v= func1;
 	//	}
+	@Test
 	public void testBug181735() throws DOMException {
 		IBinding b0 = getBindingFromASTName("func1;", 5);
 		assertTrue(b0 instanceof IFunction);
@@ -112,6 +104,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	//    usertype ut;
 	//    func(ut);
 	// }
+	@Test
 	public void testFuncWithTypedefForAnonymousStruct_190730() throws Exception {
 		IBinding b0 = getBindingFromASTName("func(", 4);
 		assertTrue(b0 instanceof IFunction);
@@ -134,6 +127,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	//    userEnum ut;
 	//    func(ut);
 	// }
+	@Test
 	public void testFuncWithTypedefForAnonymousEnum_190730() throws Exception {
 		IBinding b0 = getBindingFromASTName("func(", 4);
 		assertTrue(b0 instanceof IFunction);
@@ -151,6 +145,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 
 	// // don't include header
 	// char globalVar;
+	@Test
 	public void testAstIndexConflictVariable_Bug195127() throws Exception {
 		fakeFailForMultiProject();
 		IBinding b0 = getBindingFromASTName("globalVar;", 9);
@@ -165,6 +160,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 
 	// // don't include header
 	// char globalFunc();
+	@Test
 	public void testAstIndexConflictFunction_Bug195127() throws Exception {
 		fakeFailForMultiProject();
 		IBinding b0 = getBindingFromASTName("globalFunc(", 10);
@@ -184,6 +180,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	//    char member;
 	//    int additionalMember;
 	// };
+	@Test
 	public void testAstIndexConflictStruct_Bug195127() throws Exception {
 		fakeFailForMultiProject();
 		IBinding b0 = getBindingFromASTName("astruct", 7);
@@ -213,6 +210,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	// enum anenum {
 	//    eItem0, eItem1
 	// };
+	@Test
 	public void testAstIndexConflictEnumerator_Bug195127() throws Exception {
 		fakeFailForMultiProject();
 		IBinding b0 = getBindingFromASTName("anenum", 6);
@@ -226,6 +224,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 
 	// // don't include header
 	// typedef char atypedef;
+	@Test
 	public void testAstIndexConflictTypedef_Bug195127() throws Exception {
 		fakeFailForMultiProject();
 		IBinding b0 = getBindingFromASTName("atypedef;", 8);
@@ -245,6 +244,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	// void func(struct st_20070703* x) {
 	//    x->member= 0;
 	// }
+	@Test
 	public void testAstIndexStructFwdDecl_Bug195227() throws Exception {
 		IBinding b0 = getBindingFromASTName("member=", 6);
 		assertTrue(b0 instanceof IField);
@@ -262,6 +262,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	// enum anenum;
 	// void func(struct astruct a, enum anenum b) {
 	// }
+	@Test
 	public void testAstIndexFwdDecl_Bug195227() throws Exception {
 		IBinding b0 = getBindingFromASTName("astruct;", 7);
 		IBinding b1 = getBindingFromASTName("anenum;", 6);
@@ -297,6 +298,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	// typedef enum {
 	//    ei
 	// } t_enum;
+	@Test
 	public void testIsSameAnonymousType_Bug193962() throws DOMException {
 		// struct
 		IBinding tdAST = getBindingFromASTName("t_struct;", 8);
@@ -355,6 +357,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	//    struct outer x;
 	//    x.var1=1;
 	// }
+	@Test
 	public void testAnonymousUnion_Bug216791() throws DOMException {
 		// struct
 		IBinding b = getBindingFromASTName("var1=", 4);
@@ -376,6 +379,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	//    union outer x;
 	//    x.var1=1;
 	// }
+	@Test
 	public void testAnonymousStruct_Bug216791() throws DOMException {
 		// struct
 		IBinding b = getBindingFromASTName("var1=", 4);
@@ -396,6 +400,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	// int main(void) {
 	//    return myFunc(0);
 	// }
+	@Test
 	public void testKRStyleFunction_Bug216791() throws DOMException {
 		// struct
 		IBinding b = getBindingFromASTName("myFunc(", 6);
@@ -416,6 +421,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	//	void setValue(S *pSelf, int value) {
 	//		pSelf->value = value;
 	//	}
+	@Test
 	public void testOpaqueStruct_Bug262719() throws Exception {
 		IBinding b = getBindingFromASTName("value =", 5);
 		assertTrue(b instanceof IField);
@@ -476,6 +482,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	//          0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 	//          0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0);
 	//	}
+	@Test
 	public void testFunctionsWithManyParameters_Bug319186() throws Exception {
 		getBindingFromASTName("f255", 0);
 		getBindingFromASTName("f256", 0);
@@ -488,6 +495,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	//	struct B b = {
 	//			.f = 3.1
 	//	};
+	@Test
 	public void testDesignatedInitializer_Bug210019() throws Exception {
 		IField f = getBindingFromASTName("f", 0);
 	}
@@ -500,6 +508,7 @@ public abstract class IndexCBindingResolutionBugsTest extends IndexBindingResolu
 	//		struct S *i;
 	//		f(&i->data);
 	//	}
+	@Test
 	public void testBug394151() throws Exception {
 		IParameter f = getBindingFromASTName("f(", 1);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCBindingResolutionTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCBindingResolutionTest.java
@@ -14,6 +14,10 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.index.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.io.IOException;
 
 import org.eclipse.cdt.core.dom.ast.IBasicType;
@@ -27,8 +31,7 @@ import org.eclipse.cdt.core.dom.ast.IPointerType;
 import org.eclipse.cdt.core.dom.ast.ITypedef;
 import org.eclipse.cdt.core.dom.ast.IValue;
 import org.eclipse.cdt.core.dom.ast.IVariable;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * For testing PDOM binding C language resolution
@@ -44,10 +47,6 @@ public abstract class IndexCBindingResolutionTest extends IndexBindingResolution
 		public SingleProjectTest() {
 			setStrategy(new SinglePDOMTestStrategy(false));
 		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTest.class);
-		}
 	}
 
 	public static class ProjectWithDepProjTest extends IndexCBindingResolutionTest {
@@ -55,14 +54,6 @@ public abstract class IndexCBindingResolutionTest extends IndexBindingResolution
 			setStrategy(new ReferencedProject(false));
 		}
 
-		public static TestSuite suite() {
-			return suite(ProjectWithDepProjTest.class);
-		}
-	}
-
-	public static void addTests(TestSuite suite) {
-		suite.addTest(SingleProjectTest.suite());
-		suite.addTest(ProjectWithDepProjTest.suite());
 	}
 
 	public IndexCBindingResolutionTest() {
@@ -75,6 +66,7 @@ public abstract class IndexCBindingResolutionTest extends IndexBindingResolution
 	// void foo() {
 	//    f= g;
 	// }
+	@Test
 	public void testPointerToFunction() throws Exception {
 		IBinding b0 = getBindingFromASTName("f= g;", 1);
 		IBinding b1 = getBindingFromASTName("g;", 1);
@@ -128,6 +120,7 @@ public abstract class IndexCBindingResolutionTest extends IndexBindingResolution
 	//	  func1(var1); /*func2*/
 	//	  func2(s); /*func3*/
 	//	}
+	@Test
 	public void testSimpleGlobalBindings() throws IOException {
 		IBinding b2 = getBindingFromASTName("S s;", 1);
 		IBinding b3 = getBindingFromASTName("s;", 1);
@@ -159,6 +152,7 @@ public abstract class IndexCBindingResolutionTest extends IndexBindingResolution
 	//    S *s;
 	//    E *e;
 	// };
+	@Test
 	public void testTypedefA() throws Exception {
 		IBinding b1 = getBindingFromASTName("S {", 1);
 		IBinding b2 = getBindingFromASTName("S;", 1);
@@ -190,6 +184,7 @@ public abstract class IndexCBindingResolutionTest extends IndexBindingResolution
 	//    S *s;
 	//    E *e;
 	// };
+	@Test
 	public void testTypedefB() throws Exception {
 		IBinding b1 = getBindingFromASTName("S *s", 1);
 		IBinding b2 = getBindingFromASTName("E *e", 1);
@@ -237,6 +232,7 @@ public abstract class IndexCBindingResolutionTest extends IndexBindingResolution
 	//    b6->u.y = 12;
 	//    b6->z = 13;
 	// }
+	@Test
 	public void testFieldReference() throws Exception {
 		IBinding b01 = getBindingFromASTName("b1;", 2);
 		assertVariable(b01, "b1", ICompositeType.class, "U");
@@ -324,6 +320,7 @@ public abstract class IndexCBindingResolutionTest extends IndexBindingResolution
 	//			foo3/*j*/(sizeof(struct S));/*8*/       // IASTTypeIdExpression
 	//			foo1/*k*/(*sp);/*9*/                    // IASTUnaryExpression
 	//		}
+	@Test
 	public void testExpressionKindForFunctionCalls() {
 		IBinding b0 = getBindingFromASTName("foo1/*a*/", 4);
 		IBinding b0a = getBindingFromASTName("sp[1]", 2);
@@ -380,6 +377,7 @@ public abstract class IndexCBindingResolutionTest extends IndexBindingResolution
 	//    u->a= 1;  // since we include the definition, we may use the type.
 	//    v->b= 1;  // since we include the definition, we may use the type.
 	// }
+	@Test
 	public void testTypeDefinitionWithFwdDeclaration() {
 		getBindingFromASTName("a= 1", 1);
 		getBindingFromASTName("b= 1", 1);
@@ -393,6 +391,7 @@ public abstract class IndexCBindingResolutionTest extends IndexBindingResolution
 	// void ref() {
 	// a; b; c; e0; e2; e3; e4; e5;
 	// }
+	@Test
 	public void testValues() throws Exception {
 		IVariable v = (IVariable) getBindingFromASTName("a;", 1);
 		checkValue(v.getInitialValue(), -4);
@@ -423,6 +422,7 @@ public abstract class IndexCBindingResolutionTest extends IndexBindingResolution
 	//	extern char TableValue[10];
 
 	//	char TableValue[sizeof TableValue];
+	@Test
 	public void testNameLookupFromArrayModifier_435075() throws Exception {
 		checkBindings();
 	}
@@ -433,6 +433,7 @@ public abstract class IndexCBindingResolutionTest extends IndexBindingResolution
 	//	};
 
 	//	int waldo = a;
+	@Test
 	public void testAnonymousUnion_377409() {
 		checkBindings();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCPPBindingResolutionBugsSingleProjectFirstASTTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCPPBindingResolutionBugsSingleProjectFirstASTTest.java
@@ -13,36 +13,37 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.index.tests;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class IndexCPPBindingResolutionBugsSingleProjectFirstASTTest extends IndexCPPBindingResolutionBugsTest {
 	public IndexCPPBindingResolutionBugsSingleProjectFirstASTTest() {
 		setStrategy(new SinglePDOMTestFirstASTStrategy(true));
 	}
 
-	public static TestSuite suite() {
-		return suite(IndexCPPBindingResolutionBugsSingleProjectFirstASTTest.class);
-	}
-
 	/* Invalid tests for this strategy, they assume that the second file is already indexed. */
 	@Override
+	@Test
 	public void test_208558() {
 	}
 
 	@Override
+	@Test
 	public void test_176708_CCE() {
 	}
 
 	@Override
+	@Test
 	public void testIsSameAnonymousType_193962() {
 	}
 
 	@Override
+	@Test
 	public void testIsSameNestedAnonymousType_193962() {
 	}
 
 	/* For some unknown reason this test is flaky for this strategy. */
 	@Override
+	@Test
 	public void testTemplateArgumentResolution_450888() {
 	}
 }

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCPPBindingResolutionBugsTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCPPBindingResolutionBugsTest.java
@@ -15,6 +15,12 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.index.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
@@ -64,8 +70,7 @@ import org.eclipse.cdt.core.model.IWorkingCopy;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPTemplateTypeArgument;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ClassTypeHelper;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ICPPInstanceCache;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * For testing PDOM binding resolution
@@ -76,30 +81,12 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 		public SingleProjectTest() {
 			setStrategy(new SinglePDOMTestStrategy(true));
 		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTest.class);
-		}
 	}
 
 	public static class ProjectWithDepProjTest extends IndexCPPBindingResolutionBugsTest {
 		public ProjectWithDepProjTest() {
 			setStrategy(new ReferencedProject(true));
 		}
-
-		public static TestSuite suite() {
-			return suite(ProjectWithDepProjTest.class);
-		}
-	}
-
-	public static void addTests(TestSuite suite) {
-		suite.addTest(IndexCPPBindingResolutionBugsSingleProjectFirstASTTest.suite());
-		suite.addTest(SingleProjectTest.suite());
-		suite.addTest(ProjectWithDepProjTest.suite());
-	}
-
-	public static TestSuite suite() {
-		return suite(IndexCPPBindingResolutionBugsTest.class);
 	}
 
 	public IndexCPPBindingResolutionBugsTest() {
@@ -113,6 +100,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	// OBJ {}
 	// FUNC() {}
 	// FUNC2(1) {}
+	@Test
 	public void test_208558() throws Exception {
 		IIndex index = getIndex();
 
@@ -170,6 +158,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//	    Temp testFile;
 	//	    testTemplate(testFile);
 	//	}
+	@Test
 	public void test_207320() {
 		IBinding b0 = getBindingFromASTName("testTemplate(", 12);
 		assertInstance(b0, ICPPFunction.class);
@@ -206,6 +195,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//			testCall( /*7*/ (void *)global_cBaseRef);
 	//          testCall( /*8*/ global_cBaseRef);
 	//		}
+	@Test
 	public void test_206187() throws Exception {
 		IBinding b1 = getBindingFromASTName("testCall( /*1*/", 8);
 		IBinding b2 = getBindingFromASTName("testCall( /*2*/", 8);
@@ -228,6 +218,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	// B<C> b;
 
 	// void foo() {C c; B<int> b;}
+	@Test
 	public void test_188274() throws Exception {
 		IBinding b0 = getBindingFromASTName("C", 1);
 		IBinding b1 = getBindingFromASTName("B", 1);
@@ -250,6 +241,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 
 	// ns::A a;
 	// class B {};
+	@Test
 	public void test_188324() throws Exception {
 		IASTName name = findName("B", 1);
 		IBinding b0 = getBindingFromASTName("ns::A", 2);
@@ -264,6 +256,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	// 	 void foo() {
 	//      C<int>::unresolvable();
 	//   };
+	@Test
 	public void test_185828() throws Exception {
 		// Bug 185828 reports a StackOverflowException is thrown before we get here.
 		// That the SOE is thrown is detected in BaseTestCase via an Error IStatus
@@ -295,6 +288,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//	int main() {
 	//		MyClass* cls= new MyClass();
 	//	}
+	@Test
 	public void test_184216() throws Exception {
 		IBinding b0 = getBindingFromASTName("MyClass*", 7);
 		assertInstance(b0, ICPPClassType.class);
@@ -315,6 +309,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//     cl* a;
 	//     func(a);
 	//  }
+	@Test
 	public void test_166954() {
 		IBinding b0 = getBindingFromASTName("func(a)", 4);
 	}
@@ -342,6 +337,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//   b.fooovr(1);
 	//   b.fooovr('a');
 	// }
+	@Test
 	public void test_168020() {
 		getBindingFromASTName("foo(int i)", 3);
 		getBindingFromASTName("fooint()", 6);
@@ -377,6 +373,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	// void func2(int l) {
 	//  l=2;
 	// }
+	@Test
 	public void test_168054() {
 		getBindingFromASTName("i=2", 1);
 		getBindingFromASTName("j=2", 1);
@@ -393,6 +390,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//       Ambiguity problem;
 	//    }
 	// }
+	@Test
 	public void test_176708_CCE() throws Exception {
 		IBinding binding = getBindingFromASTName("Y {", 1);
 		assertTrue(binding instanceof ICPPNamespace);
@@ -405,6 +403,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	// namespace X {int i;}
 
 	// int a= X::i;
+	@Test
 	public void test_176708_NPE() throws Exception {
 		IBinding binding = getBindingFromASTName("i;", 1);
 		assertTrue(binding instanceof ICPPVariable);
@@ -416,6 +415,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 
 	//	template<>
 	//	class A<int, bool, double> {};
+	@Test
 	public void test_180784() throws Exception {
 		IBinding b0 = getBindingFromASTName("A<int, bool, double> {};", 20);
 		assertInstance(b0, ICPPSpecialization.class);
@@ -446,6 +446,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//		id(*new A());
 	//		id(6);
 	//	}
+	@Test
 	public void test_180948() throws Exception {
 		// Main check occurs in BaseTestCase - that no ClassCastException
 		// is thrown during indexing
@@ -458,6 +459,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//	int main(void) {
 	//      void* v= func1;
 	//	}
+	@Test
 	public void test_181735() throws DOMException {
 		IBinding b0 = getBindingFromASTName("func1;", 5);
 		assertTrue(b0 instanceof IFunction);
@@ -477,6 +479,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//		A c;
 	//		c.field;//comment
 	//	}
+	@Test
 	public void test_183843() throws DOMException {
 		IBinding b0 = getBindingFromASTName("field;//", 5);
 		assertTrue(b0 instanceof ICPPField);
@@ -491,6 +494,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//    usertype ut;
 	//    func(ut);
 	// }
+	@Test
 	public void testFuncWithTypedefForAnonymousStruct_190730() throws Exception {
 		IBinding b0 = getBindingFromASTName("func(", 4);
 		assertTrue(b0 instanceof IFunction);
@@ -512,6 +516,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//    userEnum ut;
 	//    func(ut);
 	// }
+	@Test
 	public void testFuncWithTypedefForAnonymousEnum_190730() throws Exception {
 		IBinding b0 = getBindingFromASTName("func(", 4);
 		assertTrue(b0 instanceof IFunction);
@@ -538,6 +543,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	// typedef enum {
 	//    ei
 	// } t_enum;
+	@Test
 	public void testIsSameAnonymousType_193962() throws DOMException {
 		// class
 		IBinding tdAST = getBindingFromASTName("t_class;", 7);
@@ -616,6 +622,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//    ei
 	// } t_enum;
 	// };
+	@Test
 	public void testIsSameNestedAnonymousType_193962() throws DOMException {
 		// class
 		IBinding tdAST = getBindingFromASTName("t_class;", 7);
@@ -694,6 +701,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//	       return pBar;
 	//	    }
 	//	}
+	@Test
 	public void testAdvanceUsingDeclaration_217102() throws Exception {
 		IBinding cl = getBindingFromASTName("Bar* Foo", 3);
 
@@ -717,6 +725,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//    struct outer x;
 	//    x.var1=1;
 	// }
+	@Test
 	public void testAnonymousUnion_216791() throws DOMException {
 		// struct
 		IBinding b = getBindingFromASTName("var1=", 4);
@@ -741,6 +750,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//    x.var1=1;
 	//    x.var2= 2; // must be a problem
 	// }
+	@Test
 	public void testAnonymousStruct_216791() throws DOMException {
 		// struct
 		IBinding b = getBindingFromASTName("var1=", 4);
@@ -761,6 +771,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	// void test() {
 	//    v=1;
 	// }
+	@Test
 	public void testUsingDirective_216527() throws Exception {
 		IBinding b = getBindingFromASTName("v=", 1);
 		assertTrue(b instanceof IVariable);
@@ -784,6 +795,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	// void f() {
 	//   NSAB::a= NSAB::b;
 	// }
+	@Test
 	public void testNamespaceComposition_200673() throws Exception {
 		IBinding a = getBindingFromASTName("a=", 1);
 		assertTrue(a instanceof IVariable);
@@ -805,6 +817,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	// namespace N {using namespace N::M;}
 	// using namespace N;
 	// void test() {x;}
+	@Test
 	public void testEndlessLoopWithUsingDeclaration_209813() throws DOMException {
 		getProblemFromASTName("x;", 1);
 	}
@@ -813,6 +826,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 
 	// void test(MyClass* ptr);
 	// class MyClass;
+	@Test
 	public void testClassRedeclarationAfterReference_229571() throws Exception {
 		IBinding cl = getBindingFromASTName("MyClass;", 7);
 		IFunction fn = getBindingFromASTName("test(", 4, IFunction.class);
@@ -849,6 +863,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//   ca.bar();/*7*/
 	//   a.bar();/*8*/
 	// }
+	@Test
 	public void testMemberFunctionDisambiguationByCVness_238409() throws Exception {
 		ICPPMethod bar_cv = getBindingFromASTName("bar();/*1*/", 3, ICPPMethod.class);
 		ICPPMethod bar_v = getBindingFromASTName("bar();/*2*/", 3, ICPPMethod.class);
@@ -898,6 +913,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//	   test2(x); // problem binding here
 	//	   test3(x); // problem binding here
 	//	}
+	@Test
 	public void testAdjustmentOfParameterTypes_239975() throws Exception {
 		getBindingFromASTName("test1(x)", 5, ICPPFunction.class);
 		getBindingFromASTName("test2(x)", 5, ICPPFunction.class);
@@ -968,6 +984,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	// Container<int>::CT<int> spect;
 	// Container<char>::C espec;
 	// Container<char>::CT<int> espect;
+	@Test
 	public void testClassTypes_98171() throws Exception {
 		// regular class
 		ICPPClassType ct = getBindingFromASTName("C", 1);
@@ -1079,6 +1096,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//      const int* q = p;
 	//		func(q);
 	//	}
+	@Test
 	public void testOverloadedFunctionFromIndex_256240() throws Exception {
 		getBindingFromASTName("func(q", 4, ICPPFunction.class);
 	}
@@ -1091,6 +1109,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//	};
 
 	//	void A::B::m() {}
+	@Test
 	public void testNestedClasses_259683() throws Exception {
 		getBindingFromASTName("A::B::m", 7, ICPPMethod.class);
 	}
@@ -1111,6 +1130,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//			a.operator S *();
 	//		}
 	//	}
+	@Test
 	public void testLookupScopeForConversionNames_267221() throws Exception {
 		getBindingFromASTName("operator S *", 12, ICPPMethod.class);
 	}
@@ -1160,6 +1180,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//      X x;
 	//      useBase(x.d);
 	//	}
+	@Test
 	public void testLateDefinitionOfInheritance_292749() throws Exception {
 		getBindingFromFirstIdentifier("useBase(x.d)", ICPPFunction.class);
 	}
@@ -1178,6 +1199,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//    two::fx(1);
 	//    two::fx(1,1);
 	// }
+	@Test
 	public void testUsingDeclaration_300019() throws Exception {
 		getBindingFromASTName("fx();", 2, ICPPFunction.class);
 		getBindingFromASTName("fx(1);", 2, ICPPFunction.class);
@@ -1199,6 +1221,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//	void YetAnotherTest::test() {
 	//	  arr[0].member=0;
 	//	}
+	@Test
 	public void testElaboratedTypeSpecifier_303739() throws Exception {
 		getBindingFromASTName("member=0", -2, ICPPField.class);
 	}
@@ -1208,6 +1231,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//	void test() {
 	//		MBR_PTR x;
 	//	}
+	@Test
 	public void testProblemInIndexBinding_317146() throws Exception {
 		ITypedef td = getBindingFromASTName("MBR_PTR", 0, ITypedef.class);
 		ICPPPointerToMemberType ptrMbr = (ICPPPointerToMemberType) td.getType();
@@ -1270,6 +1294,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//          0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 	//          0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0);
 	//	}
+	@Test
 	public void testFunctionsWithManyParameters_319186() throws Exception {
 		getBindingFromASTName("f255", 0);
 		getBindingFromASTName("f256", 0);
@@ -1283,6 +1308,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//     char32_t c32;
 	//     f(c16); f(c32);
 	// }
+	@Test
 	public void testChar16_319186() throws Exception {
 		IFunction f = getBindingFromASTName("f(c16)", 1);
 		assertEquals("char16_t", ASTTypeUtil.getType(f.getType().getParameterTypes()[0]));
@@ -1306,6 +1332,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//	  fun();
 	//	  Type x;
 	//	}
+	@Test
 	public void test_326778() throws Exception {
 		IVariable v = getBindingFromASTName("var", 0);
 		IFunction f = getBindingFromASTName("fun", 0);
@@ -1328,6 +1355,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//	    *left - *right;
 	//	  }
 	//	};
+	@Test
 	public void test_356982() throws Exception {
 		IASTName name = findName("+ ", 1);
 		assertTrue(name instanceof IASTImplicitName);
@@ -1351,6 +1379,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//	}
 	//
 	//	}
+	@Test
 	public void test_457503() throws Exception {
 		checkBindings();
 	}
@@ -1361,6 +1390,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 
 	//	class D : public A {};
 	//	class D::B {};
+	@Test
 	public void testInvalidOwner_412766() throws Exception {
 		getProblemFromFirstIdentifier("B {}");
 	}
@@ -1384,6 +1414,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//	    waldo(new B<E>());
 	//	  }
 	//	};
+	@Test
 	public void testTemplateArgumentResolution_450888() throws Exception {
 		getProblemFromFirstIdentifier("waldo"); // waldo is unresolved because E doesn't extend C.
 		IASTTranslationUnit ast = strategy.getAst(0);
@@ -1411,6 +1442,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	// MyClass::MyClass() {
 	// 	new MyInnerClass(true, true);
 	// }
+	@Test
 	public void testIssue_254() throws Exception {
 		checkBindings();
 	}
@@ -1444,6 +1476,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	//	};
 	//
 	//	UsingStructFromAnonymousNs usingStructFromAnonymousNs;
+	@Test
 	public void testStructNameIntroducedInNamespace() throws Exception {
 		checkBindings();
 	}
@@ -1455,6 +1488,7 @@ public abstract class IndexCPPBindingResolutionBugsTest extends IndexBindingReso
 	// constexpr int getNum(long);
 	// constexpr int v3 = getNum((int)0);
 	// constexpr int v6 = getNum((long)0);
+	@Test
 	public void testFuncDefnFromIndex() throws Exception {
 		ICPPVariable v3 = getBindingFromASTName("v3 ", 2, ICPPVariable.class);
 		ICPPVariable v6 = getBindingFromASTName("v6 ", 2, ICPPVariable.class);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCPPBindingResolutionTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCPPBindingResolutionTest.java
@@ -16,6 +16,13 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.index.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -54,8 +61,7 @@ import org.eclipse.cdt.core.index.IIndexBinding;
 import org.eclipse.cdt.core.parser.IProblem;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.ClassTypeHelper;
 import org.eclipse.core.runtime.CoreException;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * For testing PDOM binding CPP language resolution
@@ -71,33 +77,16 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 		public SingleProjectTest() {
 			setStrategy(new SinglePDOMTestStrategy(true));
 		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTest.class);
-		}
 	}
 
 	public static class ProjectWithDepProjTest extends IndexCPPBindingResolutionTest {
 		public ProjectWithDepProjTest() {
 			setStrategy(new ReferencedProject(true));
 		}
-
-		public static TestSuite suite() {
-			return suite(ProjectWithDepProjTest.class);
-		}
-	}
-
-	public static void addTests(TestSuite suite) {
-		suite.addTest(SingleProjectTest.suite());
-		suite.addTest(ProjectWithDepProjTest.suite());
 	}
 
 	public IndexCPPBindingResolutionTest() {
 		setStrategy(new SinglePDOMTestStrategy(true));
-	}
-
-	public static TestSuite suite() {
-		return suite(SingleProjectTest.class);
 	}
 
 	/* Assertion helpers */
@@ -212,6 +201,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//    B b;
 	//    b.p(E1);
 	//  }
+	@Test
 	public void testUsingTypeDeclaration_201177() {
 		IBinding b0 = getBindingFromASTName("B::m", 4);
 		IBinding b1 = getBindingFromASTName("B::n", 4);
@@ -230,6 +220,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// }
 	// m::C c;
 	// m::D d;
+	@Test
 	public void testUsingNamingDirective_177917_1a() {
 		IBinding b0 = getBindingFromASTName("C c", 1);
 		IBinding b1 = getBindingFromASTName("D d", 1);
@@ -243,6 +234,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 
 	// namespace n { class C{}; }
 	// m::C c;
+	@Test
 	public void testUsingNamingDirective_177917_1b() {
 		IBinding b0 = getBindingFromFirstIdentifier("C c");
 	}
@@ -261,6 +253,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// int g(int x) {return 4;}
 	// int g(char x) {return 2;}
 	// int nn= g(f(2));
+	@Test
 	public void testUsingTypeDeclaration_177917_1() {
 		IBinding b1 = getBindingFromASTName("A a", 1);
 		IBinding b2 = getBindingFromASTName("B b", 1);
@@ -277,6 +270,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 
 	// b::A aa;
 	// b::B bb;
+	@Test
 	public void testUsingTypeDeclaration_177917_2() {
 		IBinding b0 = getBindingFromASTName("A aa", 1);
 		IBinding b1 = getBindingFromASTName("B bb", 1);
@@ -324,6 +318,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//		fs(1);
 	//		cls c2;
 	//	}
+	@Test
 	public void testUsingOverloadedFunctionDeclaration() {
 		IBinding b;
 		b = getBindingFromASTName("fh()", 2);
@@ -344,6 +339,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// void foo() {
 	//    f= g;
 	// }
+	@Test
 	public void testPointerToFunction() {
 		IBinding b0 = getBindingFromASTName("f= g;", 1);
 		IBinding b1 = getBindingFromASTName("g;", 1);
@@ -386,6 +382,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//		((cp->cs).*(cp->method))(cp->cspp);/*3*/
 	//		((&(cp->cs))->*(cp->method))(cp->cspp);/*4*/
 	//	}
+	@Test
 	public void testPointerToMemberFields() throws IOException, DOMException {
 		IBinding b0 = getBindingFromASTName("C *cp", 1);
 		assertClassType((ICPPClassType) b0, "C", ICPPClassType.k_class, 1, 6, 5, 9, 0, 1, 0, 2, 1);
@@ -436,6 +433,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// }
 	// class C2 : public C {}; /*base*/
 	// struct S2 : public S {}; /*base*/
+	@Test
 	public void testSimpleGlobalBindings() throws IOException, DOMException {
 		{
 			IBinding b0 = getBindingFromASTName("C c; ", 1);
@@ -531,6 +529,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//      }
 	//   };
 	//}
+	@Test
 	public void testSingletonQualifiedName() {
 		IBinding b0 = getBindingFromASTName("TopC c", 4);
 		IBinding b1 = getBindingFromASTName("TopS s", 4);
@@ -570,6 +569,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// namespace n3 { c3::s3::u3::S _s10; }
 	// namespace n1 { n2::S _s11; }
 	// namespace n1 { namespace n2 { S _s12; }}
+	@Test
 	public void testQualifiedNamesForStruct() throws DOMException {
 		IBinding b0 = getBindingFromASTName("S _s0;", 1);
 		assertTrue(b0.getScope() instanceof ICPPNamespaceScope);
@@ -637,6 +637,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// namespace n3 { c3::s3::u3::U _u10; }
 	// namespace n1 { n2::U _u11; }
 	// namespace n1 { namespace n2 { U _u12; }}
+	@Test
 	public void testQualifiedNamesForUnion() throws DOMException {
 		IBinding b0 = getBindingFromASTName("U _u0;", 1);
 		assertQNEquals("n1::n2::U", b0);
@@ -682,6 +683,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	  A().p();//5      // calls A::p()&&
 	//	  a.p();//6        // calls A::p()&
 	//  }
+	@Test
 	public void testRankingOfReferenceBindings() throws Exception {
 		ICPPMethod m = getBindingFromImplicitASTName("<< 1;//1", 2);
 		assertNotNull(m);
@@ -722,6 +724,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// namespace n3 { c3::s3::u3::C _c10; }
 	// namespace n1 { n2::C _c11; }
 	// namespace n1 { namespace n2 { C _c12; }}
+	@Test
 	public void testQualifiedNamesForClass() throws DOMException {
 		IBinding b0 = getBindingFromASTName("C _c0;", 1);
 		assertQNEquals("n1::n2::C", b0);
@@ -770,6 +773,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// namespace n3 { c3::s3::u3::Int i10; }
 	// namespace n1 { n2::Int i11; }
 	// namespace n1 { namespace n2 { Int i12; }}
+	@Test
 	public void testQualifiedNamesForTypedef() throws DOMException {
 		IBinding b0 = getBindingFromASTName("Int i0;", 3);
 		assertQNEquals("n1::n2::Int", b0);
@@ -810,6 +814,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	decltype(A::waldo) A::waldo;
 
 	//	A a;
+	@Test
 	public void testDecltype_434150() {
 		checkBindings();
 	}
@@ -824,6 +829,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	 void m1() { e1 = ER1; }
 	//	 static void m2() { e2 = ER2; }
 	// };
+	@Test
 	public void testEnumeratorInClassScope() {
 		IBinding b0 = getBindingFromASTName("E e1", 1);
 		IBinding b1 = getBindingFromASTName("ER1; }", 3);
@@ -840,6 +846,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	 void m1() { e1 = ER1; }
 	//	 static void m2() { e2 = ER2; }
 	// };
+	@Test
 	public void testEnumeratorInStructScope() {
 		IBinding b0 = getBindingFromASTName("E e1", 1);
 		IBinding b1 = getBindingFromASTName("ER1; }", 3);
@@ -856,6 +863,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	 void m1() { e1 = ER1; }
 	//	 static void m2() { e2 = ER2; }
 	// };
+	@Test
 	public void testEnumeratorInUnionScope() {
 		IBinding b0 = getBindingFromASTName("E e1", 1);
 		IBinding b1 = getBindingFromASTName("ER1; }", 3);
@@ -872,6 +880,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	 void f1() { e1 = ER1; }
 	//	 static void f2() { e2 = ER2; }
 	// };
+	@Test
 	public void testEnumeratorInNamespaceScope() {
 		IBinding b0 = getBindingFromASTName("E e1", 1);
 		IBinding b1 = getBindingFromASTName("ER1; }", 3);
@@ -891,6 +900,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 
 	//	int waldo1 = a;
 	//	int waldo2 = N::d;
+	@Test
 	public void testAnonymousUnion_377409() {
 		checkBindings();
 	}
@@ -898,6 +908,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// void foo(int a=2, int b=3);
 
 	// void ref() { foo(); }
+	@Test
 	public void testFunctionDefaultArguments() {
 		IBinding b0 = getBindingFromASTName("foo();", 3);
 	}
@@ -908,6 +919,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// };
 
 	// const TYPE* ns::foo(int a) { return 0; }
+	@Test
 	public void testTypeQualifier() {
 		IBinding b0 = getBindingFromASTName("foo(", 3);
 	}
@@ -921,6 +933,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//    d.foo(4); // also calls long version (int version is hidden)
 	//    // aftodo - does this test make sense?
 	// }
+	@Test
 	public void testMethodHidingInInheritance() {
 		IBinding b0 = getBindingFromASTName("d; /*d*/", 1);
 		IBinding b1 = getBindingFromASTName("foo(55L);", 3);
@@ -940,6 +953,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//       x::y::j++;
 	//    }
 	// };
+	@Test
 	public void testGQualifiedReference() {
 		IBinding b0 = getBindingFromASTName("x::y::i++", 1);
 		assertTrue(ICPPNamespace.class.isInstance(b0));
@@ -982,6 +996,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	/* not applicable */                                 // ICPPASTDeleteExpression
 	//	(new S())->i/*18*/++;                                // ICPPASTNewExpression
 	//}
+	@Test
 	public void testFieldReference() {
 		IBinding b0 = getBindingFromASTName("i/*0*/", 1);
 		IBinding b1 = getBindingFromASTName("i/*1*/", 1);
@@ -1028,6 +1043,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//		// ?? foo/*o*/();                       // ICPPASTTypenameExprssion
 	//		// foo/*p*/(MADE_UP_SYMBOL);            // ICPPASTTypenameExprssion
 	//	}
+	@Test
 	public void testExpressionKindForFunctionCalls() {
 		// depends on bug 164470 because resolution takes place during parse.
 		IBinding b0 = getBindingFromASTName("foo/*a*/", 3);
@@ -1113,6 +1129,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//		         fni4 = &f;/*20*/ fnlp4 = &f;/*21*/ fnS4 = &f;/*22*/ fnU4 = &f;/*23*/ fnE4 = &f;/*24*/
 	//		fE = &f;/*25*/
 	//	}
+	@Test
 	public void testAddressOfOverloadedFunction() throws DOMException {
 		IBinding b0 = getBindingFromASTName("f;/*0*/", 1);
 		IBinding b1 = getBindingFromASTName("f;/*1*/", 1);
@@ -1153,6 +1170,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	 func(&C::m1);
 	//	 func(&C::m2);
 	// }
+	@Test
 	public void testAddressOfConstMethod_233889() {
 		IBinding fn1 = getBindingFromASTName("func(&C::m1", 4, ICPPFunction.class);
 		IBinding fn2 = getBindingFromASTName("func(&C::m2", 4, ICPPFunction.class);
@@ -1176,6 +1194,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//  void f_const_int(const int const_int) {
 	//     f_int_ptr(&const_int); // error
 	//  }
+	@Test
 	public void testConstIntParameter() {
 		getBindingFromASTName("f_int(i)", 5);
 		getBindingFromASTName("f_int(const_int)", 5);
@@ -1241,6 +1260,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//   f_int_const_ptr_const(const_int_ptr_const);	// ok
 	//   f_int_const_ptr_const(int_const_ptr_const);	// ok
 	// }
+	@Test
 	public void testConstIntPtrParameter() {
 		getBindingFromASTName("f_int_ptr(int_ptr)", 9);
 		getProblemFromASTName("f_int_ptr(const_int_ptr)", 9);
@@ -1293,6 +1313,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// void f(int *const){}	// b1, redef
 	// void f(const int*const){} // b2, redef
 	// void f(int const*const){} // b2, redef
+	@Test
 	public void testConstIntPtrParameterInDefinitionAST() throws CoreException {
 		IBinding binding1 = getBindingFromASTName("f(int*){}", 1);
 		IBinding binding2 = getBindingFromASTName("f(const int*){}", 1);
@@ -1307,6 +1328,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// void f(int&){}		// b1
 	// void f(const int&){}	// b2
 	// void f(int const&){}	// b2, redef
+	@Test
 	public void testConstIntRefParameterInDefinitionAST() throws CoreException {
 		IBinding binding1 = getBindingFromASTName("f(int&){}", 1);
 		IBinding binding2 = getBindingFromASTName("f(const int&){}", 1);
@@ -1340,6 +1362,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//   f(const_int_ptr_const);	// b2
 	//   f(int_const_ptr_const);	// b2
 	// }
+	@Test
 	public void testConstIntPtrParameterInDefinitionAST2() throws CoreException {
 		IBinding binding1 = getBindingFromASTName("f(int*){}", 1);
 		IBinding binding2 = getBindingFromASTName("f(const int*){}", 1);
@@ -1377,6 +1400,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//   f(const_int_ptr_const);	// b2
 	//   f(int_const_ptr_const);	// b2
 	// }
+	@Test
 	public void testConstIntPtrParameterInDefinition() throws CoreException {
 		IBinding binding1 = getBindingFromASTName("f(int*){}", 1);
 		IBinding binding2 = getBindingFromASTName("f(const int*){}", 1);
@@ -1411,6 +1435,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//    u->a= 1;  // since we include the definition, we may use the type.
 	//    v->b= 1;  // since we include the definition, we may use the type.
 	// }
+	@Test
 	public void testTypeDefinitionWithFwdDeclaration() {
 		getBindingFromASTName("a= 1", 1);
 		getBindingFromASTName("b= 1", 1);
@@ -1425,6 +1450,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// void test() {
 	//    a(1);
 	// }
+	@Test
 	public void testLegalConflictWithUsingDeclaration() {
 		getBindingFromASTName("a(1)", 1);
 	}
@@ -1447,6 +1473,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//		E e;
 	//		foo(e);
 	//	}
+	@Test
 	public void testUserDefinedConversionOperator_224364() {
 		IBinding ca = getBindingFromASTName("C c;", 1);
 		assertInstance(ca, ICPPClassType.class);
@@ -1468,6 +1495,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// void ref() {
 	// a; b; c; e0; e2; e3; e4; e5;
 	// }
+	@Test
 	public void testValues() {
 		IVariable v = (IVariable) getBindingFromASTName("a;", 1);
 		asserValueEquals(v.getInitialValue(), -4);
@@ -1494,6 +1522,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	using namespace ns1::ns2;
 
 	//	A a;
+	@Test
 	public void testUsingDirectiveWithQualifiedName_269727() {
 		getBindingFromASTName("A a", 1, ICPPClassType.class);
 	}
@@ -1505,6 +1534,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//   int a[1], b[2];
 	//   f(a); f(b);
 	// }
+	@Test
 	public void testArrayTypeWithSize_269926() {
 		IFunction f1 = getBindingFromASTName("f(a)", 1, IFunction.class);
 		IFunction f2 = getBindingFromASTName("f(b)", 1, IFunction.class);
@@ -1536,6 +1566,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	};
 
 	//	// empty file
+	@Test
 	public void testArrayWithOneElement_508254() throws Exception {
 		checkBindings();
 	}
@@ -1554,6 +1585,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	  new B(0);
 	//    B::m(0);
 	//	}
+	@Test
 	public void testNestedClass_284665() {
 		ICPPClassType b0 = getBindingFromASTName("B {", 1, ICPPClassType.class);
 		assertFalse(b0 instanceof IIndexBinding);
@@ -1571,6 +1603,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	void test(A a) {
 	//	  m(a);
 	//	}
+	@Test
 	public void testInlineFriendFunction_284690() {
 		getBindingFromASTName("m(a)", 1, IFunction.class);
 	}
@@ -1608,6 +1641,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//		g(a);
 	//		gb(a);
 	//	}
+	@Test
 	public void testInlineNamespace_305980a() {
 		IFunction f = getBindingFromASTName("fa(s)", 2);
 		f = getBindingFromASTName("fb(s)", 2);
@@ -1651,6 +1685,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//		g(a);
 	//		gb(a);
 	//	}
+	@Test
 	public void testInlineNamespace_305980am() {
 		IFunction f = getBindingFromASTName("fa(s)", 2);
 		f = getBindingFromASTName("fb(s)", 2);
@@ -1669,6 +1704,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//		ns::m::a; //1
 	//		ns::a; //2
 	//	}
+	@Test
 	public void testInlineNamespace_305980b() {
 		IVariable v1 = getBindingFromASTName("a; //1", 1);
 		IVariable v2 = getBindingFromASTName("a; //2", 1);
@@ -1691,6 +1727,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//		ns::m::a; //3
 	//		ns::a; //4
 	//	}
+	@Test
 	public void testInlineNamespace_305980bm() {
 		IVariable v1 = getBindingFromASTName("a; //1", 1);
 		IVariable v2 = getBindingFromASTName("a; //2", 1);
@@ -1719,6 +1756,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//		::f(1);
 	//      ::g(1);
 	//	}
+	@Test
 	public void testInlineNamespace_305980c() {
 		IFunction ref = getBindingFromASTName("f(1)", 1);
 		assertEquals("void (char)", ASTTypeUtil.getType(ref.getType()));
@@ -1746,6 +1784,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//		::f(1);
 	//      ::g(1);
 	//	}
+	@Test
 	public void testInlineNamespace_305980cm() {
 		IFunction ref = getBindingFromASTName("f(1)", 1);
 		assertEquals("void (char)", ASTTypeUtil.getType(ref.getType()));
@@ -1762,6 +1801,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	    }
 	//	    void regex_match(string);  // Type 'string' could not be resolved
 	//	}
+	@Test
 	public void testInlineNamespaceReopenedWithoutInlineKeyword_483824() {
 		checkBindings();
 	}
@@ -1773,6 +1813,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	namespace alias = ns;
 	//	void alias::fun() {
 	//	}
+	@Test
 	public void testNamespaceAliasAsQualifier_356493a() {
 		IFunction ref = getBindingFromASTName("fun", 0);
 		assertEquals("ns", ref.getOwner().getName());
@@ -1785,6 +1826,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 
 	//	void alias::fun() {
 	//	}
+	@Test
 	public void testNamespaceAliasAsQualifier_356493b() {
 		IFunction ref = getBindingFromASTName("fun", 0);
 		assertEquals("ns", ref.getOwner().getName());
@@ -1802,6 +1844,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	  f(a);
 	//	  g(b);
 	//	}
+	@Test
 	public void testStructClassMismatch_358282() {
 		getBindingFromASTName("f(a)", 1, ICPPFunction.class);
 		getBindingFromASTName("g(b)", 1, ICPPFunction.class);
@@ -1812,6 +1855,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	}
 
 	//	A a;
+	@Test
 	public void testAnonymousNamespace() {
 		getBindingFromFirstIdentifier("A", ICPPClassType.class);
 	}
@@ -1835,6 +1879,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	}
 	//
 	//	}
+	@Test
 	public void testAnonymousNamespaces_392577() {
 		getBindingFromFirstIdentifier("f(str)", ICPPFunction.class);
 	}
@@ -1848,6 +1893,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	    using ::ns::INT;
 	//	}
 	//	}
+	@Test
 	public void testAnonymousNamespaces_418130() {
 		checkBindings();
 	}
@@ -1865,6 +1911,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	int test() {
 	//	  foo(1);
 	//	}
+	@Test
 	public void testInheritedConstructor() {
 		checkBindings();
 	}
@@ -1883,6 +1930,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	int test() {
 	//	  foo(1);
 	//	}
+	@Test
 	public void testInheritedConstructorFromTemplateInstance() {
 		checkBindings();
 	}
@@ -1901,6 +1949,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	int test() {
 	//	  foo(1);
 	//	}
+	@Test
 	public void testInheritedConstructorFromUnknownClass() {
 		checkBindings();
 	}
@@ -1922,6 +1971,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	void test(A<int> a) {
 	//	  foo(a);
 	//	}
+	@Test
 	public void testInheritedTemplateConstructor() {
 		checkBindings();
 	}
@@ -1931,6 +1981,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	}
 
 	//	constexpr int waldo = foo();
+	@Test
 	public void testNameLookupInDefaultArgument_432701() {
 		IVariable waldo = getBindingFromASTName("waldo", 5);
 		assertEquals(42, waldo.getInitialValue().numberValue().longValue());
@@ -1948,6 +1999,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	};
 
 	//	int z;
+	@Test
 	public void testLambdaOwnedByClass_409882() {
 		checkBindings();
 	}
@@ -1957,6 +2009,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	};
 
 	//  // No code in this file.
+	@Test
 	public void testLambdaOwnedByClass_449099() {
 		checkBindings();
 	}
@@ -1964,6 +2017,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	extern char TableValue[10];
 
 	//	char TableValue[sizeof TableValue];
+	@Test
 	public void testNameLookupFromArrayModifier_435075() {
 		checkBindings();
 	}
@@ -1976,6 +2030,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	constexpr S waldo = { nullptr, waldo.a };
 
 	//  // empty file
+	@Test
 	public void testVariableInitializerThatReferencesVariable_508254a() throws Exception {
 		checkBindings();
 	}
@@ -1996,6 +2051,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	};
 
 	//	// empty file
+	@Test
 	public void testVariableInitializerThatReferencesVariable_508254b() throws Exception {
 		checkBindings();
 	}
@@ -2027,6 +2083,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	  c4->m();//4
 	//	  c5->m();//5
 	//	}
+	@Test
 	public void testOverridden_248846() throws Exception {
 		ICPPMethod m0 = getBindingFromFirstIdentifier("m();//0");
 		ICPPMethod m1 = getBindingFromFirstIdentifier("m();//1");
@@ -2085,6 +2142,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(unsigned long long i) { return Ret(); }
 
 	// auto test = 123_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes1() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2093,6 +2151,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(long double i) { return Ret(); }
 
 	// auto test = 12.3_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes2() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2101,6 +2160,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char* s) { return Ret(); }
 
 	// auto test = 123_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes1a() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2109,6 +2169,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char* s) { return Ret(); }
 
 	// auto test = 12.3_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes2a() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2118,6 +2179,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// bool operator "" _X(const char* s) { return false; }
 
 	// auto test = 123_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes1b() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2127,6 +2189,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// bool operator "" _X(const char* s) { return false; }
 
 	// auto test = 12.3_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes2b() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2135,6 +2198,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 
 	// auto test = "123"_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes3() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2143,6 +2207,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const wchar_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = L"123"_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes3a() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2151,6 +2216,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char16_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = u"123"_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes3b() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2159,6 +2225,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char32_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = U"123"_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes3c() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2167,6 +2234,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// template<char... Chars> Ret operator "" _X() { return Ret(); }
 
 	// auto test = 123_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes4a() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2175,6 +2243,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// template<char... Chars> Ret operator "" _X() { return Ret(); }
 
 	// auto test = 123.123_X;
+	@Test
 	public void testUserDefinedLiteralOperatorTypes4b() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2183,6 +2252,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 
 	// auto test = "123" "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation1a() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2191,6 +2261,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 
 	// auto test = "123"_X "123";
+	@Test
 	public void testUserDefinedLiteralConcatenation1b() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2199,6 +2270,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 
 	// auto test = u8"123" "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation2a() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2207,6 +2279,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 
 	// auto test = u8"123"_X "123";
+	@Test
 	public void testUserDefinedLiteralConcatenation2b() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2215,6 +2288,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 
 	// auto test = "123" u8"123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation2c() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2223,6 +2297,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char* s, unsigned sz) { return Ret(); }
 
 	// auto test = "123"_X u8"123";
+	@Test
 	public void testUserDefinedLiteralConcatenation2d() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2231,6 +2306,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const wchar_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = L"123" "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation3a() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2239,6 +2315,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const wchar_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = L"123"_X "123";
+	@Test
 	public void testUserDefinedLiteralConcatenation3b() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2247,6 +2324,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const wchar_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = "123" L"123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation3c() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2255,6 +2333,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const wchar_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = "123"_X L"123";
+	@Test
 	public void testUserDefinedLiteralConcatenation3d() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2263,6 +2342,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char16_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = u"123" "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation4a() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2271,6 +2351,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char16_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = u"123"_X "123";
+	@Test
 	public void testUserDefinedLiteralConcatenation4b() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2279,6 +2360,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char16_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = "123" u"123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation4c() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2287,6 +2369,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char16_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = "123"_X u"123";
+	@Test
 	public void testUserDefinedLiteralConcatenation4d() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2295,6 +2378,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char32_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = U"123" "123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation5a() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2303,6 +2387,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char32_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = U"123"_X "123";
+	@Test
 	public void testUserDefinedLiteralConcatenation5b() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2311,6 +2396,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char32_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = "123" U"123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation5c() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2319,6 +2405,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char32_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = "123"_X U"123";
+	@Test
 	public void testUserDefinedLiteralConcatenation5d() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2327,6 +2414,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _X(const char32_t* s, unsigned sz) { return Ret(); }
 
 	// auto test = "123"_X U"123"_X;
+	@Test
 	public void testUserDefinedLiteralConcatenation6() throws Exception {
 		assertUserDefinedLiteralType("Ret");
 	}
@@ -2336,6 +2424,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// Ret operator "" _Y(const char* s, unsigned sz) { return Ret(); }
 
 	// auto test = "123"_X "123"_Y;
+	@Test
 	public void testUserDefinedLiteralBadConcat1() throws Exception {
 		IASTProblem[] problems = strategy.getAst(0).getPreprocessorProblems();
 		assertEquals(1, problems.length);
@@ -2348,6 +2437,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// RetB operator "" _X(unsigned long long i) { return RetB(); }
 
 	// auto test = 123_X;
+	@Test
 	public void testUserDefinedLiteralResolution1() throws Exception {
 		assertUserDefinedLiteralType("RetB");
 	}
@@ -2358,6 +2448,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// RetB operator "" _X(long double i) { return RetB(); }
 
 	// auto test = 123.123_X;
+	@Test
 	public void testUserDefinedLiteralResolution2() throws Exception {
 		assertUserDefinedLiteralType("RetB");
 	}
@@ -2368,6 +2459,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	// RetB operator "" _X(const char * c) { return RetB(); }
 
 	// auto test = 123_X;
+	@Test
 	public void testUserDefinedLiteralResolution3() throws Exception {
 		ICPPVariable v = getBindingFromFirstIdentifier("test");
 		assertTrue(v.getType() instanceof IProblemType);
@@ -2385,6 +2477,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	int main() {
 	//	    B waldo;
 	//	}
+	@Test
 	public void testFinalOverriderAnalysis_489477() throws Exception {
 		ICPPVariable waldo = getBindingFromFirstIdentifier("waldo");
 		IType type = waldo.getType();
@@ -2398,6 +2491,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	};
 
 	//	B* b;
+	@Test
 	public void testFriendClassDeclaration_508338() throws Exception {
 		getProblemFromFirstIdentifier("B*");
 	}
@@ -2411,6 +2505,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	waldo waldo::instance;
 
 	//	// empty file
+	@Test
 	public void testStaticFieldOfEnclosingType_508254() throws Exception {
 		checkBindings();
 	}
@@ -2420,6 +2515,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	}
 
 	//	// empty file
+	@Test
 	public void testAnonymousStructInAnonymousNamespace_508254() throws Exception {
 		checkBindings();
 	}
@@ -2440,6 +2536,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	int main() {
 	//	    Foo a;  // Error: Type 'Foo' could not be resolved
 	//	}
+	@Test
 	public void testDelegatingConstructorCallInConstexprConstructor_509871() throws Exception {
 		checkBindings();
 	}
@@ -2460,6 +2557,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//
 	//	class C {};
 	//	derived<C> waldo = 0;
+	@Test
 	public void testDelegatingConstructorCallInConstexprConstructor_514595() throws Exception {
 		checkBindings();
 	}
@@ -2468,6 +2566,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	const NoneType None = None;
 
 	//	// empty file
+	@Test
 	public void testSelfReferencingVariable_510484() throws Exception {
 		checkBindings();
 	}
@@ -2483,6 +2582,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	void Foo::func() {
 	//		Bar waldo(0, 0);
 	//	}
+	@Test
 	public void testNestedClassDefinedOutOfLine_502999() throws Exception {
 		checkBindings();
 	}
@@ -2549,6 +2649,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	const MyClass MyClass::CONSTANT_NAME26( 26 );
 
 	//	// empty file
+	@Test
 	public void testOOM_529646() throws Exception {
 		checkBindings();
 	}
@@ -2556,6 +2657,7 @@ public abstract class IndexCPPBindingResolutionTest extends IndexBindingResoluti
 	//	int foo() noexcept;
 
 	//	constexpr bool is_noexcept = noexcept(foo());
+	@Test
 	public void testNoexceptOperator_545021() throws Exception {
 		IVariable isNoexcept = getBindingFromASTName("is_noexcept", 11);
 		assertEquals(1, isNoexcept.getInitialValue().numberValue().longValue());

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCPPTemplateResolutionTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCPPTemplateResolutionTest.java
@@ -16,6 +16,13 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.index.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -71,8 +78,7 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.CPPTemplates;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.SemanticUtil;
 import org.eclipse.cdt.internal.core.index.IIndexScope;
 import org.eclipse.core.runtime.CoreException;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for exercising resolution of template bindings against IIndex
@@ -83,10 +89,6 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 		public SingleProjectTest() {
 			setStrategy(new SinglePDOMTestStrategy(true));
 		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTest.class);
-		}
 	}
 
 	public static class ProjectWithDepProjTest extends IndexCPPTemplateResolutionTest {
@@ -94,20 +96,12 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 			setStrategy(new ReferencedProject(true));
 		}
 
-		public static TestSuite suite() {
-			return suite(ProjectWithDepProjTest.class);
-		}
-
 		@Override
+		@Test
 		public void testDefaultTemplateArgInHeader_264988() throws Exception {
 			// Not supported across projects (the composite index does not merge
 			// default values of template parameters).
 		}
-	}
-
-	public static void addTests(TestSuite suite) {
-		suite.addTest(SingleProjectTest.suite());
-		suite.addTest(ProjectWithDepProjTest.suite());
 	}
 
 	public IndexCPPTemplateResolutionTest() {
@@ -129,6 +123,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// };
 
 	// void f(Vec<int>::reference r) {}
+	@Test
 	public void testRebindPattern_214017_1() throws Exception {
 		IBinding b0 = getBindingFromASTName("r)", 1);
 		assertInstance(b0, ICPPVariable.class);
@@ -158,6 +153,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// };
 
 	// void f(Vec<int>::reference r) {}
+	@Test
 	public void testRebindPattern_214017_2() throws Exception {
 		IBinding b0 = getBindingFromASTName("r)", 1);
 		assertInstance(b0, ICPPVariable.class);
@@ -198,6 +194,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// };
 
 	// void f(Vec<int>::reference r) {}
+	@Test
 	public void testRebindPattern_214017_3() throws Exception {
 		IBinding b0 = getBindingFromASTName("r)", 1);
 		assertInstance(b0, ICPPVariable.class);
@@ -232,6 +229,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// void test(Vec<int>::reference p) {
 	//   f(p);
 	// }
+	@Test
 	public void testRebindPattern_276610() throws Exception {
 		getBindingFromASTName("f(p)", 1, ICPPFunction.class);
 	}
@@ -267,6 +265,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	   c1.m1("aaa");  // OK
 	//	   c1.m2("aaa");  // problem
 	//  }
+	@Test
 	public void testUnindexedConstructorInstanceImplicitReferenceToDeferred() throws Exception {
 		IBinding b0 = getBindingFromASTName("C1<char> c1", 8);
 		IBinding b1 = getBindingFromASTName("m1(\"aaa\")", 2);
@@ -285,6 +284,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// void bar() {
 	//   X<A>::foo();
 	// }
+	@Test
 	public void testUnindexedMethodInstance() {
 		IBinding b0 = getBindingFromASTName("foo()", 3);
 		assertInstance(b0, ICPPMethod.class);
@@ -299,6 +299,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//   StrT<char> x;
 	//   x.assign("aaa");
 	// }
+	@Test
 	public void testUnindexedMethodInstance2() throws Exception {
 		IBinding b0 = getBindingFromASTName("assign(\"aaa\")", 6);
 		assertInstance(b0, ICPPMethod.class);
@@ -314,6 +315,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// void bar() {
 	//   X<A> xa= new X<A>();
 	// }
+	@Test
 	public void testUnindexedConstructorInstance() {
 		IBinding b0 = getBindingFromImplicitASTName("X<A>()", 4);
 		assertInstance(b0, ICPPConstructor.class);
@@ -340,6 +342,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//     C1< StrT<A> > c1a;
 	//     c1a.m2(*new StrT<A>(new A()));
 	//  }
+	@Test
 	public void testUnindexedConstructorInstanceImplicitReference3() throws Exception {
 		IBinding b0 = getBindingFromASTName("C1< StrT<A> >", 2);
 		IBinding b1 = getBindingFromASTName("StrT<A> > c1a", 7);
@@ -380,6 +383,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	   m1("aaa");  // OK
 	//	   m2("aaa");  // problem
 	//  }
+	@Test
 	public void testUnindexedConstructorInstanceImplicitReference() throws Exception {
 		IBinding b0 = getBindingFromASTName("m1(\"aaa\")", 2);
 		IBinding b1 = getBindingFromASTName("m2(\"aaa\")", 2);
@@ -409,6 +413,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//            // foo -> CPPMethodTemplateSpecialization
 	//            // foo<int,int> -> CPPMethodInstance
 	//    }
+	@Test
 	public void testCPPConstructorTemplateSpecialization() throws Exception {
 		IBinding b0 = getBindingFromASTName("D<int> *var", 1);
 		IBinding b1 = getBindingFromASTName("D<int> *var", 6);
@@ -456,6 +461,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//		A<B> a;
 	//		a.f= foo<B>;
 	//	}
+	@Test
 	public void testOverloadedFunctionTemplate() {
 		IBinding b0 = getBindingFromASTName("foo<B>;", 6);
 		assertInstance(b0, ICPPFunction.class);
@@ -472,6 +478,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 
 	//	const char C::c[] = "";
 	//	int x = sizeof(f(C::c));
+	@Test
 	public void testOverloadedFunctionTemplate_407579() throws Exception {
 		checkBindings();
 	}
@@ -502,6 +509,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	  E y;
 	//	  waldo(x, y);
 	//	}
+	@Test
 	public void testOverloadedFunctionTemplate_429624() throws Exception {
 		checkBindings();
 	}
@@ -523,6 +531,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//		Foo<A,X> f;
 	//		f.s.foo(*new A());
 	//	}
+	@Test
 	public void testTemplateTemplateParameter() throws Exception {
 		IBinding b0 = getBindingFromASTName("Foo<A,X>", 3);
 		IBinding b1 = getBindingFromASTName("Foo<A,X>", 8);
@@ -580,6 +589,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// X x;
 	// Y y;
 	// Z z;
+	@Test
 	public void testInstanceInheritance() throws Exception {
 		IBinding[] bs = { getBindingFromASTName("X x;", 1), getBindingFromASTName("Y y;", 1),
 				getBindingFromASTName("Z z;", 1) };
@@ -613,6 +623,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void test() {
 	//	  B<int>::a;
 	//	}
+	@Test
 	public void testInstanceInheritance_258745() throws Exception {
 		getBindingFromFirstIdentifier("a", ICPPField.class);
 	}
@@ -627,6 +638,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	};
 
 	//	Derived waldo;
+	@Test
 	public void testMethodOveriddenFromTemplateInstanceBase_480892() throws Exception {
 		IVariable waldo = getBindingFromFirstIdentifier("waldo");
 		IType derived = waldo.getType();
@@ -646,6 +658,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// template<typename T3> class D<A, T3>; // harmless declaration for test purposes
 	// template<typename T3> class D<B, T3> {};
 	// template<typename T3> class D<C, T3> {};
+	@Test
 	public void testClassPartialSpecializations() throws Exception {
 		IBinding b0 = getBindingFromASTName("D<A, T3>", 8);
 		IBinding b1 = getBindingFromASTName("D<B, T3>", 8);
@@ -694,6 +707,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//    B<long>::foo(); // instance not in the referenced pdom
 	//    X<int> x;
 	// }
+	@Test
 	public void testClassImplicitInstantiations_188274() throws Exception {
 		IBinding b2 = getBindingFromASTName("X<int>", 6);
 		assertInstance(b2, ICPPClassType.class);
@@ -738,6 +752,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	};
 
 	// A<B> ab;
+	@Test
 	public void testClassSpecializationMethods() throws Exception {
 		IBinding b0 = getBindingFromASTName("A<B> ab", 4);
 		assertInstance(b0, ICPPClassType.class);
@@ -797,6 +812,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// 	void test() {
 	// 	  waldo(b);
 	// 	}
+	@Test
 	public void testTrailingReturnType_460183() throws Exception {
 		checkBindings();
 	}
@@ -816,6 +832,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//   A<B>::TD foo2= foo;
 	//   A<C>::TD bar2= bar;
 	// }
+	@Test
 	public void testTypedefSpecialization() {
 		IBinding b0 = getBindingFromASTName("TD foo2", 2);
 		IBinding b1 = getBindingFromASTName("TD bar2", 2);
@@ -844,6 +861,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//   C<int> x;
 	//   x.m(1);
 	// }
+	@Test
 	public void testTypedefSpecialization_213861() throws Exception {
 		IBinding b0 = getBindingFromASTName("m(1)", 1);
 		assertInstance(b0, ICPPMethod.class);
@@ -868,6 +886,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//      foo<C3,C2>(*new C3(), *new C2());
 	//      foo<C1,C3>(*new C1(), *new C3());
 	//	}
+	@Test
 	public void testFunctionTemplateSpecializations() throws Exception {
 		IBinding b0 = getBindingFromASTName("foo<C1>(", 3);
 		IBinding b1 = getBindingFromASTName("foo<C2>(", 3);
@@ -895,6 +914,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//		foo(a,b); // function instance of function template (0)
 	//		foo(c,a); // function specialization (1)
 	//	}
+	@Test
 	public void testFunctionInstanceSpecializationsParameters() throws Exception {
 		IBinding b0 = getBindingFromASTName("foo(a,b)", 3);
 		assertInstance(b0, ICPPFunction.class);
@@ -999,6 +1019,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//		A a;
 	//		foo(a);
 	//  }
+	@Test
 	public void testFunctionInstanceParameters() throws Exception {
 		IBinding b0 = getBindingFromFirstIdentifier("foo(a)");
 		assertInstance(b0, ICPPTemplateInstance.class);
@@ -1040,6 +1061,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	  A a;
 	//	  func(&a, &A::m);
 	//	}
+	@Test
 	public void testFunctionTemplate_245030() throws Exception {
 		ICPPFunction f = getBindingFromFirstIdentifier("func(&a, &A::m)");
 		assertInstance(f, ICPPTemplateInstance.class);
@@ -1061,6 +1083,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void test(const A<int>& a, int b) {
 	//	  func(a, b);
 	//	}
+	@Test
 	public void testFunctionTemplate_319498() throws Exception {
 		ICPPFunction f = getBindingFromFirstIdentifier("func(a, b)");
 		assertInstance(f, ICPPTemplateInstance.class);
@@ -1075,6 +1098,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	  typedef A a;
 	//	  waldo<a>();
 	//	}
+	@Test
 	public void testFunctionTemplateWithTypedef_431945() throws Exception {
 		checkBindings();
 	}
@@ -1095,6 +1119,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// class Foo<A> {};
 	//
 	// Foo<B> b2;
+	@Test
 	public void testClassSpecializations_180738() {
 		IBinding b1a = getBindingFromASTName("Foo<B> b1;", 3);
 		IBinding b1b = getBindingFromASTName("Foo<B> b1;", 6);
@@ -1140,6 +1165,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	Int a,b;
 	//	Int c= left(a,b);
 	//  Int c= left(a,d);
+	@Test
 	public void testSimpleFunctionTemplate() {
 		IBinding b0 = getBindingFromASTName("sanity();", 6);
 		IBinding b1 = getBindingFromASTName("a,b;", 1);
@@ -1155,6 +1181,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// template<typename X1> class D<X1,X1> {};
 
 	// D<A,A> daa;
+	@Test
 	public void testClassPartialSpecializations_199572() throws Exception {
 		IBinding b0 = getBindingFromASTName("D<A,A>", 6);
 		assertInstance(b0, ICPPTemplateInstance.class);
@@ -1182,6 +1209,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// };
 
 	// void f(Vec<int>::reference r) {}
+	@Test
 	public void testTemplateTypedef_214447() throws Exception {
 		IBinding b0 = getBindingFromASTName("r)", 1);
 		assertInstance(b0, ICPPVariable.class);
@@ -1226,6 +1254,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void test() {
 	//	  waldo(f(A()));
 	//	}
+	@Test
 	public void testTemplateArgumentDeduction_507511() throws Exception {
 		checkBindings();
 	}
@@ -1261,6 +1290,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//      C<X> cx;
 	//      foo(cx);
 	//	}
+	@Test
 	public void testUserDefinedConversionOperator_224364() throws Exception {
 		IBinding ca = getBindingFromASTName("C<A>", 4);
 		assertInstance(ca, ICPPClassType.class);
@@ -1293,6 +1323,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//
 	// A<B> ab;
 	// A<C> ac;
+	@Test
 	public void testEnclosingScopes_a() throws Exception {
 		ICPPSpecialization b0 = getBindingFromASTName("A<B>", 4, ICPPSpecialization.class, ICPPClassType.class);
 		ICPPTemplateInstance b1 = getBindingFromASTName("A<C>", 4, ICPPTemplateInstance.class, ICPPClassType.class);
@@ -1323,6 +1354,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//    A<C>::B acb;
 	//    A<D>::B adb;
 	// }
+	@Test
 	public void testEnclosingScopes_b() throws Exception {
 		ICPPClassType b0 = getBindingFromASTName("B acb", 1, ICPPClassType.class);
 		ICPPClassType b1 = getBindingFromASTName("B adb", 1, ICPPClassType.class, ICPPSpecialization.class);
@@ -1357,7 +1389,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 		ICPPClassScope cs1 = assertInstance(s1, ICPPClassScope.class);
 		assertInstance(cs1.getClassType(), ICPPClassType.class);
 		assertInstance(cs1.getClassType(), ICPPTemplateInstance.class);
-		assertTrue(((IType) ((ICPPClassSpecialization) s4.getScopeBinding()).getSpecializedBinding())
+		assertTrue(((ICPPClassSpecialization) s4.getScopeBinding()).getSpecializedBinding()
 				.isSameType((IType) ((IIndexScope) b3.getCompositeScope()).getScopeBinding()));
 	}
 
@@ -1373,6 +1405,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// };
 
 	// X<A>::Y::Z xayz;
+	@Test
 	public void testEnclosingScopes_c() throws Exception {
 		ICPPClassType b0 = getBindingFromASTName("Y::Z x", 1, ICPPClassType.class);
 		ICPPClassType b1 = getBindingFromASTName("Z xayz", 1, ICPPClassType.class);
@@ -1400,6 +1433,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// };
 
 	// X<B,A>::N n;
+	@Test
 	public void testEnclosingScopes_d() throws Exception {
 		ICPPClassType b0 = getBindingFromASTName("N n", 1, ICPPClassType.class, ICPPSpecialization.class);
 		ICPPClassType b1 = assertInstance(((ICPPSpecialization) b0).getSpecializedBinding(), ICPPClassType.class);
@@ -1420,6 +1454,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 
 	//    const SI y= 99;
 	//    A<y> ay;
+	@Test
 	public void testNonTypeTemplateParameter_207840() {
 		ICPPVariable b0 = getBindingFromASTName("y>", 1, ICPPVariable.class);
 		ICPPClassType b1 = getBindingFromASTName("A<y>", 1, ICPPClassType.class, ICPPTemplateDefinition.class);
@@ -1437,6 +1472,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//    A<int> a;
 	//    a.b.t;
 	// }
+	@Test
 	public void testNestedClassTypeSpecializations() throws Exception {
 		ICPPField t2 = getBindingFromASTName("t;", 1, ICPPField.class);
 
@@ -1490,6 +1526,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//		VS1::iterator it;
 	//		it->member; // it->member
 	//	}
+	@Test
 	public void testVectorIterator() throws Exception {
 		ICPPField t2 = getBindingFromASTName("member; // it->member", 6, ICPPField.class);
 		ICPPClassType ct = t2.getClassOwner();
@@ -1508,6 +1545,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	struct A::S {};
 
 	//  A::S<int> a;
+	@Test
 	public void testMemberTemplateClass() throws Exception {
 		checkBindings();
 	}
@@ -1532,6 +1570,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//		bar(t);
 	//		baz();
 	//	}
+	@Test
 	public void testClassInstanceWithNonTypeArgument_207871() throws Exception {
 		ICPPTemplateInstance c256 = getBindingFromASTName("C<256>", 6, ICPPTemplateInstance.class, ICPPClassType.class);
 		ICPPTemplateParameterMap paramMap = c256.getTemplateParameterMap();
@@ -1553,6 +1592,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	A<B, 'x'>::X x;
 	//	A<B, 'y'>::Y y;
 	//	A<B, 'z'>::Z z;
+	@Test
 	public void testNonTypeCharArgumentDisambiguation() throws Exception {
 		ICPPClassType b2 = getBindingFromASTName("A<B, 'x'>", 9, ICPPClassType.class, ICPPTemplateInstance.class);
 		ICPPClassType b3 = getBindingFromASTName("A<B, 'y'>", 9, ICPPClassType.class, ICPPTemplateInstance.class);
@@ -1581,6 +1621,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//
 	//	A<B, true>::X x; //3 should be an error
 	//	A<B, false>::Y y; //4 should be an error
+	@Test
 	public void testNonTypeBooleanArgumentDisambiguation() throws Exception {
 		ICPPClassType X = getBindingFromASTName("X x; //1", 1, ICPPClassType.class);
 		ICPPClassType Y = getBindingFromASTName("Y y; //2", 1, ICPPClassType.class);
@@ -1604,6 +1645,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//    A<5> a5d;
 	//    A<1> a1;
 	// }
+	@Test
 	public void testConstantPropagationFromHeader() throws Exception {
 		ICPPClassType a5a = getBindingFromASTName("A<FIVE>", 7, ICPPClassType.class, ICPPSpecialization.class);
 		ICPPClassType a5b = getBindingFromASTName("A<CINQ>", 7, ICPPClassType.class, ICPPSpecialization.class);
@@ -1637,6 +1679,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	template <int I>
 	//	inline This<I>::This() : That<I>(I) {
 	//  }
+	@Test
 	public void testParameterReferenceInChainInitializer_a() throws Exception {
 		// These intermediate assertions will not hold until deferred non-type arguments are
 		// correctly modelled
@@ -1667,6 +1710,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	template <typename I>
 	//	inline This<I>::This() : That<I>() {
 	//	}
+	@Test
 	public void testParameterReferenceInChainInitializer_b() throws Exception {
 		ICPPClassType tid = getBindingFromASTName("This<I>::T", 7, ICPPClassType.class);
 		assertFalse(tid instanceof ICPPSpecialization);
@@ -1683,6 +1727,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// };
 
 	// CT<int> v1;
+	@Test
 	public void testUniqueSpecializations_241641() throws Exception {
 		ICPPVariable v1 = getBindingFromASTName("v1", 2, ICPPVariable.class);
 		ICPPVariable v2 = getBindingFromASTName("v1", 2, ICPPVariable.class);
@@ -1702,6 +1747,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// };
 
 	// CT<int> v1;
+	@Test
 	public void testUniqueInstance_241641() throws Exception {
 		IASTName name = findName("v1", 2);
 		ICPPVariable v1 = getBindingFromASTName("v1", 2, ICPPVariable.class);
@@ -1729,6 +1775,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void test() {
 	//     x.method();
 	//  }
+	@Test
 	public void testMethodSpecialization_248927() throws Exception {
 		ICPPMethod m = getBindingFromASTName("method", 6, ICPPMethod.class);
 		assertInstance(m, ICPPSpecialization.class);
@@ -1745,6 +1792,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	};
 
 	//	template<class T> void A<T, int>::foo(T t) {}
+	@Test
 	public void testBug177418() throws Exception {
 		ICPPMethod m = getBindingFromASTName("foo", 3, ICPPMethod.class);
 		ICPPClassType owner = m.getClassOwner();
@@ -1762,6 +1810,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//    this->m(); // 2
 	//    this->f; // 2
 	// };
+	@Test
 	public void testUnknownBindings_264988() throws Exception {
 		ICPPMethod m = getBindingFromASTName("m(); // 1", 1, ICPPMethod.class);
 		assertFalse(m instanceof ICPPUnknownBinding);
@@ -1780,6 +1829,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// void test() {
 	//    XT<> x;
 	// };
+	@Test
 	public void testDefaultTemplateArgInHeader_264988() throws Exception {
 		ICPPTemplateInstance ti = getBindingFromASTName("XT<>", 4, ICPPTemplateInstance.class);
 	}
@@ -1792,6 +1842,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	// template<> void XT<int>::m() {
 	//    TInt t;
 	// }
+	@Test
 	public void testParentScopeOfSpecialization_267013() throws Exception {
 		ITypedef ti = getBindingFromASTName("TInt", 4, ITypedef.class);
 	}
@@ -1862,6 +1913,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	  vector<int> v;
 	//	  f(v.begin());
 	//	}
+	@Test
 	public void testTemplateMetaprogramming_284686() throws Exception {
 		getBindingFromASTName("f(v.begin())", 1, ICPPFunction.class);
 	}
@@ -1881,6 +1933,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//		Noder1<int> f;
 	//		Noder2<int> g;
 	//	}
+	@Test
 	public void testInstantiationOfValue_284683() throws Exception {
 		getBindingFromASTName("Noder1<int>", 11, ICPPClassSpecialization.class);
 		getBindingFromASTName("Noder2<int>", 11, ICPPClassSpecialization.class);
@@ -1898,6 +1951,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//		CT<X> p;
 	//		p.f.x;
 	//	}
+	@Test
 	public void testTemplateParameterWithoutName_300978() throws Exception {
 		getBindingFromASTName("x;", 1, ICPPField.class);
 		ICPPClassSpecialization ctx = getBindingFromASTName("CT<X>", 5, ICPPClassSpecialization.class);
@@ -1918,6 +1972,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//    f(1);
 	//    g(1);
 	// }
+	@Test
 	public void testExplicitSpecializations_296427() throws Exception {
 		ICPPTemplateInstance inst;
 		inst = getBindingFromASTName("X<int>", 0);
@@ -1940,6 +1995,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//		OutStream<char> out;
 	//		out << endl;
 	//	}
+	@Test
 	public void testInstantiationOfEndl_297457() throws Exception {
 		final IBinding reference = getBindingFromASTName("<< endl", 2);
 		assertTrue(reference instanceof ICPPSpecialization);
@@ -1977,6 +2033,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	    a.f(0);
 	//	    return 0;
 	//	}
+	@Test
 	public void testPartialSpecializationsOfClassTemplateSpecializations_332884() throws Exception {
 		final IBinding reference = getBindingFromASTName("f(0)", 1);
 		assertTrue(reference instanceof ICPPSpecialization);
@@ -1995,6 +2052,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//  struct TXT : XT<int> {};
 
 	// TXT x;
+	@Test
 	public void testClassSpecialization_354086() throws Exception {
 		ICPPClassType ct = getBindingFromASTName("TXT", 0, ICPPClassType.class);
 		ICPPMethod[] methods = ct.getAllDeclaredMethods();
@@ -2040,6 +2098,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//		c.f(2);
 	//		c.f(2,1);
 	//	}
+	@Test
 	public void testSpecializationOfUsingDeclaration_357293() throws Exception {
 		getBindingFromASTName("f()", 1, ICPPMethod.class);
 		getBindingFromASTName("f(1)", 1, ICPPMethod.class);
@@ -2056,6 +2115,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	template<class T> typename C1<T>::iterator C1<T>::m1() {
 	//		return 0;
 	//	}
+	@Test
 	public void testUsageOfClassTemplateOutsideOfClassBody_357320() throws Exception {
 		getBindingFromASTName("m1", 0, ICPPMethod.class);
 	}
@@ -2069,6 +2129,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	int main() {
 	//	    typedef foo<int>::type type;
 	//	}
+	@Test
 	public void testSpecializationInIndex_367563a() throws Exception {
 		getBindingFromASTName("type type", 4, ITypedef.class);
 	}
@@ -2082,6 +2143,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	int main() {
 	//	    typedef foo<int*>::type type;
 	//	}
+	@Test
 	public void testSpecializationInIndex_367563b() throws Exception {
 		getBindingFromASTName("type type", 4, ITypedef.class);
 	}
@@ -2100,6 +2162,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void test(A<int> a) {
 	//	  waldo(a);
 	//	}
+	@Test
 	public void testSpecializationInIndex_491636() throws Exception {
 		checkBindings();
 	}
@@ -2120,6 +2183,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	    typedef int type;
 	//	};
 	//	typedef foo<remove_const<const int>::type>::type t;
+	@Test
 	public void testCurrentInstanceOfClassTemplatePartialSpec_368404() throws Exception {
 		ITypedef tdef = getBindingFromASTName("type t;", 4, ITypedef.class);
 		assertEquals("int", ASTTypeUtil.getType(tdef, true));
@@ -2169,6 +2233,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	};
 	//
 	//	typedef A<C> type;
+	@Test
 	public void testSfinae_a() throws Exception {
 		checkBindings();
 	}
@@ -2201,6 +2266,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	  A<double>::get();
 	//	  A<int>::get();
 	//	}
+	@Test
 	public void testSfinae_b() throws Exception {
 		checkBindings();
 	}
@@ -2216,6 +2282,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	int waldo(int p);
 	//
 	//	int x = waldo(test<A>(0));
+	@Test
 	public void testSfinaeInNewExpression_430230() throws Exception {
 		checkBindings();
 	}
@@ -2228,6 +2295,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	template<template<class,class> class ListT, class UType, class Alloc, class StringT>
 	//	void CString::split(ListT<UType,Alloc>& out, const StringT& sep, bool keepEmptyElements, bool trimElements, bool emptyBefore) const {
 	//	}
+	@Test
 	public void testMemberOfTemplateTemplateParameter_381824() throws Exception {
 		checkBindings();
 	}
@@ -2240,6 +2308,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	struct my_type{};
 	//
 	//	using foo = my_template<my_type>;
+	@Test
 	public void testTemplateTemplateNonTypeParameterPack_bug538069() throws Exception {
 		checkBindings();
 	}
@@ -2255,6 +2324,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//     TAlias<int> myA;
 	//     myA.t = 42;
 	// }
+	@Test
 	public void testAliasTemplate() throws Exception {
 		checkBindings();
 	}
@@ -2272,6 +2342,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void test() {
 	//	  int x = C<bool>::id;
 	//	}
+	@Test
 	public void testDependentEnumValue_389009() throws Exception {
 		IEnumerator binding = getBindingFromASTName("id;", 2, IEnumerator.class);
 		IValue value = binding.getValue();
@@ -2307,6 +2378,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void foo(C<S> x){
 	//	    bar(x());
 	//	}
+	@Test
 	public void testDependentEnumerator_482421a() throws Exception {
 		checkBindings();
 	}
@@ -2338,6 +2410,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void foo(C<S> x){
 	//	    bar(x());
 	//	}
+	@Test
 	public void testDependentEnumerator_482421b() throws Exception {
 		checkBindings();
 	}
@@ -2407,6 +2480,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	  F<int*> a;
 	//	  f(*a[0]);
 	//	}
+	@Test
 	public void testConstexprFunction_395238_1() throws Exception {
 		checkBindings();
 	}
@@ -2436,6 +2510,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 
 	//	B<bool>::type x;
 	//	B<int*>::type y;
+	@Test
 	public void testConstexprFunction_395238_2() throws Exception {
 		ITypedef td = getBindingFromFirstIdentifier("type x", ITypedef.class);
 		assertEquals("bool", ASTTypeUtil.getType(td.getType()));
@@ -2452,6 +2527,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void test(BinaryPredicate bp) {
 	//	    sort(s, [&bp](const S* a, const S* b){ return bp(*a, *b); });
 	//	}
+	@Test
 	public void testLambdaExpression_395884() throws Exception {
 		checkBindings();
 	}
@@ -2466,6 +2542,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	    S<1> n;
 	//	    f(n.foo(0));
 	//	}
+	@Test
 	public void testDependentExpression_395875() throws Exception {
 		getBindingFromASTName("f(n.foo(0))", 1, ICPPFunction.class);
 	}
@@ -2504,6 +2581,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	int main() {
 	//	    A<has_type<T>::type::value>::type a;
 	//	}
+	@Test
 	public void testIntNullPointerConstant_407808() throws Exception {
 		checkBindings();
 	}
@@ -2526,6 +2604,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	int main() {
 	//	    waldo(foo::cat{});
 	//	}
+	@Test
 	public void testADLForQualifiedName_408296() throws Exception {
 		checkBindings();
 	}
@@ -2543,6 +2622,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	struct outer::inner<waldo<T>> {};
 
 	//	int main() {}
+	@Test
 	public void testRegression_408314() throws Exception {
 		checkBindings();
 	}
@@ -2552,6 +2632,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	template<> struct A<int> { enum { v = 1 }; };
 
 	//	int main() {}
+	@Test
 	public void testSpecializationRedefinition_409444() throws Exception {
 		checkBindings();
 	}
@@ -2567,6 +2648,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	};
 
 	//	List<N>::Base<&N::node> base;
+	@Test
 	public void testDependentTemplateParameterInNestedTemplate_407497() throws Exception {
 		checkBindings();
 	}
@@ -2580,6 +2662,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	};
 
 	//	typedef enclosing<int>::nested<>::type waldo;
+	@Test
 	public void testDependentTemplateParameterInNestedTemplate_399454() throws Exception {
 		checkBindings();
 	}
@@ -2594,6 +2677,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	};
 
 	//	typedef decltype(A<int>::foo<>()) waldo;
+	@Test
 	public void testNPE_407497() throws Exception {
 		checkBindings();
 	}
@@ -2638,6 +2722,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	}
 	//
 	//	static_assert(D<10>(1000000000) == 10, "");
+	@Test
 	public void testOOM_497875() throws Exception {
 		// TODO(sprigogin): Uncomment after http://bugs.eclipse.org/497931 is fixed.
 		//		checkBindings();
@@ -2658,6 +2743,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//      C c;
 	//      c.eof();
 	//  }
+	@Test
 	public void testAmbiguousBaseClassLookup_413406() throws Exception {
 		getProblemFromASTName("eof();", 3);
 	}
@@ -2676,6 +2762,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	};
 	//
 	//	typedef S<>::type T;
+	@Test
 	public void testExplicitSpecializationOfTemplateDeclaredInHeader_401820() throws Exception {
 		IType T = getBindingFromASTName("T", 1);
 		assertEquals("int", ASTTypeUtil.getType(T));
@@ -2699,6 +2786,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	    overloaded c, d;
 	//	    foo(c * d);
 	//	}
+	@Test
 	public void testFriendFunctionOfClassSpecialization_419301a() throws Exception {
 		checkBindings();
 	}
@@ -2721,6 +2809,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	    overloaded c, d;
 	//	    foo(c * d);
 	//	}
+	@Test
 	public void testFriendFunctionOfClassSpecialization_419301b() throws Exception {
 		checkBindings();
 	}
@@ -2737,6 +2826,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void test() {
 	//	  A<B>::get();
 	//	}
+	@Test
 	public void testFriendClassSpecialization_466362() throws Exception {
 		checkBindings();
 	}
@@ -2752,6 +2842,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	}
 
 	//	// empty source file
+	@Test
 	public void testSpecializationOfConstexprFunction_420995() throws Exception {
 		checkBindings();
 	}
@@ -2770,6 +2861,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	}
 
 	//	constexpr int waldo = foo<int>();
+	@Test
 	public void testInstantiationOfReturnExpression_484959() throws Exception {
 		ICPPVariable waldo = getBindingFromFirstIdentifier("waldo");
 		assertVariableValue(waldo, 42);
@@ -2797,6 +2889,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	struct meta<int> {};
 
 	//	int z;
+	@Test
 	public void testEnumerationWithMultipleEnumerators_434467() throws Exception {
 		checkBindings();
 	}
@@ -2824,6 +2917,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void foo() {
 	//	    bar(decl());  // ERROR HERE: Invalid arguments
 	//	}
+	@Test
 	public void testInstantiationOfFunctionInstance_437675() throws Exception {
 		checkBindings();
 	}
@@ -2850,6 +2944,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	class MYCComQIPtr<IUnknown, &IID_IUnknown> : public MYCComPtr<IUnknown> {};
 
 	//	// source file is deliberately empty
+	@Test
 	public void testInfiniteRecursionMarshallingTemplateDefinition_439923() throws Exception {
 		checkBindings();
 	}
@@ -2871,6 +2966,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//  }
 
 	//	// empty source file
+	@Test
 	public void testInfiniteRecursion_516648() throws Exception {
 		checkBindings();
 	}
@@ -2890,6 +2986,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	struct make_int_pack : append<typename make_int_pack<C - 1>::type, C - 1> {};
 	//
 	//	template <> struct make_int_pack<0> : int_pack<> {};
+	@Test
 	public void testRecursiveInheritance_466362() throws Exception {
 		checkBindings();
 	}
@@ -2911,6 +3008,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//		Bar<int> var1;
 	//		auto var2 = foo(S());
 	//	}
+	@Test
 	public void testTypeOfUnknownMember_447728() throws Exception {
 		IVariable var1 = getBindingFromASTName("var1", 4);
 		IVariable var2 = getBindingFromASTName("var2", 4);
@@ -2932,6 +3030,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	    allocator<Item>::value_type item;
 	//	    item.waldo = 5;
 	//	}
+	@Test
 	public void testRedeclarationWithUnnamedTemplateParameter_472199() throws Exception {
 		checkBindings();
 	}
@@ -2956,6 +3055,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	typedef Operation< R<1> >::value MYTYPE;
 
 	//	// empty file
+	@Test
 	public void testRecursiveTemplateInstantiation_479138a() throws Exception {
 		// This tests that a template metaprogram whose termination depends on
 		// its inputs being known, doesn't cause a stack overflow when its
@@ -2992,6 +3092,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	typedef Operation< R<1> >::value MYTYPE;
 
 	//	// empty file
+	@Test
 	public void testRecursiveTemplateInstantiation_479138b() throws Exception {
 		// This is similar to 479138a, but the metaprogram additionally has
 		// exponential memory usage when the inputs are unknown and thus
@@ -3016,6 +3117,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 
 	//	// empty file
 	//	// special:allowRecursionBindings
+	@Test
 	public void testRecursiveTemplateInstantiation_479138c() throws Exception {
 		// This tests that a template metaprogram that doesn't terminate at all
 		// (e.g. because the author omitted a base case) doesn't cause a stack overflow.
@@ -3036,6 +3138,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	}
 
 	//	// empty file
+	@Test
 	public void testStackOverflow_462764() throws Exception {
 		checkBindings();
 	}
@@ -3051,6 +3154,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	};
 
 	//	derived<int> waldo;
+	@Test
 	public void testSerializationOfUnknownConstructor_490475() throws Exception {
 		IASTName waldoName = findName("waldo", 5);
 		IVariable waldo = getBindingFromASTName("waldo", 5);
@@ -3074,6 +3178,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void bar() {
 	//	    foo([]{});
 	//	}
+	@Test
 	public void testBracedInitList_490475() throws Exception {
 		checkBindings();
 	}
@@ -3093,6 +3198,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//		auto x = foo(0);
 	//		x.woof();
 	//	}
+	@Test
 	public void testUnqualifiedFunctionCallInTemplate_402498() throws Exception {
 		checkBindings();
 	}
@@ -3107,6 +3213,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	};
 	//
 	//	typedef traits<M<int>>::type waldo;  // ERROR
+	@Test
 	public void testRegression_402498() throws Exception {
 		checkBindings();
 	}
@@ -3158,6 +3265,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void foo(sub_match<Iter> w) {
 	//	    waldo(w);
 	//	}
+	@Test
 	public void testRegression_516338() throws Exception {
 		checkBindings();
 	}
@@ -3171,6 +3279,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	constexpr auto foo = Foo{};
 
 	//	// empty file
+	@Test
 	public void testAssignmentToMemberArrayElement_514363() throws Exception {
 		checkBindings();
 	}
@@ -3185,6 +3294,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	auto waldo = Outer<int>::static_field;
 
 	//	int x = waldo.field;
+	@Test
 	public void testSpecializationOfAnonymousClass_528456() throws Exception {
 		checkBindings();
 	}
@@ -3216,6 +3326,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	struct MessageFunctionPrivate {
 	//	    QFlags<Option> Options{ShowMessageBox, Log};
 	//	};
+	@Test
 	public void testConstexprInitListConstructor_519091() throws Exception {
 		checkBindings();
 	}
@@ -3237,6 +3348,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	void callInCpp1(int i) {
 	//	    apply(i, &consume);
 	//	}
+	@Test
 	public void testClassCastException_533216() throws Exception {
 		checkBindings();
 	}
@@ -3248,6 +3360,7 @@ public abstract class IndexCPPTemplateResolutionTest extends IndexBindingResolut
 	//	auto make_array(Ts... ts) -> array<sizeof...(ts)>;
 
 	//	auto x = make_array(2);
+	@Test
 	public void testRecursion_535548() throws Exception {
 		checkBindings();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCPPVariableTemplateResolutionTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexCPPVariableTemplateResolutionTest.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.index.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.eclipse.cdt.core.dom.ast.IVariable;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPField;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPFieldTemplate;
@@ -21,18 +23,13 @@ import org.eclipse.cdt.core.dom.ast.cpp.ICPPVariableInstance;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPVariableTemplate;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPVariableTemplatePartialSpecialization;
 import org.eclipse.cdt.core.index.IIndexBinding;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public abstract class IndexCPPVariableTemplateResolutionTest extends IndexBindingResolutionTestBase {
 
 	public static class SingleProjectTest extends IndexCPPVariableTemplateResolutionTest {
 		public SingleProjectTest() {
 			setStrategy(new SinglePDOMTestStrategy(true));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTest.class);
 		}
 	}
 
@@ -41,14 +38,6 @@ public abstract class IndexCPPVariableTemplateResolutionTest extends IndexBindin
 			setStrategy(new ReferencedProject(true));
 		}
 
-		public static TestSuite suite() {
-			return suite(ProjectWithDepProjTest.class);
-		}
-	}
-
-	public static void addTests(TestSuite suite) {
-		suite.addTest(SingleProjectTest.suite());
-		suite.addTest(ProjectWithDepProjTest.suite());
 	}
 
 	public IndexCPPVariableTemplateResolutionTest() {
@@ -58,6 +47,7 @@ public abstract class IndexCPPVariableTemplateResolutionTest extends IndexBindin
 	// template<typename T> constexpr T pi = T(3);
 
 	// int f(){ return pi<int>; };
+	@Test
 	public void testVariableTemplateReference() {
 		checkBindings();
 		ICPPVariableTemplate pi = getBindingFromASTName("pi", 0);
@@ -71,6 +61,7 @@ public abstract class IndexCPPVariableTemplateResolutionTest extends IndexBindin
 	// };
 
 	// int f(){ return S::pi<int>; };
+	@Test
 	public void testFieldTemplateReference() {
 		checkBindings();
 		ICPPFieldTemplate pi = getBindingFromASTName("pi", 0);
@@ -83,6 +74,7 @@ public abstract class IndexCPPVariableTemplateResolutionTest extends IndexBindin
 	// template constexpr int pi<int>;
 
 	// int f(){ return pi<int>; }
+	@Test
 	public void testExplicitVariableInstance() {
 		checkBindings();
 		ICPPVariableTemplate pi = getBindingFromASTName("pi", 0);
@@ -98,6 +90,7 @@ public abstract class IndexCPPVariableTemplateResolutionTest extends IndexBindin
 	// template constexpr double S::pi<double>;
 
 	// double f(){ return S::pi<double>; }
+	@Test
 	public void testExplicitFieldInstance() {
 		checkBindings();
 		ICPPFieldTemplate pi = getBindingFromASTName("pi", 0);
@@ -111,6 +104,7 @@ public abstract class IndexCPPVariableTemplateResolutionTest extends IndexBindin
 	// template<> constexpr int pi<int> = 4;
 
 	// int f(){ return pi<int>; }
+	@Test
 	public void testVariableSpecialization() {
 		checkBindings();
 		ICPPVariableTemplate pi = getBindingFromASTName("pi", 0);
@@ -126,6 +120,7 @@ public abstract class IndexCPPVariableTemplateResolutionTest extends IndexBindin
 	// template<> constexpr double S::pi<double> = 4;
 
 	// double f(){ return S::pi<double>; }
+	@Test
 	public void testFieldSpecialization() {
 		checkBindings();
 		ICPPFieldTemplate pi = getBindingFromASTName("pi", 0);
@@ -140,6 +135,7 @@ public abstract class IndexCPPVariableTemplateResolutionTest extends IndexBindin
 	// };
 
 	// template<> constexpr double S::pi<double> = 4;
+	@Test
 	public void testFieldSpecializationInRef() {
 		checkBindings();
 		ICPPVariableInstance piOfDouble = getBindingFromASTName("pi<double>", 0, ICPPVariableInstance.class,
@@ -150,6 +146,7 @@ public abstract class IndexCPPVariableTemplateResolutionTest extends IndexBindin
 	// template<int I> float c<float, I> = float(I);
 
 	// float f() { return c<float, 100>; }
+	@Test
 	public void testVariableTemplatePartialSpecialization() {
 		checkBindings();
 		ICPPVariableTemplate c = getBindingFromASTName("c", 0);
@@ -167,6 +164,7 @@ public abstract class IndexCPPVariableTemplateResolutionTest extends IndexBindin
 	// template<typename T> T* c<T*> = T(10);
 
 	// float f() { return c<int*>; }
+	@Test
 	public void testVariableTemplatePartialSpecialization2() {
 		checkBindings();
 		ICPPVariableTemplate c = getBindingFromASTName("c", 0);
@@ -186,6 +184,7 @@ public abstract class IndexCPPVariableTemplateResolutionTest extends IndexBindin
 	// template<int I> constexpr float S::c<float, I> = float(I);
 
 	// float f() { return S::c<float, 100>; }
+	@Test
 	public void testFieldTemplatePartialSpecialization() {
 		checkBindings();
 		ICPPVariableTemplate c = getBindingFromASTName("c", 0);
@@ -205,6 +204,7 @@ public abstract class IndexCPPVariableTemplateResolutionTest extends IndexBindin
 
 	//  struct A {};
 	//  constexpr bool waldo = templ<A>;
+	@Test
 	public void testStorageOfUninstantiatedValue_bug486671() {
 		checkBindings();
 		IVariable waldo = getBindingFromASTName("waldo", 5);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexConceptTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexConceptTest.java
@@ -16,8 +16,8 @@ package org.eclipse.cdt.internal.index.tests;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTConceptDefinition;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPConcept;
 import org.eclipse.cdt.core.testplugin.TestScannerProvider;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * AST tests for C++20 concepts via PDOM.
@@ -27,19 +27,11 @@ public abstract class IndexConceptTest extends IndexBindingResolutionTestBase {
 		public SingleProject() {
 			setStrategy(new SinglePDOMTestStrategy(true /* cpp */));
 		}
-
-		public static TestSuite suite() {
-			return suite(SingleProject.class);
-		}
 	}
 
 	public static class SingleProjectReindexed extends IndexConceptTest {
 		public SingleProjectReindexed() {
 			setStrategy(new SinglePDOMReindexedTestStrategy(true /* cpp */));
-		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectReindexed.class);
 		}
 	}
 
@@ -47,26 +39,13 @@ public abstract class IndexConceptTest extends IndexBindingResolutionTestBase {
 		public ProjectWithDepProj() {
 			setStrategy(new ReferencedProject(true /* cpp */));
 		}
-
-		public static TestSuite suite() {
-			return suite(ProjectWithDepProj.class);
-		}
-	}
-
-	private static void cxx20SetUp() {
-		TestScannerProvider.sDefinedSymbols.put("__cpp_concepts", "201907L");
 	}
 
 	@Override
-	public void setUp() throws Exception {
-		cxx20SetUp();
-		super.setUp();
-	}
-
-	public static void addTests(TestSuite suite) {
-		suite.addTest(SingleProject.suite());
-		suite.addTest(SingleProjectReindexed.suite());
-		suite.addTest(ProjectWithDepProj.suite());
+	@BeforeEach
+	protected void setUpStrategy() throws Exception {
+		TestScannerProvider.sDefinedSymbols.put("__cpp_concepts", "201907L");
+		super.setUpStrategy();
 	}
 
 	//  template<typename T>
@@ -74,6 +53,7 @@ public abstract class IndexConceptTest extends IndexBindingResolutionTestBase {
 
 	//  template<typename T>
 	//  concept B = A<T>;
+	@Test
 	public void testConceptDefinitionFromHeader() throws Exception {
 		checkBindings();
 

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexDeductionGuideTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexDeductionGuideTest.java
@@ -18,8 +18,7 @@ import static org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes.double_;
 import static org.eclipse.cdt.core.parser.tests.ast2.CommonCPPTypes.int_;
 
 import org.eclipse.cdt.core.dom.ast.IVariable;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * AST tests for C++17 deduction guides via PDOM.
@@ -29,19 +28,11 @@ public abstract class IndexDeductionGuideTest extends IndexBindingResolutionTest
 		public IndexDeductionGuideTestSingleProject() {
 			setStrategy(new SinglePDOMTestStrategy(true /* cpp */));
 		}
-
-		public static TestSuite suite() {
-			return suite(IndexDeductionGuideTestSingleProject.class);
-		}
 	}
 
 	public static class IndexDeductionGuideTestSingleProjectReindexed extends IndexDeductionGuideTest {
 		public IndexDeductionGuideTestSingleProjectReindexed() {
 			setStrategy(new SinglePDOMReindexedTestStrategy(true /* cpp */));
-		}
-
-		public static TestSuite suite() {
-			return suite(IndexDeductionGuideTestSingleProjectReindexed.class);
 		}
 	}
 
@@ -49,16 +40,6 @@ public abstract class IndexDeductionGuideTest extends IndexBindingResolutionTest
 		public IndexDeductionGuideTestProjectWithDepProj() {
 			setStrategy(new ReferencedProject(true /* cpp */));
 		}
-
-		public static TestSuite suite() {
-			return suite(IndexDeductionGuideTestProjectWithDepProj.class);
-		}
-	}
-
-	public static void addTests(TestSuite suite) {
-		suite.addTest(IndexDeductionGuideTestSingleProject.suite());
-		suite.addTest(IndexDeductionGuideTestSingleProjectReindexed.suite());
-		suite.addTest(IndexDeductionGuideTestProjectWithDepProj.suite());
 	}
 
 	//  template<typename T> struct S {
@@ -86,6 +67,7 @@ public abstract class IndexDeductionGuideTest extends IndexBindingResolutionTest
 	//  }
 	//
 	//  constexpr size_t value = sizeof(ddouble.value);
+	@Test
 	public void testDeductionGuideBasicHeader() throws Exception {
 		assertType(getBindingFromASTName("dchar = S", 5), char_);
 		assertType(getBindingFromASTName("dint = S", 4), double_);
@@ -135,6 +117,7 @@ public abstract class IndexDeductionGuideTest extends IndexBindingResolutionTest
 	//	  Unrelated(_KeyInUnrelated)
 	//	    -> Unrelated<_KeyInUnrelated, Dependent<_KeyInUnrelated>>;
 	//	}
+	@Test
 	public void testDeductionGuideTemplateIssue438() throws Exception {
 		getBindingFromASTName("Base<int>::result_type; // test marker", 22);
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexGPPBindingResolutionTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexGPPBindingResolutionTest.java
@@ -17,8 +17,7 @@ import org.eclipse.cdt.core.dom.ast.IField;
 import org.eclipse.cdt.core.dom.ast.ITypedef;
 import org.eclipse.cdt.core.testplugin.TestScannerProvider;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPBasicType;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * For testing resolution of bindings in C++ code with GNU extensions.
@@ -74,25 +73,12 @@ public abstract class IndexGPPBindingResolutionTest extends IndexBindingResoluti
 		public SingleProjectTest() {
 			setStrategy(new GPPSinglePDOMTestStrategy());
 		}
-
-		public static TestSuite suite() {
-			return suite(SingleProjectTest.class);
-		}
 	}
 
 	public static class ProjectWithDepProjTest extends IndexGPPBindingResolutionTest {
 		public ProjectWithDepProjTest() {
 			setStrategy(new GPPReferencedProject());
 		}
-
-		public static TestSuite suite() {
-			return suite(ProjectWithDepProjTest.class);
-		}
-	}
-
-	public static void addTests(TestSuite suite) {
-		suite.addTest(SingleProjectTest.suite());
-		suite.addTest(ProjectWithDepProjTest.suite());
 	}
 
 	//	struct B {
@@ -102,6 +88,7 @@ public abstract class IndexGPPBindingResolutionTest extends IndexBindingResoluti
 	//	struct B b = {
 	//	  .f = 3.1
 	//	};
+	@Test
 	public void testDesignatedInitializer() throws Exception {
 		IField f = getBindingFromASTName("f", 0);
 	}
@@ -130,6 +117,7 @@ public abstract class IndexGPPBindingResolutionTest extends IndexBindingResoluti
 	//	typedef underlying_type<e_int>::type int_type;
 	//	typedef underlying_type<e_ulong>::type ulong_type;
 	//	typedef underlying_type<e_long>::type loong_type;
+	@Test
 	public void testUnderlyingTypeBuiltin_bug411196() throws Exception {
 		assertSameType((ITypedef) getBindingFromASTName("short1_type", 0), CPPBasicType.SHORT);
 		assertSameType((ITypedef) getBindingFromASTName("short2_type", 0), CPPBasicType.SHORT);

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexMultiFileTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexMultiFileTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.index.tests;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * Index tests involving multiple header and source files.
@@ -26,10 +26,6 @@ public class IndexMultiFileTest extends IndexBindingResolutionTestBase {
 
 	public IndexMultiFileTest() {
 		setStrategy(new SinglePDOMTestNamedFilesStrategy(true));
-	}
-
-	public static TestSuite suite() {
-		return suite(IndexMultiFileTest.class);
 	}
 
 	// A.h
@@ -56,6 +52,7 @@ public class IndexMultiFileTest extends IndexBindingResolutionTestBase {
 	//	void test(A<B*> a, B* b) {
 	//	  a.m(b);
 	//	}
+	@Test
 	public void testAnonymousNamespace_416278() throws Exception {
 		checkBindings();
 	}
@@ -100,6 +97,7 @@ public class IndexMultiFileTest extends IndexBindingResolutionTestBase {
 	//	waldo::A a;
 	//	}
 	//	}
+	@Test
 	public void testNamespaceAlias_442117() throws Exception {
 		checkBindings();
 	}
@@ -124,6 +122,7 @@ public class IndexMultiFileTest extends IndexBindingResolutionTestBase {
 	//
 	//	}
 	//	}
+	@Test
 	public void testNamespace_481161() throws Exception {
 		checkBindings();
 	}
@@ -163,6 +162,7 @@ public class IndexMultiFileTest extends IndexBindingResolutionTestBase {
 	//	  D<C> x;
 	//	  new A<B, C>(x);
 	//	}
+	@Test
 	public void testExplicitSpecialization_494359() throws Exception {
 		checkBindings();
 	}
@@ -199,6 +199,7 @@ public class IndexMultiFileTest extends IndexBindingResolutionTestBase {
 	//	void test(ns::A a) {
 	//	  waldo(a);
 	//	}
+	@Test
 	public void testFriendClassDeclaration_508338() throws Exception {
 		checkBindings();
 	}
@@ -222,6 +223,7 @@ public class IndexMultiFileTest extends IndexBindingResolutionTestBase {
 	//	};
 	//	template <typename> struct Waldo;
 	//	Waldo<decltype(0.5 * C<>{})> w;
+	@Test
 	public void testFriendFunctionInHeaderIncludedAtClassScope_509662() throws Exception {
 		checkBindings();
 	}
@@ -246,6 +248,7 @@ public class IndexMultiFileTest extends IndexBindingResolutionTestBase {
 	//	struct atomic<T*> {
 	//		void fetch_sub();
 	//	};
+	@Test
 	public void testClassTemplatePartialSpecialization_470726() throws Exception {
 		checkBindings();
 	}
@@ -267,6 +270,7 @@ public class IndexMultiFileTest extends IndexBindingResolutionTestBase {
 	//	struct base {};
 	//
 	//	static derived<> waldo;
+	@Test
 	public void testProblemBindingInMemInitList_508254() throws Exception {
 		// This code is invalid, so we don't checkBindings().
 		// If the test gets this far (doesn't throw in setup() during indexing), it passes.
@@ -301,6 +305,7 @@ public class IndexMultiFileTest extends IndexBindingResolutionTestBase {
 	//	void func() {
 	//	  waldo(a);
 	//	}
+	@Test
 	public void testFriendFunctionDeclarationInNamespace_513681() throws Exception {
 		checkBindings();
 	}
@@ -343,6 +348,7 @@ public class IndexMultiFileTest extends IndexBindingResolutionTestBase {
 	// const S Waldo::s = {
 	//   &Base::field
 	// };
+	@Test
 	public void testStackOverflow_514459() throws Exception {
 		checkBindings();
 	}
@@ -361,6 +367,7 @@ public class IndexMultiFileTest extends IndexBindingResolutionTestBase {
 	//test.cpp
 	//	#include "test.hpp"
 	//	C::C() {}
+	@Test
 	public void testAliasTemplateReferencingSameName_518937() throws Exception {
 		checkBindings();
 	}
@@ -381,6 +388,7 @@ public class IndexMultiFileTest extends IndexBindingResolutionTestBase {
 	//	#include "h2.h"
 	//	B1 b1;
 	//	B2 b2;
+	@Test
 	public void testClassFirstDeclaredAsFriend_530430() throws Exception {
 		checkBindings();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexMultiVariantHeaderTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexMultiVariantHeaderTest.java
@@ -13,13 +13,16 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.index.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.eclipse.cdt.core.dom.ast.IASTName;
 import org.eclipse.cdt.core.dom.ast.IASTPreprocessorIncludeStatement;
 import org.eclipse.cdt.core.dom.ast.IFunction;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPFunction;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPVariable;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for header files included in multiple variants.
@@ -32,10 +35,6 @@ public class IndexMultiVariantHeaderTest extends IndexBindingResolutionTestBase 
 
 	public IndexMultiVariantHeaderTest() {
 		setStrategy(new SinglePDOMTestNamedFilesStrategy(true));
-	}
-
-	public static TestSuite suite() {
-		return suite(IndexMultiVariantHeaderTest.class);
 	}
 
 	// test.h
@@ -57,6 +56,7 @@ public class IndexMultiVariantHeaderTest extends IndexBindingResolutionTestBase 
 	//
 	//	#include "test.h"
 	//	void func(3)() {}
+	@Test
 	public void testExampleFromBug197989_Comment0() throws Exception {
 		IFunction f1 = getBindingFromASTName("func(1)", 7, IFunction.class);
 		assertEquals("foo1", f1.getName());
@@ -108,6 +108,7 @@ public class IndexMultiVariantHeaderTest extends IndexBindingResolutionTestBase 
 	//	void test() {
 	//	  f2(NULL, 1);
 	//	}
+	@Test
 	public void testExampleFromBug197989_Comment73() throws Exception {
 		getBindingFromASTName("f1(NULL)", 2, ICPPFunction.class);
 		getBindingFromASTName("f2(NULL, 1)", 2, ICPPFunction.class);
@@ -136,6 +137,7 @@ public class IndexMultiVariantHeaderTest extends IndexBindingResolutionTestBase 
 	//	  y = 0;
 	//	  z = 0;
 	//	}
+	@Test
 	public void testSignificantMacroDetection() throws Exception {
 		getBindingFromASTName("x = 0", 1, ICPPVariable.class);
 		getBindingFromASTName("y = 0", 1, ICPPVariable.class);
@@ -155,6 +157,7 @@ public class IndexMultiVariantHeaderTest extends IndexBindingResolutionTestBase 
 
 	//	a.cpp *
 	//	#include "a.h"
+	@Test
 	public void testSignificantMacroDetection_367753a() throws Exception {
 		IASTName includeName = findName("a.h", 0);
 		IASTPreprocessorIncludeStatement inc = (IASTPreprocessorIncludeStatement) includeName.getParent();
@@ -179,6 +182,7 @@ public class IndexMultiVariantHeaderTest extends IndexBindingResolutionTestBase 
 
 	//	a.cpp *
 	//	#include "a.h"
+	@Test
 	public void testSignificantMacroDetection_367753b() throws Exception {
 		IASTName includeName = findName("a.h", 0);
 		IASTPreprocessorIncludeStatement inc = (IASTPreprocessorIncludeStatement) includeName.getParent();

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexUpdateMultiFileTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/index/tests/IndexUpdateMultiFileTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.index.tests;
 
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * Index tests involving multiple header and source files.
@@ -26,10 +26,6 @@ public class IndexUpdateMultiFileTest extends IndexBindingResolutionTestBase {
 
 	public IndexUpdateMultiFileTest() {
 		setStrategy(new SinglePDOMTestNamedFilesStrategy(true));
-	}
-
-	public static TestSuite suite() {
-		return suite(IndexUpdateMultiFileTest.class);
 	}
 
 	// A.h
@@ -71,6 +67,7 @@ public class IndexUpdateMultiFileTest extends IndexBindingResolutionTestBase {
 	//	    waldo(new B<E>());
 	//	  }
 	//	};
+	@Test
 	public void testMacroRemoval_450888() throws Exception {
 		checkBindings();
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/pdom/tests/CPPClassTemplateTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/internal/pdom/tests/CPPClassTemplateTests.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package org.eclipse.cdt.internal.pdom.tests;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/search/LinkedNamesFinderTest.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/search/LinkedNamesFinderTest.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.cdt.ui.tests.search;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -24,9 +27,9 @@ import org.eclipse.cdt.internal.core.parser.ParserException;
 import org.eclipse.cdt.internal.ui.search.LinkedNamesFinder;
 import org.eclipse.cdt.ui.testplugin.CTestPlugin;
 import org.eclipse.jface.text.IRegion;
+import org.junit.jupiter.api.Test;
 
 import junit.framework.AssertionFailedError;
-import junit.framework.TestSuite;
 
 /**
  * Tests for LinkedNamesFinder class.
@@ -40,17 +43,6 @@ public class LinkedNamesFinderTest extends AST2TestBase {
 	}
 
 	static final RegionComparator REGION_COMPARATOR = new RegionComparator();
-
-	public LinkedNamesFinderTest() {
-	}
-
-	public LinkedNamesFinderTest(String name) {
-		super(name);
-	}
-
-	public static TestSuite suite() {
-		return suite(LinkedNamesFinderTest.class);
-	}
 
 	@Override
 	protected CharSequence[] getContents(int sections) throws IOException {
@@ -87,6 +79,7 @@ public class LinkedNamesFinderTest extends AST2TestBase {
 	//
 	//	void A::m(int x) {}
 	//	void A::m(int x, int y) {}
+	@Test
 	public void testMethodParameter() throws Exception {
 		String code = getAboveComment();
 		IRegion[] regions = getLinkedRegions(code, "x);", 1, true);
@@ -105,6 +98,7 @@ public class LinkedNamesFinderTest extends AST2TestBase {
 	//	A::A() {}
 	//	A::A(int x) {}
 	//	A::~A() {}
+	@Test
 	public void testClass() throws Exception {
 		String code = getAboveComment();
 		IRegion[] regions = getLinkedRegions(code, "A {", 1, true);
@@ -140,6 +134,7 @@ public class LinkedNamesFinderTest extends AST2TestBase {
 	//	public:
 	//    void m(int c);
 	//	};
+	@Test
 	public void testVirtualMethod() throws Exception {
 		String code = getAboveComment();
 		IRegion[] regions = getLinkedRegions(code, "m(int c)", 1, true);
@@ -156,6 +151,7 @@ public class LinkedNamesFinderTest extends AST2TestBase {
 	//	#define GUARD //2
 	//	// This is a GUARD test
 	//	#endif // GUARD
+	@Test
 	public void testIncludeGuards() throws Exception {
 		String code = getAboveComment();
 		IRegion[] regions = getLinkedRegions(code, "GUARD //1", 5, true);


### PR DESCRIPTION
SemanticTestBase is the base class for a huge hierarchy of tests and all those test updates are included in this commit.

Part of https://github.com/eclipse-cdt/cdt/issues/1380