### PR TITLE
Remove 'LLVM with Clang' linker I/O options

### DIFF
--- a/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/plugin.properties
+++ b/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/plugin.properties
@@ -160,10 +160,6 @@ Option.Posix.UserBcs=Other bitcode and object files
 #Option.Posix.Linker.SOName=Shared object name (-Wl,-soname=)
 #Option.Posix.Linker.Implib=Import Library name (-Wl,--out-implib=)
 #Option.Posix.Linker.Defname=DEF file name (-Wl,--output-def=)
-Option.Posix.Linker.link_as_library=Create a library
-Option.Posix.Linker.LlvmOptions=Input/Output Options
-Option.Posix.Linker.native=Create native binary (with LLVM native code generator)
-Option.Posix.Linker.nativeCBackend=Create native binary (with C backend code generator)
 Option.Posix.Static.Compiler.Flags=Static Compiler Flags
 
 Option.Llvm.Clang.EmitLlvm.name=Emit LLVM IR (-emit-llvm)
@@ -188,7 +184,7 @@ Option.Llvm.Lli.enable-correct-eh-support=Make the -lowerinvoke pass insert expe
 Option.Llvm.Lli.jit-enable-eh=Exception handling should be enabled in the just-in-time compiler
 Option.Llvm.Assembler.Flags=Assembler flags
 Option.Llvm.Assembler.warn.suppress=Suppress warnings (-W)
-Option.Llvm.Assembler.version=Announce version (-v)
+Option.Llvm.Assembler.version=Announce version (--version)
 
 # Platform specific option names
 #Option.Windows.Windres.OutputFormat = Output format
@@ -220,9 +216,6 @@ extension.name.2 = LLVM-GCC managed make per project SCD profile
 option.tip = In this mode the linker will print additional information about the actions it takes, programs it executes, etc.
 option.tip.0 = Strip all debug and symbol information from the executable to make it smaller.
 option.tip.1 = Strip all debug information from the executable to make it smaller.
-option.tip.6 = Generate a native machine code executable.
-option.tip.7 = Generate a native machine code executable with the LLVM C backend. Uses the C backend to generate code for the program instead of an LLVM native code generator.
-option.tip.8 = Link the bitcode files together as a library, not an executable. In this mode, undefined symbols will be permitted.
 option.tip.9 = Print the table of contents.
 option.tip.10 = Print statistics recorded by code-generation passes.
 option.tip.11 = Disable optimizations that may produce excess precision for floating point. Note that this option can dramatically slow down code on some systems (e.g. X86).

--- a/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/plugin.xml
+++ b/llvm/org.eclipse.cdt.managedbuilder.llvm.ui/plugin.xml
@@ -137,68 +137,11 @@ Contributors:
                valueType="string">
          </option>
          <option
-               category="llvm.c.link.category.llvmOptions"
-               command="-native"
-               defaultValue="false"
-               id="llvm.c.link.option.native"
-               isAbstract="false"
-               name="%Option.Posix.Linker.native"
-               resourceFilter="all"
-               tip="%option.tip.6"
-               valueType="boolean">
-         </option>
-         <option
-               category="llvm.c.link.category.llvmOptions"
-               command="-native-cbe"
-               defaultValue="false"
-               id="llvm.c.link.option.nativeCBackEnd"
-               isAbstract="false"
-               name="%Option.Posix.Linker.nativeCBackend"
-               resourceFilter="all"
-               tip="%option.tip.7"
-               valueType="boolean">
-            <enablement
-                  attribute="defaultValue"
-                  extensionAdjustment="false"
-                  type="CONTAINER_ATTRIBUTE"
-                  value="false">
-               <checkBuildProperty
-                     property="org.eclipse.cdt.build.core.buildArtefactType"
-                     value="org.eclipse.cdt.build.core.buildArtefactType.exe">
-               </checkBuildProperty>
-            </enablement>
-         </option>
-         <option
                browseType="file"
                category="llvm.c.link.category.other"
                id="llvm.c.link.option.userobjs"
                name="%Option.Posix.UserBcs"
                valueType="userObjs">
-         </option>
-         <optionCategory
-               id="llvm.c.link.category.llvmOptions"
-               name="%Option.Posix.Linker.LlvmOptions"
-               owner="cdt.managedbuild.tool.llvm.c.linker">
-         </optionCategory>
-         <option
-               category="llvm.c.link.category.llvmOptions"
-               command="-link-as-library"
-               defaultValue="false"
-               id="llvm.c.link.option.linkaslibrary"
-               isAbstract="false"
-               name="%Option.Posix.Linker.link_as_library"
-               tip="%option.tip.8"
-               valueType="boolean">
-            <enablement
-                  attribute="defaultValue"
-                  extensionAdjustment="false"
-                  type="CONTAINER_ATTRIBUTE"
-                  value="true">
-               <checkBuildProperty
-                     property="org.eclipse.cdt.build.core.buildArtefactType"
-                     value="org.eclipse.cdt.build.core.buildArtefactType.sharedLib">
-               </checkBuildProperty>
-            </enablement>
          </option>
          <optionCategory
                id="llvm.c.link.category.other"
@@ -384,7 +327,7 @@ Contributors:
          </option>
          <option
                category="llvm.asm.category.general"
-               command="-v"
+               command="--version"
                defaultValue="false"
                id="llvm.both.asm.option.version"
                name="%Option.Llvm.Assembler.version"


### PR DESCRIPTION
The `-native`, `-native-cbe` and `-link-as-library` options are now obsolete.

Relates to: https://github.com/eclipse-cdt/cdt/issues/1427