### PR TITLE
Update asciidoc copyright headers to 2026

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,6 +38,7 @@ find \
     $CDT_ROOT/remote/org.eclipse.remote.doc.isv/pom.xml \
     -type f -exec sed -i s/12.4.0/12.5.0/g {} \;
 ```
+- At the beginning of the calendar year, or on the first edit to `**/*.adoc` files, update the copyright end year in `doc/org.eclipse.cdt.doc.user/adoc-headers.txt` and run `releng/scripts/do_generate_asciidoc.sh` to propagate the change to all the asciidoc files.
 - run check_code_cleanliness to make sure that everything looks good `docker run --rm -it -v $(git rev-parse --show-toplevel):/work -w /work/$(git rev-parse --show-prefix) quay.io/eclipse-cdt/cdt-infra:latest releng/scripts/check_code_cleanliness.sh` - if version bumps are needed, see "bump bundle versions" below
 - create a PR with the above and push it to main when it succeeds.
 - test CDT.setup works

--- a/doc/org.eclipse.cdt.doc.user/adoc-headers.txt
+++ b/doc/org.eclipse.cdt.doc.user/adoc-headers.txt
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/concepts/cdt_c_before_you_begin.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/concepts/cdt_c_before_you_begin.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/example/example.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/example/example.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cbs_build_project.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cbs_build_project.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cbs_debug_project.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cbs_debug_project.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cbs_debug_remote.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cbs_debug_remote.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cbs_launchbar.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cbs_launchbar.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cbs_run_project.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cbs_run_project.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cbs_using_existing_code.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cbs_using_existing_code.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_o_tutorial.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_o_tutorial.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_basic.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_basic.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_build.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_build.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_debug.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_debug.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_existing_code.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_existing_code.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_import.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_import.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_newcpp.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_newcpp.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_newmake.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_newmake.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_prepare_workbench.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/cdt_w_prepare_workbench.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/core_build_system.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/core_build_system.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/hw_example.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/hw_example.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/index_cbs.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/index_cbs.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/index_mbs.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/index_mbs.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/make_example.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/make_example.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/managed_build_system.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/managed_build_system.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/new_cbs_makefile_proj.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/new_cbs_makefile_proj.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/getting_started/new_cmake_proj.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/getting_started/new_cmake_proj.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/llvm/general.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/llvm/general.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/llvm/initial_configuration.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/llvm/initial_configuration.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/llvm/llvm_specific.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/llvm/llvm_specific.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at

--- a/doc/org.eclipse.cdt.doc.user/src/llvm/user_manual.adoc
+++ b/doc/org.eclipse.cdt.doc.user/src/llvm/user_manual.adoc
@@ -1,5 +1,5 @@
 ////
-Copyright (c) 2000, 2025 Contributors to the Eclipse Foundation
+Copyright (c) 2000, 2026 Contributors to the Eclipse Foundation
 This program and the accompanying materials
 are made available under the terms of the Eclipse Public License 2.0
 which accompanies this distribution, and is available at


### PR DESCRIPTION
And document the procedure to bump year in RELEASING.md

Fixes https://github.com/eclipse-cdt/cdt/issues/1437