### PR TITLE
Remove Qt jui -> Java builder from LLVM plug-in

### DIFF
--- a/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/.project
+++ b/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/.project
@@ -6,11 +6,6 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>com.trolltech.qtjambi.juicBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
 			</arguments>


### PR DESCRIPTION
This isn't in use as there are no .jui files in our source repo.

Part of https://github.com/eclipse-cdt/cdt/issues/1405