### PR TITLE
fix: preserve GCC __attribute__ between enum keyword and name in AST

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2Tests.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/AST2Tests.java
@@ -8153,4 +8153,20 @@ public class AST2Tests extends AST2TestBase {
 		IASTAttributeSpecifier[] attributes = declSpec.getAttributeSpecifiers();
 		assertEquals(1, attributes.length);
 	}
+
+	//	enum __attribute__ ((packed)) color {
+	//		RED = 1,
+	//		GREEN = 2
+	//	};
+	@Test
+	public void testEnumAttribute() throws Exception {
+		BindingAssertionHelper helper = getAssertionHelper(C);
+		IASTDeclaration[] decls = helper.getTranslationUnit().getDeclarations();
+		assertEquals(1, decls.length);
+		assertInstance(decls[0], IASTSimpleDeclaration.class);
+		IASTDeclSpecifier declSpec = ((IASTSimpleDeclaration) decls[0]).getDeclSpecifier();
+		assertInstance(declSpec, IASTEnumerationSpecifier.class);
+		IASTAttributeSpecifier[] attributes = declSpec.getAttributeSpecifiers();
+		assertEquals(1, attributes.length);
+	}
 }

--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core; singleton:=true
-Bundle-Version: 9.3.100.qualifier
+Bundle-Version: 9.3.200.qualifier
 Bundle-Activator: org.eclipse.cdt.core.CCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/AbstractGNUSourceCodeParser.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/AbstractGNUSourceCodeParser.java
@@ -1554,8 +1554,9 @@ public abstract class AbstractGNUSourceCodeParser implements ISourceCodeParser {
 		final IToken mark = mark();
 		final int offset = consume().getOffset();
 
-		// if __attribute__ or __declspec occurs after struct/union/class and before the identifier
-		__attribute_decl_seq(supportAttributeSpecifiers, supportDeclspecSpecifiers);
+		// if __attribute__ or __declspec occurs after enum and before the identifier
+		List<IASTAttributeSpecifier> attributes = __attribute_decl_seq(supportAttributeSpecifiers,
+				supportDeclspecSpecifiers);
 
 		IASTName name;
 		if (LT(1) == IToken.tIDENTIFIER) {
@@ -1570,6 +1571,7 @@ public abstract class AbstractGNUSourceCodeParser implements ISourceCodeParser {
 		}
 
 		final IASTEnumerationSpecifier result = nodeFactory.newEnumerationSpecifier(name);
+		addAttributeSpecifiers(attributes, result);
 
 		int endOffset = enumBody(result);
 		return setRange(result, offset, endOffset);


### PR DESCRIPTION
`__attribute__` placed between `enum` and the tag name (e.g. `enum __attribute__((packed)) color { ... }`) was silently dropped from the AST. The parser consumed the tokens correctly but discarded the returned attribute list instead of attaching it to the `IASTEnumerationSpecifier`.

```c
// Previously: attribute was consumed but not added to the AST node
enum __attribute__ ((packed)) color {
    RED = 1,
    GREEN = 2
};
```