### PR TITLE
fix: __attribute__ of declarator missing from AST (issues #706 and #602)

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPAttributeTests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2CPPAttributeTests.java
@@ -642,4 +642,19 @@ public class AST2CPPAttributeTests extends AST2TestBase {
 		assertSame(parent1, parent3);
 		assertSame(parent1, parent4);
 	}
+
+	//	int target;
+	//	extern int other, __attribute__((alias("target"))) error_decl;
+	@Test
+	public void testGCCAttributeBeforeDeclaratorInList_bug706() throws Exception {
+		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.C, ScannerKind.GNU);
+		checkAttributeRelations(getAttributeSpecifiers(tu), IASTDeclarator.class);
+	}
+
+	//	extern int ( __attribute__((__artificial__)) func)();
+	@Test
+	public void testGCCAttributeInNestedDeclarator_bug602() throws Exception {
+		IASTTranslationUnit tu = parseAndCheckBindings(getAboveComment(), ParserLanguage.C, ScannerKind.GNU);
+		checkAttributeRelations(getAttributeSpecifiers(tu), IASTDeclarator.class);
+	}
 }

--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core; singleton:=true
-Bundle-Version: 9.3.100.qualifier
+Bundle-Version: 9.3.200.qualifier
 Bundle-Activator: org.eclipse.cdt.core.CCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/c/GNUCSourceParser.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/c/GNUCSourceParser.java
@@ -869,10 +869,11 @@ public class GNUCSourceParser extends AbstractGNUSourceCodeParser {
 	protected void consumePointerOperators(List<IASTPointerOperator> pointerOps)
 			throws EndOfFileException, BacktrackException {
 		for (;;) {
+			IToken mark = mark();
+
 			// __attribute__ in-between pointers
 			__attribute_decl_seq(supportAttributeSpecifiers, false);
 
-			IToken mark = mark();
 			IToken last = null;
 
 			boolean isConst = false, isVolatile = false, isRestrict = false;
@@ -883,7 +884,7 @@ public class GNUCSourceParser extends AbstractGNUSourceCodeParser {
 			}
 
 			last = consume();
-			int startOffset = mark.getOffset();
+			int startOffset = last.getOffset();
 			for (;;) {
 				IToken t = LA(1);
 				switch (LT(1)) {


### PR DESCRIPTION
Fixes [eclipse-cdt/cdt#706](https://github.com/eclipse-cdt/cdt/issues/706) and [eclipse-cdt/cdt#602](https://github.com/eclipse-cdt/cdt/issues/602):

## Root Cause

In `GNUCSourceParser.consumePointerOperators()`, `IToken mark = mark()` was called *after* `__attribute_decl_seq()` consumed any attributes. When no pointer operator (`*`) followed the attribute, `backup(mark)` restored only to *after* the attribute — permanently losing it from the token stream. The `declarator()` caller then tried to re-consume the attribute at line 1407 but it was already gone.

## Fix

Move `IToken mark = mark()` to *before* the `__attribute_decl_seq()` call. Now when no `*` follows, `backup(mark)` correctly restores to *before* the attribute, allowing `declarator()` to pick it up via its own `__attribute_decl_seq()` call.

Also update `startOffset` to use `last.getOffset()` (the `*` token's offset) instead of `mark.getOffset()`, since `mark` now points before any attribute rather than at the `*`.