### PR TITLE
Add `inline` and `goto` qualifier support to `__asm__` declarations

### DIFF
--- a/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/GCCCompleteParseExtensionsTest.java
+++ b/core/org.eclipse.cdt.core.tests/parser/org/eclipse/cdt/core/parser/tests/ast2/GCCCompleteParseExtensionsTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.cdt.core.parser.tests.ast2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringWriter;
@@ -506,5 +507,51 @@ public class GCCCompleteParseExtensionsTest extends AST2TestBase {
 		String code = getAboveComment();
 		parseGCC(code);
 		parseGPP(code);
+	}
+
+	@Test
+	public void testAsmInlineGotoQualifiers() throws Exception {
+		// __asm__ inline ("nop");
+		IASTDeclaration[] decls = parseGCC("__asm__ inline (\"nop\");").getDeclarations();
+		IASTASMDeclaration asmDecl = (IASTASMDeclaration) decls[0];
+		assertEquals("\"nop\"", asmDecl.getAssembly());
+		assertTrue(asmDecl.isInline());
+		assertFalse(asmDecl.isVolatile());
+		assertFalse(asmDecl.isGoto());
+
+		// __asm__ goto ("nop");
+		decls = parseGCC("__asm__ goto (\"nop\");").getDeclarations();
+		asmDecl = (IASTASMDeclaration) decls[0];
+		assertEquals("\"nop\"", asmDecl.getAssembly());
+		assertTrue(asmDecl.isGoto());
+		assertFalse(asmDecl.isVolatile());
+		assertFalse(asmDecl.isInline());
+
+		// asm volatile inline goto ("nop"); - multiple qualifiers in any order
+		decls = parseGCC("asm volatile inline goto (\"nop\");").getDeclarations();
+		asmDecl = (IASTASMDeclaration) decls[0];
+		assertTrue(asmDecl.isVolatile());
+		assertTrue(asmDecl.isInline());
+		assertTrue(asmDecl.isGoto());
+
+		// CPP variants
+		decls = parseGPP("__asm__ inline (\"nop\");").getDeclarations();
+		asmDecl = (IASTASMDeclaration) decls[0];
+		assertTrue(asmDecl.isInline());
+		assertFalse(asmDecl.isVolatile());
+		assertFalse(asmDecl.isGoto());
+
+		decls = parseGPP("__asm__ goto (\"nop\");").getDeclarations();
+		asmDecl = (IASTASMDeclaration) decls[0];
+		assertTrue(asmDecl.isGoto());
+		assertFalse(asmDecl.isVolatile());
+		assertFalse(asmDecl.isInline());
+
+		// volatile qualifier (existing) is still stored correctly
+		decls = parseGCC("asm volatile (\"nop\");").getDeclarations();
+		asmDecl = (IASTASMDeclaration) decls[0];
+		assertTrue(asmDecl.isVolatile());
+		assertFalse(asmDecl.isInline());
+		assertFalse(asmDecl.isGoto());
 	}
 }

--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core; singleton:=true
-Bundle-Version: 9.3.100.qualifier
+Bundle-Version: 9.3.200.qualifier
 Bundle-Activator: org.eclipse.cdt.core.CCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
+++ b/core/org.eclipse.cdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.core; singleton:=true
-Bundle-Version: 9.3.200.qualifier
+Bundle-Version: 9.4.0.qualifier
 Bundle-Activator: org.eclipse.cdt.core.CCorePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/IASTASMDeclaration.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/IASTASMDeclaration.java
@@ -35,6 +35,48 @@ public interface IASTASMDeclaration extends IASTDeclaration {
 	public void setAssembly(String assembly);
 
 	/**
+	 * Returns whether the <code>volatile</code> qualifier was present.
+	 *
+	 * @since 9.4
+	 */
+	public boolean isVolatile();
+
+	/**
+	 * Sets the <code>volatile</code> qualifier.
+	 *
+	 * @since 9.4
+	 */
+	public void setVolatile(boolean value);
+
+	/**
+	 * Returns whether the <code>inline</code> qualifier was present.
+	 *
+	 * @since 9.4
+	 */
+	public boolean isInline();
+
+	/**
+	 * Sets the <code>inline</code> qualifier.
+	 *
+	 * @since 9.4
+	 */
+	public void setInline(boolean value);
+
+	/**
+	 * Returns whether the <code>goto</code> qualifier was present.
+	 *
+	 * @since 9.4
+	 */
+	public boolean isGoto();
+
+	/**
+	 * Sets the <code>goto</code> qualifier.
+	 *
+	 * @since 9.4
+	 */
+	public void setGoto(boolean value);
+
+	/**
 	 * @since 5.1
 	 */
 	@Override

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/IASTASMDeclaration.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/core/dom/ast/IASTASMDeclaration.java
@@ -37,42 +37,42 @@ public interface IASTASMDeclaration extends IASTDeclaration {
 	/**
 	 * Returns whether the <code>volatile</code> qualifier was present.
 	 *
-	 * @since 9.4
+	 * @since 9.3
 	 */
 	public boolean isVolatile();
 
 	/**
 	 * Sets the <code>volatile</code> qualifier.
 	 *
-	 * @since 9.4
+	 * @since 9.3
 	 */
 	public void setVolatile(boolean value);
 
 	/**
 	 * Returns whether the <code>inline</code> qualifier was present.
 	 *
-	 * @since 9.4
+	 * @since 9.3
 	 */
 	public boolean isInline();
 
 	/**
 	 * Sets the <code>inline</code> qualifier.
 	 *
-	 * @since 9.4
+	 * @since 9.3
 	 */
 	public void setInline(boolean value);
 
 	/**
 	 * Returns whether the <code>goto</code> qualifier was present.
 	 *
-	 * @since 9.4
+	 * @since 9.3
 	 */
 	public boolean isGoto();
 
 	/**
 	 * Sets the <code>goto</code> qualifier.
 	 *
-	 * @since 9.4
+	 * @since 9.3
 	 */
 	public void setGoto(boolean value);
 

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/AbstractGNUSourceCodeParser.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/AbstractGNUSourceCodeParser.java
@@ -1867,8 +1867,26 @@ public abstract class AbstractGNUSourceCodeParser implements ISourceCodeParser {
 
 	protected IASTDeclaration asmDeclaration() throws EndOfFileException, BacktrackException {
 		final int offset = consume().getOffset(); // t_asm
-		if (LT(1) == IToken.t_volatile) {
-			consume();
+		boolean isVolatile = false;
+		boolean isInline = false;
+		boolean isGoto = false;
+		loop: while (true) {
+			switch (LT(1)) {
+			case IToken.t_volatile:
+				isVolatile = true;
+				consume();
+				break;
+			case IToken.t_inline:
+				isInline = true;
+				consume();
+				break;
+			case IToken.t_goto:
+				isGoto = true;
+				consume();
+				break;
+			default:
+				break loop;
+			}
 		}
 
 		if (supportFunctionStyleAsm && LT(1) != IToken.tLPAREN) {
@@ -1879,7 +1897,7 @@ public abstract class AbstractGNUSourceCodeParser implements ISourceCodeParser {
 		asmExpression(buffer);
 		int lastOffset = consume(IToken.tSEMI).getEndOffset();
 
-		return buildASMDirective(offset, buffer.toString(), lastOffset);
+		return buildASMDirective(offset, buffer.toString(), lastOffset, isVolatile, isInline, isGoto);
 	}
 
 	protected IASTDeclaration functionStyleAsmDeclaration() throws BacktrackException, EndOfFileException {
@@ -1956,7 +1974,15 @@ public abstract class AbstractGNUSourceCodeParser implements ISourceCodeParser {
 	}
 
 	protected IASTASMDeclaration buildASMDirective(int offset, String assembly, int lastOffset) {
+		return buildASMDirective(offset, assembly, lastOffset, false, false, false);
+	}
+
+	protected IASTASMDeclaration buildASMDirective(int offset, String assembly, int lastOffset, boolean isVolatile,
+			boolean isInline, boolean isGoto) {
 		IASTASMDeclaration result = nodeFactory.newASMDeclaration(assembly);
+		result.setVolatile(isVolatile);
+		result.setInline(isInline);
+		result.setGoto(isGoto);
 		((ASTNode) result).setOffsetAndLength(offset, lastOffset - offset);
 		return result;
 	}

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/c/CASTASMDeclaration.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/c/CASTASMDeclaration.java
@@ -24,6 +24,9 @@ import org.eclipse.cdt.internal.core.dom.parser.ASTNode;
 public class CASTASMDeclaration extends ASTNode implements IASTASMDeclaration {
 
 	char[] assembly = null;
+	private boolean isVolatile;
+	private boolean isInline;
+	private boolean isGoto;
 
 	public CASTASMDeclaration() {
 	}
@@ -41,6 +44,9 @@ public class CASTASMDeclaration extends ASTNode implements IASTASMDeclaration {
 	public CASTASMDeclaration copy(CopyStyle style) {
 		CASTASMDeclaration copy = new CASTASMDeclaration();
 		copy.assembly = assembly == null ? null : assembly.clone();
+		copy.isVolatile = isVolatile;
+		copy.isInline = isInline;
+		copy.isGoto = isGoto;
 		return copy(copy, style);
 	}
 
@@ -55,6 +61,39 @@ public class CASTASMDeclaration extends ASTNode implements IASTASMDeclaration {
 	public void setAssembly(String assembly) {
 		assertNotFrozen();
 		this.assembly = assembly == null ? null : assembly.toCharArray();
+	}
+
+	@Override
+	public boolean isVolatile() {
+		return isVolatile;
+	}
+
+	@Override
+	public void setVolatile(boolean value) {
+		assertNotFrozen();
+		isVolatile = value;
+	}
+
+	@Override
+	public boolean isInline() {
+		return isInline;
+	}
+
+	@Override
+	public void setInline(boolean value) {
+		assertNotFrozen();
+		isInline = value;
+	}
+
+	@Override
+	public boolean isGoto() {
+		return isGoto;
+	}
+
+	@Override
+	public void setGoto(boolean value) {
+		assertNotFrozen();
+		isGoto = value;
 	}
 
 	@Override

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/CPPASTASMDeclaration.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/parser/cpp/CPPASTASMDeclaration.java
@@ -22,6 +22,9 @@ import org.eclipse.cdt.internal.core.dom.parser.ASTNode;
  */
 public class CPPASTASMDeclaration extends ASTNode implements IASTASMDeclaration {
 	char[] assembly = null;
+	private boolean isVolatile;
+	private boolean isInline;
+	private boolean isGoto;
 
 	public CPPASTASMDeclaration() {
 	}
@@ -39,6 +42,9 @@ public class CPPASTASMDeclaration extends ASTNode implements IASTASMDeclaration 
 	public CPPASTASMDeclaration copy(CopyStyle style) {
 		CPPASTASMDeclaration copy = new CPPASTASMDeclaration();
 		copy.assembly = assembly.clone();
+		copy.isVolatile = isVolatile;
+		copy.isInline = isInline;
+		copy.isGoto = isGoto;
 		return copy(copy, style);
 	}
 
@@ -53,6 +59,39 @@ public class CPPASTASMDeclaration extends ASTNode implements IASTASMDeclaration 
 	public void setAssembly(String assembly) {
 		assertNotFrozen();
 		this.assembly = assembly.toCharArray();
+	}
+
+	@Override
+	public boolean isVolatile() {
+		return isVolatile;
+	}
+
+	@Override
+	public void setVolatile(boolean value) {
+		assertNotFrozen();
+		isVolatile = value;
+	}
+
+	@Override
+	public boolean isInline() {
+		return isInline;
+	}
+
+	@Override
+	public void setInline(boolean value) {
+		assertNotFrozen();
+		isInline = value;
+	}
+
+	@Override
+	public boolean isGoto() {
+		return isGoto;
+	}
+
+	@Override
+	public void setGoto(boolean value) {
+		assertNotFrozen();
+		isGoto = value;
 	}
 
 	@Override

--- a/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/rewrite/astwriter/DeclarationWriter.java
+++ b/core/org.eclipse.cdt.core/parser/org/eclipse/cdt/internal/core/dom/rewrite/astwriter/DeclarationWriter.java
@@ -68,7 +68,7 @@ public class DeclarationWriter extends NodeWriter {
 	private static final char CLOSE_PAREN = ')';
 	private static final char OPEN_BRACKET = '[';
 	private static final char CLOSE_BRACKET = ']';
-	private static final String ASM_START = "asm" + OPEN_PAREN; //$NON-NLS-1$
+	private static final String ASM_START = "asm"; //$NON-NLS-1$
 	private static final String TEMPLATE_DECLARATION = "template<"; //$NON-NLS-1$
 	private static final String TEMPLATE_SPECIALIZATION = "template<> "; //$NON-NLS-1$
 	private static final char COMMA = ',';
@@ -315,6 +315,16 @@ public class DeclarationWriter extends NodeWriter {
 
 	private void writeASMDeclatation(IASTASMDeclaration asmDeclaration) {
 		scribe.print(ASM_START);
+		if (asmDeclaration.isVolatile()) {
+			scribe.print(" volatile"); //$NON-NLS-1$
+		}
+		if (asmDeclaration.isInline()) {
+			scribe.print(" inline"); //$NON-NLS-1$
+		}
+		if (asmDeclaration.isGoto()) {
+			scribe.print(" goto"); //$NON-NLS-1$
+		}
+		scribe.print(OPEN_PAREN);
 		scribe.print(asmDeclaration.getAssembly());
 		scribe.print(CLOSE_PAREN);
 		printSemicolon();


### PR DESCRIPTION
GCC's `asm inline` and `asm goto` qualifiers were silently rejected by CDT's parser. Additionally, the existing `volatile` qualifier was consumed but never stored, making it inaccessible via the AST API.

```c
__asm__ inline ("nop");   // previously: parse error
__asm__ goto ("nop");     // previously: parse error
__asm__ volatile ("nop"); // previously: parsed but qualifier not queryable
```
