### PR TITLE
Convert org.eclipse.cdt.core.tests.BaseTestFramework to JUnit5

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/RewriteBaseTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/RewriteBaseTest.java
@@ -14,19 +14,18 @@
  *******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.rewrite;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 import org.eclipse.cdt.core.tests.BaseTestFramework;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.text.TextSelection;
+import org.junit.jupiter.api.AfterEach;
 
 /**
  * @author Guido Zgraggen IFS
@@ -34,42 +33,8 @@ import org.eclipse.jface.text.TextSelection;
 public abstract class RewriteBaseTest extends BaseTestFramework implements ILogListener {
 	protected static final NullProgressMonitor NULL_PROGRESS_MONITOR = new NullProgressMonitor();
 
-	protected TreeMap<String, TestSourceFile> fileMap = new TreeMap<>();
 	protected String fileWithSelection;
 	protected TextSelection selection;
-
-	protected RewriteBaseTest(String name) {
-		super(name);
-	}
-
-	public RewriteBaseTest(String name, List<TestSourceFile> files) {
-		super(name);
-		for (TestSourceFile file : files) {
-			fileMap.put(file.getName(), file);
-		}
-	}
-
-	@Override
-	protected abstract void runTest() throws Throwable;
-
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-		for (TestSourceFile testFile : fileMap.values()) {
-			if (testFile.getSource().length() > 0) {
-				importFile(testFile.getName(), testFile.getSource());
-			}
-		}
-	}
-
-	protected void compareFiles(Map<String, TestSourceFile> testResourceFiles) throws Exception {
-		for (String fileName : testResourceFiles.keySet()) {
-			TestSourceFile file = testResourceFiles.get(fileName);
-			IFile iFile = project.getFile(new Path(fileName));
-			StringBuilder code = getCodeFromFile(iFile);
-			assertEquals(TestHelper.unifyNewLines(file.getExpectedSource()), TestHelper.unifyNewLines(code.toString()));
-		}
-	}
 
 	protected StringBuilder getCodeFromFile(IFile file) throws Exception {
 		BufferedReader br = new BufferedReader(new InputStreamReader(file.getContents()));
@@ -83,11 +48,10 @@ public abstract class RewriteBaseTest extends BaseTestFramework implements ILogL
 		return code;
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@AfterEach
+	protected void closeAllFiles() throws Exception {
 		System.gc();
 		fileManager.closeAllFiles();
-		super.tearDown();
 	}
 
 	@Override

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/astwriter/SourceRewriteTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/astwriter/SourceRewriteTest.java
@@ -18,22 +18,25 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.cdt.core.parser.ParserLanguage;
 import org.eclipse.cdt.core.parser.tests.ast2.AST2TestBase.ScannerKind;
-import org.eclipse.cdt.core.parser.tests.rewrite.RewriteBaseTest;
 import org.eclipse.cdt.core.testplugin.CTestPlugin;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.jface.text.TextSelection;
+import org.junit.jupiter.params.provider.Arguments;
 import org.osgi.framework.Bundle;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
-public class SourceRewriteTest extends TestSuite {
+/**
+ * This is not actually a test, but a test provider. See loadTests and its uses
+ *
+ * The possibly unusual structure here is a result of migrating this JUnit 3 test
+ * suite creator to JUnit 5
+ */
+public class SourceRewriteTest {
 	private static final String testRegexp = "//!(.*)\\s*(\\w*)*$"; //$NON-NLS-1$
 	private static final String codeTypeRegexp = "//%(C|CPP|CPP20)( GNU)?$"; //$NON-NLS-1$
 	private static final String resultRegexp = "//=.*$"; //$NON-NLS-1$
@@ -42,83 +45,73 @@ public class SourceRewriteTest extends TestSuite {
 		skip, inTest, inSource, inExpectedResult
 	}
 
-	protected static BufferedReader createReader(String file) throws IOException {
+	private static BufferedReader createReader(String file) throws IOException {
 		Bundle bundle = CTestPlugin.getDefault().getBundle();
 		Path path = new Path(file);
 		file = FileLocator.toFileURL(FileLocator.find(bundle, path, null)).getFile();
 		return new BufferedReader(new FileReader(file));
 	}
 
-	public static Test suite() throws Exception {
-		TestSuite suite = new TestSuite("AstWriterTests");
-		suite.addTest(
+	public static List<Arguments> loadTests() throws Exception {
+		List<Arguments> suite = new ArrayList<>();
+		suite.addAll(
 				SourceRewriteTest.suite("ExpressionTests", "resources/rewrite/ASTWriterExpressionTestSource.awts"));
 
-		suite.addTest(
+		suite.addAll(
 				SourceRewriteTest.suite("DelcSpecifierTests", "resources/rewrite/ASTWriterDeclSpecTestSource.awts"));
-		suite.addTest(SourceRewriteTest.suite("Commented DelcSpecifierTests",
+		suite.addAll(SourceRewriteTest.suite("Commented DelcSpecifierTests",
 				"resources/rewrite/ASTWriterCommentedDeclSpecTestSource.awts"));
 
-		suite.addTest(
+		suite.addAll(
 				SourceRewriteTest.suite("DeclaratorTests", "resources/rewrite/ASTWriterDeclaratorTestSource.awts"));
-		suite.addTest(SourceRewriteTest.suite("Commented DeclaratorTests",
+		suite.addAll(SourceRewriteTest.suite("Commented DeclaratorTests",
 				"resources/rewrite/ASTWriterCommentedDeclaratorTestSource.awts"));
 
-		suite.addTest(
-				SourceRewriteTest.suite("StatementsTests", "resources/rewrite/ASTWriterStatementTestSource.awts"));
-		suite.addTest(SourceRewriteTest.suite("Commented StatementsTests",
+		suite.addAll(SourceRewriteTest.suite("StatementsTests", "resources/rewrite/ASTWriterStatementTestSource.awts"));
+		suite.addAll(SourceRewriteTest.suite("Commented StatementsTests",
 				"resources/rewrite/ASTWriterCommentedStatementTestSource.awts"));
 
-		suite.addTest(SourceRewriteTest.suite("NameTests", "resources/rewrite/ASTWriterNameTestSource.awts"));
-		suite.addTest(SourceRewriteTest.suite("Commented NameTests",
+		suite.addAll(SourceRewriteTest.suite("NameTests", "resources/rewrite/ASTWriterNameTestSource.awts"));
+		suite.addAll(SourceRewriteTest.suite("Commented NameTests",
 				"resources/rewrite/ASTWriterCommentedNameTestSource.awts"));
 
-		suite.addTest(
+		suite.addAll(
 				SourceRewriteTest.suite("InitializerTests", "resources/rewrite/ASTWriterInitializerTestSource.awts"));
 
-		suite.addTest(
+		suite.addAll(
 				SourceRewriteTest.suite("DeclarationTests", "resources/rewrite/ASTWriterDeclarationTestSource.awts"));
-		suite.addTest(SourceRewriteTest.suite("Commented DeclarationTests",
+		suite.addAll(SourceRewriteTest.suite("Commented DeclarationTests",
 				"resources/rewrite/ASTWriterCommentedDeclarationTestSource.awts"));
 
-		suite.addTest(SourceRewriteTest.suite("TemplatesTests", "resources/rewrite/ASTWriterTemplateTestSource.awts"));
+		suite.addAll(SourceRewriteTest.suite("TemplatesTests", "resources/rewrite/ASTWriterTemplateTestSource.awts"));
 
-		suite.addTest(SourceRewriteTest.suite("CommentTests", "resources/rewrite/ASTWriterCommentedTestSource.awts"));
-		suite.addTest(
+		suite.addAll(SourceRewriteTest.suite("CommentTests", "resources/rewrite/ASTWriterCommentedTestSource.awts"));
+		suite.addAll(
 				SourceRewriteTest.suite("NewCommentTests", "resources/rewrite/ASTWriterCommentedTestSource2.awts"));
-		suite.addTest(SourceRewriteTest.suite("AttributeTests", "resources/rewrite/ASTWriterAttributeTestSource.awts"));
-		suite.addTestSuite(ExpressionWriterTest.class);
+		suite.addAll(SourceRewriteTest.suite("AttributeTests", "resources/rewrite/ASTWriterAttributeTestSource.awts"));
 		return suite;
 	}
 
-	public static Test suite(String name, String file) throws Exception {
+	private static List<Arguments> suite(String name, String file) throws Exception {
 		BufferedReader in = createReader(file);
-		ArrayList<RewriteBaseTest> testCases = createTests(in);
+		List<Arguments> testCases = createTests(name, in);
 		in.close();
-		return createSuite(testCases, name);
+		return testCases;
 	}
 
-	private static TestSuite createSuite(ArrayList<RewriteBaseTest> testCases, String name) {
-		TestSuite suite = new TestSuite(name);
-		for (RewriteBaseTest subject : testCases) {
-			suite.addTest(subject);
-		}
-		return suite;
-	}
-
-	protected static boolean lineMatchesBeginOfTest(String line) {
+	private static boolean lineMatchesBeginOfTest(String line) {
 		return createMatcherFromString(testRegexp, line).find();
 	}
 
-	protected static boolean lineMatchesCodeType(String line) {
+	private static boolean lineMatchesCodeType(String line) {
 		return createMatcherFromString(codeTypeRegexp, line).find();
 	}
 
-	protected static Matcher createMatcherFromString(String pattern, String line) {
+	private static Matcher createMatcherFromString(String pattern, String line) {
 		return Pattern.compile(pattern).matcher(line);
 	}
 
-	protected static String getNameOfTest(String line) {
+	private static String getNameOfTest(String line) {
 		Matcher matcherBeginOfTest = createMatcherFromString(testRegexp, line);
 		if (matcherBeginOfTest.find()) {
 			return matcherBeginOfTest.group(1);
@@ -127,21 +120,21 @@ public class SourceRewriteTest extends TestSuite {
 		}
 	}
 
-	protected static boolean lineMatchesBeginOfResult(String line) {
+	private static boolean lineMatchesBeginOfResult(String line) {
 		return createMatcherFromString(resultRegexp, line).find();
 	}
 
-	private static ArrayList<RewriteBaseTest> createTests(BufferedReader inputReader) throws Exception {
+	private static List<Arguments> createTests(String name, BufferedReader inputReader) throws Exception {
 		ASTWriterTestSourceFile file = null;
 		MatcherState matcherState = MatcherState.skip;
-		ArrayList<RewriteBaseTest> testCases = new ArrayList<>();
+		ArrayList<Arguments> testCases = new ArrayList<>();
 
 		String line;
 		while ((line = inputReader.readLine()) != null) {
 			if (lineMatchesBeginOfTest(line)) {
 				matcherState = MatcherState.inTest;
 				file = new ASTWriterTestSourceFile("ASTWritterTest.h"); //$NON-NLS-1$
-				testCases.add(createTestClass(getNameOfTest(line), file));
+				testCases.add(Arguments.argumentSet(name + "." + getNameOfTest(line), file));
 				continue;
 			} else if (lineMatchesBeginOfResult(line)) {
 				matcherState = MatcherState.inExpectedResult;
@@ -173,7 +166,7 @@ public class SourceRewriteTest extends TestSuite {
 		return testCases;
 	}
 
-	protected static ScannerKind getScannerKind(String line) {
+	private static ScannerKind getScannerKind(String line) {
 		Matcher matcherBeginOfTest = createMatcherFromString(codeTypeRegexp, line);
 		if (matcherBeginOfTest.find()) {
 			String codeType = matcherBeginOfTest.group(1);
@@ -189,7 +182,7 @@ public class SourceRewriteTest extends TestSuite {
 		return ScannerKind.STD;
 	}
 
-	protected static ParserLanguage getParserLanguage(String line) {
+	private static ParserLanguage getParserLanguage(String line) {
 		Matcher matcherBeginOfTest = createMatcherFromString(codeTypeRegexp, line);
 		if (matcherBeginOfTest.find()) {
 			String codeType = matcherBeginOfTest.group(1);
@@ -202,18 +195,5 @@ public class SourceRewriteTest extends TestSuite {
 			}
 		}
 		return ParserLanguage.C;
-	}
-
-	private static RewriteBaseTest createTestClass(String testName, ASTWriterTestSourceFile file) throws Exception {
-		ASTWriterTester test = new ASTWriterTester(testName, file) {
-			// ASTWriterTester is an abstract class so it doesn't
-			// look like a test, make it a concrete class here
-		};
-		TextSelection sel = file.getSelection();
-		if (sel != null) {
-			test.setFileWithSelection(file.getName());
-			test.setSelection(sel);
-		}
-		return test;
 	}
 }

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/changegenerator/AppendTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/changegenerator/AppendTests.java
@@ -53,18 +53,14 @@ import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTNewExpression;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTParameterDeclaration;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTSimpleDeclSpecifier;
 import org.eclipse.cdt.internal.core.dom.rewrite.ASTModificationStore;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class AppendTests extends ChangeGeneratorTest {
-
-	public static TestSuite suite() {
-		return new TestSuite(AppendTests.class);
-	}
 
 	//int *pi[5];
 
 	//int *pi[5][3];
+	@Test
 	public void testArrayModifier() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -87,6 +83,7 @@ public class AppendTests extends ChangeGeneratorTest {
 	//int *values = new int[6];
 
 	//int *values = new int[6][5];
+	@Test
 	public void testArraySizeExpression() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -119,6 +116,7 @@ public class AppendTests extends ChangeGeneratorTest {
 	//		beta(b), alpha(a) {
 	//}
 	//
+	@Test
 	public void testCtorChainInitializer() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -147,6 +145,7 @@ public class AppendTests extends ChangeGeneratorTest {
 
 	//void foo(int parameter) throw (int) {
 	//}
+	@Test
 	public void testException() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -177,6 +176,7 @@ public class AppendTests extends ChangeGeneratorTest {
 	//	int s = 0, c = 0, h = 0;
 	//	s = 3, h = 5, c = 9;
 	//}
+	@Test
 	public void testExpression() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -207,6 +207,7 @@ public class AppendTests extends ChangeGeneratorTest {
 	//	} else if (cond2) {
 	//	}
 	//}
+	@Test
 	public void testNestedElseifStatement() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -237,6 +238,7 @@ public class AppendTests extends ChangeGeneratorTest {
 
 	//void foo(int existing, int newParameter) {
 	//}
+	@Test
 	public void testParameter() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -266,6 +268,7 @@ public class AppendTests extends ChangeGeneratorTest {
 
 	//void foo(int newParameter) {
 	//}
+	@Test
 	public void testParameterToList() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -294,6 +297,7 @@ public class AppendTests extends ChangeGeneratorTest {
 
 	//void foo(int *parameter) {
 	//}
+	@Test
 	public void testPointerToParamter() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -325,6 +329,7 @@ public class AppendTests extends ChangeGeneratorTest {
 
 	//void foo(int **parameter) {
 	//}
+	@Test
 	public void testPointerToPointerParameter() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -373,6 +378,7 @@ public class AppendTests extends ChangeGeneratorTest {
 	//	int help();
 	//	int exp(int i);
 	//};
+	@Test
 	public void testAddDeclarationBugTest() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -417,6 +423,7 @@ public class AppendTests extends ChangeGeneratorTest {
 	//		int j;
 	//	}
 	//}
+	@Test
 	public void testMultilineWhitespaceHandling() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -459,6 +466,7 @@ public class AppendTests extends ChangeGeneratorTest {
 	//	for (int i = 0; i < 10; i++) {
 	//	}
 	//}
+	@Test
 	public void testAppendNull() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -491,6 +499,7 @@ public class AppendTests extends ChangeGeneratorTest {
 	//	}
 	//}
 	//
+	@Test
 	public void testSelfInsertion() throws Exception {
 		compareResult(new ASTVisitor() {
 			{

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/changegenerator/ChangeGeneratorTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/changegenerator/ChangeGeneratorTest.java
@@ -17,6 +17,8 @@ package org.eclipse.cdt.core.parser.tests.rewrite.changegenerator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.IOException;
 
@@ -45,31 +47,23 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 import org.eclipse.ltk.core.refactoring.TextFileChange;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class ChangeGeneratorTest extends BaseTestFramework {
 	protected ASTModificationStore modStore;
 	protected final ICPPNodeFactory factory = CPPNodeFactory.getDefault();
 
-	public ChangeGeneratorTest() {
-		super();
-	}
-
-	public ChangeGeneratorTest(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void setUp() throws Exception {
+	@BeforeEach
+	protected void setUpModStore() throws Exception {
 		modStore = new ASTModificationStore();
 		CCorePlugin.getIndexManager().joinIndexer(IIndexManager.FOREVER, new NullProgressMonitor());
-		super.setUp();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@AfterEach
+	protected void tearDownLocal() throws Exception {
 		System.gc();
 		fileManager.closeAllFiles();
-		super.tearDown();
 	}
 
 	protected StringBuilder[] getTestSource(int sections) throws IOException {
@@ -110,7 +104,7 @@ public abstract class ChangeGeneratorTest extends BaseTestFramework {
 		if (shouldValidateAST) {
 			ProblemNodeChecker validator = new ProblemNodeChecker();
 			unit.accept(validator);
-			assertFalse("Problem nodes found, AST is invalid.", validator.problemsFound());
+			assertFalse(validator.problemsFound(), "Problem nodes found, AST is invalid.");
 		}
 
 		final ChangeGenerator changeGenerator = new ChangeGenerator(modStore, ASTCommenter.getCommentedNodeMap(unit));

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/changegenerator/InsertBeforeTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/changegenerator/InsertBeforeTests.java
@@ -50,18 +50,14 @@ import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTSimpleDeclSpecifier;
 import org.eclipse.cdt.internal.core.dom.rewrite.ASTModification;
 import org.eclipse.cdt.internal.core.dom.rewrite.ASTModification.ModificationKind;
 import org.eclipse.cdt.internal.core.dom.rewrite.astwriter.ContainerNode;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class InsertBeforeTests extends ChangeGeneratorTest {
-
-	public static TestSuite suite() {
-		return new TestSuite(InsertBeforeTests.class);
-	}
 
 	//int *pi[3];
 
 	//int *pi[5][3];
+	@Test
 	public void testArrayModifier() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -87,6 +83,7 @@ public class InsertBeforeTests extends ChangeGeneratorTest {
 	//int *values = new int[5];
 
 	//int *values = new int[6][5];
+	@Test
 	public void testArraySizeExpression() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -116,6 +113,7 @@ public class InsertBeforeTests extends ChangeGeneratorTest {
 	//TestClass::TestClass(int a, int b) :
 	//		alpha(a), beta(b) {
 	//}
+	@Test
 	public void testCtorChainInitializer() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -147,6 +145,7 @@ public class InsertBeforeTests extends ChangeGeneratorTest {
 
 	//void foo(int parameter) throw (int, /*Test*/float) /*Test2*/{
 	//}
+	@Test
 	public void testException() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -180,6 +179,7 @@ public class InsertBeforeTests extends ChangeGeneratorTest {
 	//	int s = 0, c = 0, h = 0;
 	//	s = 3, c = 9, h = 5;
 	//}
+	@Test
 	public void testExpression() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -209,6 +209,7 @@ public class InsertBeforeTests extends ChangeGeneratorTest {
 
 	//void foo(int newParameter, int a) {
 	//}
+	@Test
 	public void testFirstParameter() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -250,6 +251,7 @@ public class InsertBeforeTests extends ChangeGeneratorTest {
 	//	s2;
 	//	int j;
 	//}
+	@Test
 	public void testInsertMultipleStatements() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -289,6 +291,7 @@ public class InsertBeforeTests extends ChangeGeneratorTest {
 	//	int j;
 	//	int j;
 	//}
+	@Test
 	public void testInsertStatement() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -314,6 +317,7 @@ public class InsertBeforeTests extends ChangeGeneratorTest {
 
 	//void foo(int **parameter) {
 	//}
+	@Test
 	public void testPointerParameter() throws Exception {
 		compareResult(new ASTVisitor() {
 			{

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/changegenerator/RemoveTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/changegenerator/RemoveTests.java
@@ -38,18 +38,14 @@ import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTConstructorInitializer;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTFunctionDeclarator;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTFunctionDefinition;
 import org.eclipse.cdt.core.dom.ast.cpp.ICPPASTNewExpression;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class RemoveTests extends ChangeGeneratorTest {
-
-	public static TestSuite suite() {
-		return new TestSuite(RemoveTests.class);
-	}
 
 	//int *pi[3];
 
 	//int *pi;
+	@Test
 	public void testArrayModifier() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -72,6 +68,7 @@ public class RemoveTests extends ChangeGeneratorTest {
 	//int *values = new int[5][6];
 
 	//int *values = new int[5];
+	@Test
 	public void testArraySizeExpression() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -98,6 +95,7 @@ public class RemoveTests extends ChangeGeneratorTest {
 
 	//TestClass::TestClass(int a) {
 	//}
+	@Test
 	public void testCtorChainInitializer() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -142,6 +140,7 @@ public class RemoveTests extends ChangeGeneratorTest {
 	//};
 	//
 	//#endif /*A_H_*/
+	@Test
 	public void testDeclaration() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -170,6 +169,7 @@ public class RemoveTests extends ChangeGeneratorTest {
 
 	//void foo(int parameter) throw () {
 	//}
+	@Test
 	public void testException() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -200,6 +200,7 @@ public class RemoveTests extends ChangeGeneratorTest {
 	//	int s = 0, c = 0, h = 0;
 	//	s = 3, h = 5;
 	//}
+	@Test
 	public void testExpression() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -224,6 +225,7 @@ public class RemoveTests extends ChangeGeneratorTest {
 
 	//void foo(int b, int c) {
 	//}
+	@Test
 	public void testFirstParameter() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -253,6 +255,7 @@ public class RemoveTests extends ChangeGeneratorTest {
 
 	//void foo(int a, int b) {
 	//}
+	@Test
 	public void testLastParameter() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -282,6 +285,7 @@ public class RemoveTests extends ChangeGeneratorTest {
 
 	//void foo(int a, int c) {
 	//}
+	@Test
 	public void testMiddleParameter() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -309,6 +313,7 @@ public class RemoveTests extends ChangeGeneratorTest {
 	//int *value = new int(5);
 
 	//int *value = new int();
+	@Test
 	public void testNewInitializerExpression() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -334,6 +339,7 @@ public class RemoveTests extends ChangeGeneratorTest {
 
 	//void foo(int parameter) {
 	//}
+	@Test
 	public void testPointerInParameter() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -364,6 +370,7 @@ public class RemoveTests extends ChangeGeneratorTest {
 
 	//void foo() {
 	//}
+	@Test
 	public void testSingleParameter() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -400,6 +407,7 @@ public class RemoveTests extends ChangeGeneratorTest {
 	//{
 	//	int i = 0;
 	//}
+	@Test
 	public void testStatement() throws Exception {
 		compareResult(new ASTVisitor() {
 			{

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/changegenerator/ReplaceTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/changegenerator/ReplaceTests.java
@@ -74,14 +74,9 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTSimpleDeclaration;
 import org.eclipse.cdt.internal.core.dom.parser.cpp.CPPASTUnaryExpression;
 import org.eclipse.cdt.internal.core.dom.rewrite.ASTModification;
 import org.eclipse.cdt.internal.core.dom.rewrite.ASTModification.ModificationKind;
-
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class ReplaceTests extends ChangeGeneratorTest {
-
-	public static TestSuite suite() {
-		return new TestSuite(ReplaceTests.class);
-	}
 
 	private IASTAttribute createAttribute(String name) {
 		return factory.newAttribute(name.toCharArray(), null);
@@ -122,6 +117,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//int *pi[3];
 
 	//int *pi[15];
+	@Test
 	public void testArrayModifier() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -146,6 +142,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//int *values = new int[5][6];
 
 	//int *values = new int[5][7];
+	@Test
 	public void testArraySizeExpression() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -175,6 +172,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//TestClass::TestClass(int a) :
 	//		alpha(a) {
 	//}
+	@Test
 	public void testCtorChainInitializer() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -209,6 +207,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 
 	//void foo(int parameter) throw (int) {
 	//}
+	@Test
 	public void testExceptionTest() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -243,6 +242,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//	int s = 0, c = 0, h = 0;
 	//	s = 3, c = 9, h = 5;
 	//}
+	@Test
 	public void testExpressionTest() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -292,6 +292,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//#endif /*A_H_*/
 	//
 	//
+	@Test
 	public void testIdentical() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -310,6 +311,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//int hs = 5;
 
 	//int hs = 999;
+	@Test
 	public void testInitializer() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -352,6 +354,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//};
 	//
 	//#endif /*A_H_*/
+	@Test
 	public void testMoveRename() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -400,6 +403,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//#endif /*A_H_*/
 	//
 	//
+	@Test
 	public void testMove() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -444,6 +448,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//#endif /*A_H_*/
 	//
 	//
+	@Test
 	public void testName() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -467,6 +472,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//void foo(int x) {
 	//	x++;
 	//}
+	@Test
 	public void testNestedReplace() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -506,6 +512,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//int *value = new int(5);
 
 	//int *value = new int(6);
+	@Test
 	public void testNewInitializerExpression() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -531,6 +538,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 
 	//void foo(int *parameter) {
 	//}
+	@Test
 	public void testPointerInParameter() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -580,6 +588,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//  }
 	//
 	//}
+	@Test
 	public void testReplaceForLoopBody() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -610,6 +619,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//	i = 42;
 	//	i++;
 	//}
+	@Test
 	public void testReplaceInsertStatement() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -647,6 +657,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 
 	//void bar() {
 	//}
+	@Test
 	public void testReplaceReplacedNode() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -691,6 +702,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//#endif /*A_H_*/
 	//
 	//
+	@Test
 	public void testSameName() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -721,6 +733,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//		i++;
 	//	}
 	//}
+	@Test
 	public void testStatement() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -770,6 +783,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//  }
 	//
 	//}
+	@Test
 	public void testWhitespaceHandling() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -811,6 +825,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//		int two = 2;
 	//	}
 	//}
+	@Test
 	public void testNestedReplacementInIfStatementWithMacroInSibling_474020() throws Exception {
 		compareResult(new ASTVisitor() {
 			private ASTModification parentModification;
@@ -861,6 +876,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//		int two = 2;
 	//	}
 	//}
+	@Test
 	public void testNestedReplacementInIfStatementWithMacroInCondition_474020() throws Exception {
 		compareResult(new ASTVisitor() {
 			private ASTModification parentModification;
@@ -911,6 +927,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//		int two = 2;
 	//	}
 	//}
+	@Test
 	public void testNestedReplacementInIfStatementWithMacroAsFirstPartOfCondition_474020() throws Exception {
 		compareResult(new ASTVisitor() {
 			private ASTModification parentModification;
@@ -961,6 +978,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//		int two = 2;
 	//	}
 	//}
+	@Test
 	public void testNestedReplacementInIfStatementWithMacroAsInnerPartOfCondition_474020() throws Exception {
 		compareResult(new ASTVisitor() {
 			private ASTModification parentModification;
@@ -1011,6 +1029,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//		int two = 2;
 	//	}
 	//}
+	@Test
 	public void testNestedReplacementInIfStatementWithMacroAsLastPartOfCondition_474020() throws Exception {
 		compareResult(new ASTVisitor() {
 			private ASTModification parentModification;
@@ -1067,6 +1086,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//	void func3() override final;
 	//	void func4() final override;
 	//};
+	@Test
 	public void testReplaceFunctionDeclaratorWithVirtualSpecifier_Bug518628() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -1090,6 +1110,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//{
 	//	virtual void foo() throw (int) = 0;
 	//};
+	@Test
 	public void testPureVirtualFunction() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -1110,26 +1131,31 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	}
 
 	//[[foo]] int hs = 5;
+	@Test
 	public void testCopyReplaceAttribute_Bug533552_1a() throws Exception {
 		compareCopyResult(new CopyReplaceVisitor(this, IASTDeclaration.class::isInstance));
 	}
 
 	//[[foo, bar]][[foobar]] int hs = 5;
+	@Test
 	public void testCopyReplaceAttribute_Bug533552_1b() throws Exception {
 		compareCopyResult(new CopyReplaceVisitor(this, IASTDeclaration.class::isInstance));
 	}
 
 	//[[foo, bar]][[foobar]] int [[asdf]] hs = 5;
+	@Test
 	public void testCopyReplaceAttribute_Bug533552_1c() throws Exception {
 		compareCopyResult(new CopyReplaceVisitor(this, IASTDeclaration.class::isInstance));
 	}
 
 	//using I [[attribute]] = int;
+	@Test
 	public void testCopyReplaceAliasDeclarationWithAttributes_Bug533552_1d() throws Exception {
 		compareCopyResult(new CopyReplaceVisitor(this, ICPPASTAliasDeclaration.class::isInstance));
 	}
 
 	//int i [[attribute]];
+	@Test
 	public void testCopyReplaceDeclaratorWithAttributes_Bug533552_1e() throws Exception {
 		compareCopyResult(new CopyReplaceVisitor(this, IASTDeclarator.class::isInstance));
 	}
@@ -1137,6 +1163,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//[[foo]] int hs = 5;
 
 	//[[foo, bar]] int hs = 5;
+	@Test
 	public void testAddAttribute_Bug533552_2a() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -1157,6 +1184,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//[[foo]] int hs = 5;
 
 	//[[foo]][[bar]] int hs = 5;
+	@Test
 	public void testAddAttribute_Bug533552_2b() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -1182,6 +1210,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//		break;
 	//	}
 	//}
+	@Test
 	public void testCopyReplaceAttribute_Bug535265_1() throws Exception {
 		compareCopyResult(new CopyReplaceVisitor(this, IASTSwitchStatement.class::isInstance));
 	}
@@ -1195,6 +1224,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//	[[foo]][[bar]] switch (true) {
 	//	}
 	//}
+	@Test
 	public void testCopyReplaceAttributeOnSwitchStatement_Bug535263_1() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -1221,6 +1251,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//	[[foo]] switch (true) [[bar]][[foobar]] {
 	//	}
 	//}
+	@Test
 	public void testCopyReplaceAttributeOnSwitchCompoundStatement_Bug535263_2() throws Exception {
 		compareResult(new ASTVisitor() {
 			{
@@ -1241,12 +1272,14 @@ public class ReplaceTests extends ChangeGeneratorTest {
 
 	//void f([[attr1]] int p1, int [[attr2]] p2, [[attr3]] int p3) {
 	//}
+	@Test
 	public void testCopyReplaceAttribute_Bug535275() throws Exception {
 		compareCopyResult(new CopyReplaceVisitor(this, ICPPASTFunctionDeclarator.class::isInstance));
 	}
 
 	//enum [[foo]] X : int [[bar]] {
 	//};
+	@Test
 	public void testEnumReplacementRetainsAttributes_Bug535256_1() throws Exception {
 		compareCopyResult(new CopyReplaceVisitor(this, ICPPASTEnumerationSpecifier.class::isInstance));
 	}
@@ -1255,6 +1288,7 @@ public class ReplaceTests extends ChangeGeneratorTest {
 	//};
 	//enum struct ES {
 	//};
+	@Test
 	public void testScopedEnumReplacementRetains_Bug535256_2() throws Exception {
 		compareCopyResult(new CopyReplaceVisitor(this, ICPPASTEnumerationSpecifier.class::isInstance));
 	}

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/comenthandler/CommentHandlingTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/comenthandler/CommentHandlingTest.java
@@ -14,6 +14,9 @@
  ******************************************************************************/
 package org.eclipse.cdt.core.parser.tests.rewrite.comenthandler;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -30,14 +33,17 @@ import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit;
 import org.eclipse.cdt.core.model.ITranslationUnit;
 import org.eclipse.cdt.core.parser.tests.rewrite.RewriteBaseTest;
 import org.eclipse.cdt.core.parser.tests.rewrite.RewriteTester;
+import org.eclipse.cdt.core.parser.tests.rewrite.TestHelper;
 import org.eclipse.cdt.core.parser.tests.rewrite.TestSourceFile;
 import org.eclipse.cdt.internal.core.dom.rewrite.commenthandler.ASTCommenter;
 import org.eclipse.cdt.internal.core.dom.rewrite.commenthandler.NodeCommentMap;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
-
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.eclipse.jface.text.TextSelection;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * This test tests the behavior of the class ASTCommenter. It checks if the ASTCommenter assigns
@@ -81,6 +87,7 @@ import junit.framework.TestSuite;
  * @author Guido Zgraggen IFS, Lukas Felber IFS
  */
 public class CommentHandlingTest extends RewriteBaseTest {
+
 	private static final String ANY_CHAR_REGEXP = "(.*)"; //$NON-NLS-1$
 	private static final String SEPARATOR = System.getProperty("line.separator"); //$NON-NLS-1$
 
@@ -92,26 +99,44 @@ public class CommentHandlingTest extends RewriteBaseTest {
 	private static final String TRAILING_COMMENT_TITLE = "<<<=== Trailing Comment Test Section ===>>>"; //$NON-NLS-1$
 	private static final String FREESTANDING_COMMENT_TITLE = "<<<=== Freestanding Comment Test Section ===>>>"; //$NON-NLS-1$
 
-	public CommentHandlingTest(String name, List<TestSourceFile> files) {
-		super(name, files);
+	public static List<Arguments> loadTests() throws Exception {
+		return RewriteTester.loadTests(CommentHandlingTest.class, "resources/rewrite/CommentHandlingTestSource.rts");
 	}
 
-	public static Test suite() throws Exception {
-		TestSuite suite = new TestSuite(CommentHandlingTest.class.getName());
-		suite.addTest(RewriteTester.suite("CommentTests", "resources/rewrite/CommentHandlingTestSource.rts")); //$NON-NLS-1$
-		return suite;
+	@ParameterizedTest
+	@MethodSource("loadTests")
+	protected void test(List<TestSourceFile> testFiles) throws Throwable {
+		loadFiles(testFiles);
+		runTest(testFiles);
 	}
 
-	@Override
-	protected void runTest() throws Throwable {
-		if (fileMap.isEmpty()) {
-			fail("No file for testing"); //$NON-NLS-1$
+	protected void loadFiles(List<TestSourceFile> testFiles) throws Exception {
+		for (TestSourceFile testFile : testFiles) {
+			if (testFile.getSource().length() > 0) {
+				importFile(testFile.getName(), testFile.getSource());
+			}
+			TextSelection sel = testFile.getSelection();
+			if (sel != null) {
+				setFileWithSelection(testFile.getName());
+				setSelection(sel);
+				break;
+			}
 		}
+	}
 
-		for (String fileName : fileMap.keySet()) {
-			TestSourceFile file = fileMap.get(fileName);
-			NodeCommentMap nodeMap = getNodeMapForFile(fileName);
-			assertEquals(buildExpectedResult(file).toString(), buildActualResult(nodeMap).toString());
+	protected void runTest(List<TestSourceFile> testFiles) throws Exception {
+		for (TestSourceFile testFile : testFiles) {
+			NodeCommentMap nodeMap = getNodeMapForFile(testFile.getName());
+			assertEquals(buildExpectedResult(testFile).toString(), buildActualResult(nodeMap).toString());
+		}
+	}
+
+	private void compareFiles(Map<String, TestSourceFile> testResourceFiles) throws Exception {
+		for (String fileName : testResourceFiles.keySet()) {
+			TestSourceFile file = testResourceFiles.get(fileName);
+			IFile iFile = project.getFile(new Path(fileName));
+			StringBuilder code = getCodeFromFile(iFile);
+			assertEquals(TestHelper.unifyNewLines(file.getExpectedSource()), TestHelper.unifyNewLines(code.toString()));
 		}
 	}
 

--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/comenthandler/CommentHandlingWithRewriteTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/rewrite/comenthandler/CommentHandlingWithRewriteTest.java
@@ -24,26 +24,23 @@ import org.eclipse.cdt.core.parser.tests.rewrite.RewriteTester;
 import org.eclipse.cdt.core.parser.tests.rewrite.TestSourceFile;
 import org.eclipse.cdt.internal.core.dom.rewrite.commenthandler.NodeCommentMap;
 import org.eclipse.text.edits.TextEditGroup;
-
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class CommentHandlingWithRewriteTest extends CommentHandlingTest {
 	private ASTRewrite newRewrite;
 
-	public CommentHandlingWithRewriteTest(String name, List<TestSourceFile> files) {
-		super(name, files);
-	}
-
-	public static Test suite() throws Exception {
-		TestSuite suite = new TestSuite(CommentHandlingWithRewriteTest.class.getName());
-		suite.addTest(
-				RewriteTester.suite("CommentMultiFileTests", "resources/rewrite/CommentHandlingWithRewriteTest.rts")); //$NON-NLS-1$
-		return suite;
+	public static List<Arguments> loadTestsWithRewrite() throws Exception {
+		return RewriteTester.loadTests(CommentHandlingWithRewriteTest.class,
+				"resources/rewrite/CommentHandlingWithRewriteTest.rts");
 	}
 
 	@Override
-	protected void runTest() throws Throwable {
+	@ParameterizedTest
+	@MethodSource("loadTestsWithRewrite")
+	protected void test(List<TestSourceFile> testFiles) throws Throwable {
+		loadFiles(testFiles);
 		IASTTranslationUnit tu = getUnit("main.cpp");
 		IASTTranslationUnit otherTu = getUnit("other.cpp");
 
@@ -53,7 +50,7 @@ public class CommentHandlingWithRewriteTest extends CommentHandlingTest {
 
 		ASTRewrite rewrite = ASTRewrite.create(tu);
 		newRewrite = rewrite.insertBefore(fooBody, iNode, jNode, new TextEditGroup("test group"));
-		super.runTest();
+		runTest(testFiles);
 	}
 
 	@Override

--- a/core/org.eclipse.cdt.core.tests/regression/org/eclipse/cdt/core/tests/BaseTestFramework.java
+++ b/core/org.eclipse.cdt.core.tests/regression/org/eclipse/cdt/core/tests/BaseTestFramework.java
@@ -18,6 +18,8 @@
  */
 package org.eclipse.cdt.core.tests;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
@@ -25,7 +27,6 @@ import org.eclipse.cdt.core.dom.IPDOMManager;
 import org.eclipse.cdt.core.model.ICProject;
 import org.eclipse.cdt.core.testplugin.CProjectHelper;
 import org.eclipse.cdt.core.testplugin.FileManager;
-import org.eclipse.cdt.core.testplugin.util.BaseTestCase;
 import org.eclipse.cdt.core.testplugin.util.BaseTestCase5;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -34,11 +35,13 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author aniefer
  */
-abstract public class BaseTestFramework extends BaseTestCase {
+abstract public class BaseTestFramework extends BaseTestCase5 {
 	protected NullProgressMonitor monitor;
 	protected IWorkspace workspace;
 	protected IProject project;
@@ -46,20 +49,8 @@ abstract public class BaseTestFramework extends BaseTestCase {
 	protected FileManager fileManager;
 	protected boolean indexDisabled = false;
 
-	public BaseTestFramework() {
-		super();
-	}
-
-	/**
-	 * @param name
-	 */
-	public BaseTestFramework(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@BeforeEach
+	protected void createProjectBefore() throws Exception {
 		monitor = new NullProgressMonitor();
 		workspace = ResourcesPlugin.getWorkspace();
 		cproject = CProjectHelper.createCCProject("RegressionTestProject", "bin", IPDOMManager.ID_NO_INDEXER); //$NON-NLS-1$ //$NON-NLS-2$
@@ -70,14 +61,13 @@ abstract public class BaseTestFramework extends BaseTestCase {
 		fileManager = new FileManager();
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
+	@AfterEach
+	protected void cleanUpProjectAfter() throws Exception {
 		if (project == null || !project.exists())
 			return;
 
 		project.delete(true, true, monitor);
 		BaseTestCase5.assertWorkspaceIsEmpty();
-		super.tearDown();
 	}
 
 	protected IFile importFile(String fileName, String contents) throws Exception {

--- a/core/org.eclipse.cdt.ui.tests/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.ui.tests/META-INF/MANIFEST.MF
@@ -44,4 +44,5 @@ Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.cdt.ui.tests
-Import-Package: org.junit.jupiter.api;version="5.9.0"
+Import-Package: org.junit.jupiter.api;version="5.9.0",
+ org.opentest4j;version="[1.3.0,2.0.0)"

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RefactoringTests.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RefactoringTests.java
@@ -13,6 +13,12 @@
  ******************************************************************************/
 package org.eclipse.cdt.ui.tests.refactoring.rename;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.StringWriter;
 
 import org.eclipse.cdt.core.CCorePlugin;
@@ -31,6 +37,8 @@ import org.eclipse.text.edits.MultiTextEdit;
 import org.eclipse.text.edits.ReplaceEdit;
 import org.eclipse.text.edits.TextEdit;
 import org.eclipse.text.edits.TextEditGroup;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author markus.schorn@windriver.com
@@ -38,24 +46,15 @@ import org.eclipse.text.edits.TextEditGroup;
 public abstract class RefactoringTests extends BaseTestFramework {
 	private int fBufferSize;
 
-	public RefactoringTests() {
-	}
-
-	public RefactoringTests(String name) {
-		super(name);
-	}
-
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+	@BeforeEach
+	protected void setUpProject() throws Exception {
 		CCorePlugin.getIndexManager().setIndexerId(cproject, IPDOMManager.ID_FAST_INDEXER);
 		fBufferSize = FileCharSequenceProvider.BUFFER_SIZE;
 		FileCharSequenceProvider.BUFFER_SIZE = 1024 * 4;
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@AfterEach
+	protected void tearDownFlush() throws Exception {
 		SavedCodeReaderFactory.getInstance().getCodeReaderCache().flush();
 		FileCharSequenceProvider.BUFFER_SIZE = fBufferSize;
 	}
@@ -70,8 +69,8 @@ public abstract class RefactoringTests extends BaseTestFramework {
 			countChanges(changes, count);
 		}
 		assertEquals(numChanges, count[0]);
-		assertEquals("potential changes: ", potChanges, count[1]);
-		assertEquals("comment changes: ", commentCh, count[2]);
+		assertEquals((long) potChanges, (long) count[1], "potential changes: ");
+		assertEquals((long) commentCh, (long) count[2], "comment changes: ");
 	}
 
 	private void countChanges(Change change, int[] count) {
@@ -156,7 +155,7 @@ public abstract class RefactoringTests extends BaseTestFramework {
 
 	private boolean checkTextEdit(TextEdit edit, int startOffset, int numChars, String newText) {
 		if (edit instanceof MultiTextEdit) {
-			if (checkTextEdits(((MultiTextEdit) edit).getChildren(), startOffset, numChars, newText)) {
+			if (checkTextEdits(edit.getChildren(), startOffset, numChars, newText)) {
 				return true;
 			}
 		} else if (edit instanceof ReplaceEdit) {
@@ -255,18 +254,18 @@ public abstract class RefactoringTests extends BaseTestFramework {
 
 	protected void assertRefactoringError(RefactoringStatus status, String msg) {
 		RefactoringStatusEntry e = status.getEntryMatchingSeverity(RefactoringStatus.ERROR);
-		assertNotNull("Expected refactoring error!", e);
+		assertNotNull(e, "Expected refactoring error!");
 		assertEquals(msg, e.getMessage());
 	}
 
 	protected void assertRefactoringWarning(RefactoringStatus status, String msg) {
 		RefactoringStatusEntry e = status.getEntryMatchingSeverity(RefactoringStatus.WARNING);
-		assertNotNull("Expected refactoring warning!", e);
+		assertNotNull(e, "Expected refactoring warning!");
 		assertEquals(msg, e.getMessage());
 	}
 
 	protected void assertRefactoringOk(RefactoringStatus status) {
-		assertTrue("Expected refactoring status ok: " + status.getMessageMatchingSeverity(status.getSeverity()),
-				status.getSeverity() == RefactoringStatus.OK);
+		assertTrue(status.getSeverity() == RefactoringStatus.OK,
+				"Expected refactoring status ok: " + status.getMessageMatchingSeverity(status.getSeverity()));
 	}
 }

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameFunctionTests.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameFunctionTests.java
@@ -18,20 +18,11 @@ import java.io.StringWriter;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
-
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class RenameFunctionTests extends RenameTestBase {
 
-	public RenameFunctionTests(String name) {
-		super(name);
-	}
-
-	public static Test suite() {
-		return new TestSuite(RenameFunctionTests.class);
-	}
-
+	@Test
 	public void testFunctionNameConflicts() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -309,6 +300,7 @@ public class RenameFunctionTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testFunctionsPlainC() throws Exception {
 		createCFwdDecls("c_fwd.h");
 		createCDefs("c_def.h");
@@ -333,6 +325,7 @@ public class RenameFunctionTests extends RenameTestBase {
 		assertTotalChanges(2, change);
 	}
 
+	@Test
 	public void testFunctionNameConflictsPlainC() throws Exception {
 		createCFwdDecls("c_fwd.h");
 		createCDefs("c_def.h");
@@ -417,6 +410,7 @@ public class RenameFunctionTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testMethodNameConflicts1() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -514,6 +508,7 @@ public class RenameFunctionTests extends RenameTestBase {
 						+ "New element: static_method  \n" + "Conflicting element type: Method");
 	}
 
+	@Test
 	public void testMethodNameConflicts2() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -696,6 +691,7 @@ public class RenameFunctionTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testBug72605() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo {               \n");
@@ -713,6 +709,7 @@ public class RenameFunctionTests extends RenameTestBase {
 		assertTotalChanges(2, changes);
 	}
 
+	@Test
 	public void testBug72732() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo {               \n");
@@ -729,6 +726,7 @@ public class RenameFunctionTests extends RenameTestBase {
 		assertTotalChanges(2, changes);
 	}
 
+	@Test
 	public void testBug330123() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo{                    \n");

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameMacroTests.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameMacroTests.java
@@ -17,20 +17,11 @@ package org.eclipse.cdt.ui.tests.refactoring.rename;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
-
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 public class RenameMacroTests extends RenameTestBase {
 
-	public RenameMacroTests(String name) {
-		super(name);
-	}
-
-	public static Test suite() {
-		return new TestSuite(RenameMacroTests.class);
-	}
-
+	@Test
 	public void testMacroRename() throws Exception {
 		StringBuilder buf = new StringBuilder();
 		buf.append("#define HALLO x   \n");
@@ -91,6 +82,7 @@ public class RenameMacroTests extends RenameTestBase {
 		off = contents.indexOf("HALLO", off + 1);
 	}
 
+	@Test
 	public void testMacroNameConflicts() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -142,6 +134,7 @@ public class RenameMacroTests extends RenameTestBase {
 						+ "New element: enum_item  \n" + "Conflicting element type: Enumerator");
 	}
 
+	@Test
 	public void testClassMacroClash() throws Exception {
 		StringBuilder buf = new StringBuilder();
 		buf.append("class CC {int a;};         \n");
@@ -163,6 +156,7 @@ public class RenameMacroTests extends RenameTestBase {
 		assertTotalChanges(2, ch);
 	}
 
+	@Test
 	public void testMacroRename_434917() throws Exception {
 		StringBuilder buf = new StringBuilder();
 		buf.append("#define CC mm\n");
@@ -180,6 +174,7 @@ public class RenameMacroTests extends RenameTestBase {
 		assertTotalChanges(2, ch);
 	}
 
+	@Test
 	public void testIncludeGuard() throws Exception {
 		StringBuilder buf = new StringBuilder();
 		buf.append("#ifndef _guard            \n");
@@ -199,6 +194,7 @@ public class RenameMacroTests extends RenameTestBase {
 		assertChange(ch, cpp, off, 6, "WELT");
 	}
 
+	@Test
 	public void testMacroParameters() throws Exception {
 		StringBuilder buf = new StringBuilder();
 		buf.append("int var;                  \n");
@@ -213,6 +209,7 @@ public class RenameMacroTests extends RenameTestBase {
 		assertTotalChanges(1, 1, 0, ch);
 	}
 
+	@Test
 	public void testRenameMacroAsMacroArgument() throws Exception {
 		StringBuilder buf = new StringBuilder();
 		buf.append("#define M1(var) var       \n");

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameRegressionTests.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameRegressionTests.java
@@ -14,6 +14,11 @@
  *******************************************************************************/
 package org.eclipse.cdt.ui.tests.refactoring.rename;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.StringWriter;
 
 import org.eclipse.cdt.core.dom.ast.IBinding;
@@ -21,23 +26,12 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.participants.RenameArguments;
-
-import junit.framework.AssertionFailedError;
-import junit.framework.Test;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 
 public class RenameRegressionTests extends RenameTestBase {
-	public RenameRegressionTests() {
-		super();
-	}
 
-	public RenameRegressionTests(String name) {
-		super(name);
-	}
-
-	public static Test suite() {
-		return suite(RenameRegressionTests.class, "_");
-	}
-
+	@Test
 	public void testSimpleRename() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("int boo;    // boo  \n");
@@ -57,6 +51,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("boo++"), 3, "ooga");
 	}
 
+	@Test
 	public void testLocalVar() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("void f() {          \n");
@@ -82,6 +77,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, offset, 3, "ooga");
 	}
 
+	@Test
 	public void testParameter() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("void f(int boo) {   \n");
@@ -106,6 +102,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, offset, 3, "ooga");
 	}
 
+	@Test
 	public void testFileStaticVar() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("static int boo;     \n");
@@ -129,6 +126,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, offset, 3, "ooga");
 	}
 
+	@Test
 	public void testClass_1() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Boo/*vp1*/{}; \n");
@@ -146,6 +144,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("Boo a"), 3, "Ooga");
 	}
 
+	@Test
 	public void testAttribute_2() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Boo{          \n");
@@ -166,6 +165,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("att1;//res2"), 4, "ooga");
 	}
 
+	@Test
 	public void testMethod_1() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo{                                \n");
@@ -190,6 +190,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, cpp, source.indexOf("method1(\"hello"), 7, "m1");
 	}
 
+	@Test
 	public void testMethod_3() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Boo{                   \n");
@@ -215,6 +216,7 @@ public class RenameRegressionTests extends RenameTestBase {
 	// However, the UI does display the error in the preview panel. Defect 78769 states
 	// the error should be shown on the first page. The parser passes, but the UI could be
 	// better.
+	@Test
 	public void testConstructor_27() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Boo{           \n");
@@ -238,6 +240,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		fail("An error should have occurred in the input check.");
 	}
 
+	@Test
 	public void testDestructor_29_72612() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Boo{           \n");
@@ -261,6 +264,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		fail("An error should have occurred in the input check.");
 	}
 
+	@Test
 	public void testFunction_31() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("void foo(){}             \n");
@@ -281,6 +285,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("foo(3)"), 3, "ooga");
 	}
 
+	@Test
 	public void testMethod_32_72717() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Base {                 \n");
@@ -303,6 +308,7 @@ public class RenameRegressionTests extends RenameTestBase {
 				+ "Type of problem: Overloading  \n" + "New element: foo  \n" + "Conflicting element type: Method");
 	}
 
+	@Test
 	public void testMethod_33_72605() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo {                  \n");
@@ -318,6 +324,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("aMethod(int x)"), 7, "ooga");
 	}
 
+	@Test
 	public void testMethod_33b_72605() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo {                  \n");
@@ -346,6 +353,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, cppfile, cppoffset, 7, "ooga");
 	}
 
+	@Test
 	public void testMethod_34() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Base{              \n");
@@ -393,6 +401,7 @@ public class RenameRegressionTests extends RenameTestBase {
 
 	}
 
+	@Test
 	public void testMethod_39() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo{                              \n");
@@ -431,6 +440,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, cpp, source.indexOf("method2(3"), 7, "m2");
 	}
 
+	@Test
 	public void testMethod_40() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo{                                   \n");
@@ -468,6 +478,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, cpp, source.indexOf("method2(3"), 7, "m2");
 	}
 
+	@Test
 	public void testMethod_41() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo{                                   \n");
@@ -499,6 +510,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, cpp, source.indexOf("method1(1"), 7, "m1");
 	}
 
+	@Test
 	public void testMethod_43() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo{                                   \n");
@@ -528,6 +540,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, cpp, source.indexOf("method1(1"), 7, "m1");
 	}
 
+	@Test
 	public void testMethod_44() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Base{              \n");
@@ -553,6 +566,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("v(){i++;}"), 1, "v1");
 	}
 
+	@Test
 	public void testMethod_45() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Base{              \n");
@@ -579,6 +593,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("v(){i"), 1, "v1");
 	}
 
+	@Test
 	public void testStruct_46() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("struct st1/*vp1*/{};             \n");
@@ -618,6 +633,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("st3 ss"), 3, "Ooga3");
 	}
 
+	@Test
 	public void testUnion_47() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("union st1/*vp1*/{};              \n");
@@ -657,6 +673,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("st3 ss"), 3, "Ooga3");
 	}
 
+	@Test
 	public void testEnumeration_48() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("enum e1/*vp1*/{E0};              \n");
@@ -696,6 +713,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("e3 ss"), 2, "Ooga3");
 	}
 
+	@Test
 	public void testTemplate_49_72626() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("template <class Type>            \n");
@@ -720,6 +738,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, offset = contents.indexOf("Array", offset + 1), 5, "Arr2");
 	}
 
+	@Test
 	public void testClass_52() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("namespace N1 {           \n");
@@ -743,6 +762,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("Boo c2"), 3, "Ooga");
 	}
 
+	@Test
 	public void testClass_53() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo/*vp1*/ {//ren1     \n");
@@ -774,6 +794,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("Foo();//ren10"), 3, "Ooga");
 	}
 
+	@Test
 	public void testAttribute_54() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Boo{                   \n");
@@ -796,6 +817,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("att;//rn3"), 3, "ooga");
 	}
 
+	@Test
 	public void testClass_55() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo{           \n");
@@ -821,6 +843,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("Hoo(){}"), 3, "ooga");
 	}
 
+	@Test
 	public void testClass_55_79231() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Boo{};//vp1            \n");
@@ -842,6 +865,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("Boo{};//vp1"), 3, "Ooga");
 	}
 
+	@Test
 	public void testClass_55_72748() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo{};//vp1            \n");
@@ -862,6 +886,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("Foo*>(0)"), 3, "Ooga");
 	}
 
+	@Test
 	public void testClass_56() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo{};//vp1,rn1            \n");
@@ -882,6 +907,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("Foo(){}//rn3"), 3, "Ooga");
 	}
 
+	@Test
 	public void testAttribute_61() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo{       \n");
@@ -903,6 +929,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, cpp, source.indexOf("count"), 5, "ooga");
 	}
 
+	@Test
 	public void testEnumerator_62() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("enum Foo{E0, E1};//vp1       \n");
@@ -927,6 +954,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, cpp, source.indexOf("E1"), 2, "ooga");
 	}
 
+	@Test
 	public void testAttribute_63() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo{       \n");
@@ -951,6 +979,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, cpp, source.indexOf("att"), 3, "ooga");
 	}
 
+	@Test
 	public void testAttribute_64() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Foo{               \n");
@@ -977,6 +1006,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, h, header.indexOf("b;//rn2"), 1, "ooga");
 	}
 
+	@Test
 	public void testAttribute_65() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class A{             \n");
@@ -1005,6 +1035,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, cpp, source.indexOf("att;"), 3, "ooga");
 	}
 
+	@Test
 	public void testNamespace_66() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("namespace Foo/*vp1*/{            \n");
@@ -1033,6 +1064,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("Baz;"), 3, "Wooga");
 	}
 
+	@Test
 	public void testNamespace_66_79281() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("namespace Foo{           \n");
@@ -1052,6 +1084,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("Bar::"), 3, "Ooga");
 	}
 
+	@Test
 	public void testNamespace_66_79282() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("namespace Foo/*vp1*/{}           \n");
@@ -1067,6 +1100,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("Foo;"), 3, "Ooga");
 	}
 
+	@Test
 	public void testFunction_67() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("void foo/*vp1*/(){}//rn1     \n");
@@ -1089,6 +1123,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("foo();}//rn3"), 3, "ooga");
 	}
 
+	@Test
 	public void testVariable_68() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class A{                 \n");
@@ -1114,6 +1149,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertChange(changes, file, contents.indexOf("var.i=3;//rn3"), 3, "ooga");
 	}
 
+	@Test
 	public void testVariable_68_79295() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("int var;//vp1            \n");
@@ -1132,6 +1168,7 @@ public class RenameRegressionTests extends RenameTestBase {
 
 	// similar to test 92, except this one will continue with warning, or error status
 	// while case in 92 must stop refactor with fatal status
+	@Test
 	public void testClass_81_72620() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("union u_haul{};      \n");
@@ -1148,6 +1185,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		fail("An error should have occurred in the input check.");
 	}
 
+	@Test
 	public void testVariable_88_72617() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class A{};               \n");
@@ -1172,6 +1210,7 @@ public class RenameRegressionTests extends RenameTestBase {
 	// if you don't know the error message, catch on getRefactorChanges
 	// or if you want to verify a message or severity, use getRefactorMessages
 	// and getRefactorSeverity
+	@Test
 	public void testClass_92A() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class Boo{};         \n");
@@ -1191,6 +1230,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		fail("An error or warning should have occurred in the input check.");
 	}
 
+	@Test
 	public void testClass_92B() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class A{};           \n");
@@ -1209,6 +1249,7 @@ public class RenameRegressionTests extends RenameTestBase {
 		assertEquals(RefactoringStatus.ERROR, s);
 	}
 
+	@Test
 	public void testRenameParticipant() throws Exception {
 		TestRenameParticipant.reset();
 		StringWriter writer = new StringWriter();

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameTemplatesTests.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameTemplatesTests.java
@@ -18,23 +18,14 @@ import java.io.StringWriter;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
-
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author markus.schorn@windriver.com
  */
 public class RenameTemplatesTests extends RenameTestBase {
 
-	public RenameTemplatesTests(String name) {
-		super(name);
-	}
-
-	public static Test suite() {
-		return new TestSuite(RenameTemplatesTests.class);
-	}
-
+	@Test
 	public void testClassTemplate() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("template <class Type>   \n");

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameTestBase.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameTestBase.java
@@ -14,6 +14,8 @@
  ******************************************************************************/
 package org.eclipse.cdt.ui.tests.refactoring.rename;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import org.eclipse.cdt.internal.ui.refactoring.rename.CRefactoringArgument;
 import org.eclipse.cdt.internal.ui.refactoring.rename.CRefactory;
 import org.eclipse.cdt.internal.ui.refactoring.rename.CRenameProcessor;
@@ -32,13 +34,6 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatusEntry;
  */
 public abstract class RenameTestBase extends RefactoringTests {
 	private static final IProgressMonitor NPM = new NullProgressMonitor();
-
-	protected RenameTestBase(String name) {
-		super(name);
-	}
-
-	protected RenameTestBase() {
-	}
 
 	/**
 	 * @param element the CElement to rename

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameTypeTests.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameTypeTests.java
@@ -19,23 +19,14 @@ import java.io.StringWriter;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
-
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author markus.schorn@windriver.com
  */
 public class RenameTypeTests extends RenameTestBase {
 
-	public RenameTypeTests(String name) {
-		super(name);
-	}
-
-	public static Test suite() {
-		return new TestSuite(RenameTypeTests.class);
-	}
-
+	@Test
 	public void testClassNameConflicts() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -340,6 +331,7 @@ public class RenameTypeTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testNamespaceNameConflicts() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -642,6 +634,7 @@ public class RenameTypeTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testStructNameConflicts() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -944,6 +937,7 @@ public class RenameTypeTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testStructNameConflictsPlainC() throws Exception {
 		createCFwdDecls("c_fwd.h");
 		createCDefs("c_def.h");
@@ -1021,6 +1015,7 @@ public class RenameTypeTests extends RenameTestBase {
 
 	}
 
+	@Test
 	public void testUnionNameConflicts() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -1323,6 +1318,7 @@ public class RenameTypeTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testUnionNameConflictsPlainC() throws Exception {
 		createCFwdDecls("c_fwd.h");
 		createCDefs("c_def.h");
@@ -1393,6 +1389,7 @@ public class RenameTypeTests extends RenameTestBase {
 
 	}
 
+	@Test
 	public void testEnumNameConflicts() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -1629,6 +1626,7 @@ public class RenameTypeTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testEnumNameConflictsPlainC() throws Exception {
 		createCppFwdDecls("c_fwd.h");
 		createCppDefs("c_def.h");
@@ -1707,6 +1705,7 @@ public class RenameTypeTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testTypedefNameConflicts() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -1941,6 +1940,7 @@ public class RenameTypeTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testTypedefNameConflictsPlainC() throws Exception {
 		createCFwdDecls("c_fwd.h");
 		createCDefs("c_def.h");
@@ -2021,6 +2021,7 @@ public class RenameTypeTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testRenameClass() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class String              \n");
@@ -2048,6 +2049,7 @@ public class RenameTypeTests extends RenameTestBase {
 		assertTotalChanges(countOccurrences(contents, "String"), ch);
 	}
 
+	@Test
 	public void testRenameClassFromCtor() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class String              \n"); //$NON-NLS-1$
@@ -2074,6 +2076,7 @@ public class RenameTypeTests extends RenameTestBase {
 		assertTotalChanges(countOccurrences(contents, "String"), ch); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testRenameClassFromDtor() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class String              \n"); //$NON-NLS-1$
@@ -2100,6 +2103,7 @@ public class RenameTypeTests extends RenameTestBase {
 		assertTotalChanges(countOccurrences(contents, "String"), ch); //$NON-NLS-1$
 	}
 
+	@Test
 	public void testUsingDeclaration_332895() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("namespace ns {            \n");
@@ -2119,6 +2123,7 @@ public class RenameTypeTests extends RenameTestBase {
 		assertTotalChanges(countOccurrences(contents, "MyType"), ch);
 	}
 
+	@Test
 	public void testBug72888() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class MyEx {};            \n");

--- a/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameVariableTests.java
+++ b/core/org.eclipse.cdt.ui.tests/ui/org/eclipse/cdt/ui/tests/refactoring/rename/RenameVariableTests.java
@@ -18,23 +18,14 @@ import java.io.StringWriter;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
-
-import junit.framework.Test;
-import junit.framework.TestSuite;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author markus.schorn@windriver.com
  */
 public class RenameVariableTests extends RenameTestBase {
 
-	public RenameVariableTests(String name) {
-		super(name);
-	}
-
-	public static Test suite() {
-		return new TestSuite(RenameVariableTests.class);
-	}
-
+	@Test
 	public void testLocalNameConflicts() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -277,6 +268,7 @@ public class RenameVariableTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testLocalNameConflictsPlainC() throws Exception {
 		createCFwdDecls("c_fwd.h");
 		createCDefs("c_def.h");
@@ -345,6 +337,7 @@ public class RenameVariableTests extends RenameTestBase {
 
 	}
 
+	@Test
 	public void testParameterNameConflicts() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -585,6 +578,7 @@ public class RenameVariableTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testParameterNameConflictsPlainC() throws Exception {
 		createCFwdDecls("c_fwd.h");
 		createCDefs("c_def.h");
@@ -656,6 +650,7 @@ public class RenameVariableTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testVaribleNameConflicts() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -937,6 +932,7 @@ public class RenameVariableTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testVaribleNameConflictsPlainC() throws Exception {
 		createCFwdDecls("c_fwd.h");
 		createCDefs("c_def.h");
@@ -1025,6 +1021,7 @@ public class RenameVariableTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testEnumeratorNameConflicts() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -1297,6 +1294,7 @@ public class RenameVariableTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testEnumeratorNameConflictsPlainC() throws Exception {
 		createCFwdDecls("c_fwd.h");
 		createCDefs("c_def.h");
@@ -1373,6 +1371,7 @@ public class RenameVariableTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testMemberNameConflicts1() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -1475,6 +1474,7 @@ public class RenameVariableTests extends RenameTestBase {
 						+ "New element: static_method  \n" + "Conflicting element type: Method");
 	}
 
+	@Test
 	public void testMemberNameConflicts2() throws Exception {
 		createCppFwdDecls("cpp_fwd.hh");
 		createCppDefs("cpp_def.hh");
@@ -1657,6 +1657,7 @@ public class RenameVariableTests extends RenameTestBase {
 		assertRefactoringOk(status);
 	}
 
+	@Test
 	public void testReferenceViaMacro() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("#define PASSON(x) (x)         \n");
@@ -1676,6 +1677,7 @@ public class RenameVariableTests extends RenameTestBase {
 		assertChange(changes, cpp, offset2, 2, "z");
 	}
 
+	@Test
 	public void testReferenceViaMacro2() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("#define INC(x,y) x+=y      \n");
@@ -1694,6 +1696,7 @@ public class RenameVariableTests extends RenameTestBase {
 		assertChange(changes, cpp, offset2, 2, "z");
 	}
 
+	@Test
 	public void testReferenceViaMacro3() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("#define INC(x,y) x+=y      \n");
@@ -1714,6 +1717,7 @@ public class RenameVariableTests extends RenameTestBase {
 		assertChange(changes, cpp, offset, 2, "z");
 	}
 
+	@Test
 	public void testReferenceViaMacro4() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("#define INC(x)   v2++      \n");
@@ -1730,6 +1734,7 @@ public class RenameVariableTests extends RenameTestBase {
 		assertChange(changes, cpp, offset, 2, "z");
 	}
 
+	@Test
 	public void testReferenceViaMacro5() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("#define INC(x)   v1++      \n");
@@ -1752,6 +1757,7 @@ public class RenameVariableTests extends RenameTestBase {
 		assertChange(changes, cpp, offset2, 2, "z");
 	}
 
+	@Test
 	public void testBug72646() throws Exception {
 		StringWriter writer = new StringWriter();
 		writer.write("class C2: public C1 {     \n");


### PR DESCRIPTION
BaseTestFramework is the base class for a hierarchy of tests and all those test updates are included in this commit.

Includes a parent commit that deletes an unused method that interfered with the resolution of assertEquals when statically imported.

Part of https://github.com/eclipse-cdt/cdt/issues/1380