### PR TITLE
[releng] Copy build output to final location in promotion script

### DIFF
--- a/releng/promote-a-build.Jenkinsfile
+++ b/releng/promote-a-build.Jenkinsfile
@@ -7,7 +7,6 @@ pipeline {
     string(defaultValue: 'cdt-9.8.0', description: 'The full name of this release (e.g. cdt-9.4.2, cdt-9.5.0-rc1, cdt-lsp-1.0.0, cdt-lsp-1.0.0-rc1)', name: 'MILESTONE')
     choice(choices: ['cdt', 'cdt-lsp'], description: 'The repo being published', name: 'CDT_REPO')
     string(defaultValue: 'main', description: 'The repo branch being published (e.g. main, master, cdt_11_3)', name: 'CDT_BRANCH')
-    string(defaultValue: '12345', description: 'The CI build number being promoted from', name: 'CDT_BUILD_NUMBER')
     choice(choices: ['releases', 'builds'], description: 'Publish location (releases or builds)', name: 'RELEASE_OR_BUILD')
   }
   options {
@@ -24,17 +23,7 @@ pipeline {
             description = "Dry Run: $description"
           }
 
-          // TODO: Can we get permission from EF IT to use Jenkins.instance.getItemByFullName
-          // def job = Jenkins.instance.getItemByFullName(jobName)
-          // def build = job?.getBuildByNumber(buildNumber)
-          
-          // if (build) {
-          //     build.setDescription(description)
-          //     build.keepLog(true)
-          // } else {
-          //     echo "Build not found: ${jobName} #${CDT_BUILD_NUMBER}"
-          // }
-          currentBuild.description = "$description from <a href='https://ci.eclipse.org/cdt/job/$CDT_REPO/job/$CDT_BRANCH/$CDT_BUILD_NUMBER'>$CDT_REPO/job/$CDT_BRANCH/$CDT_BUILD_NUMBER</a>"
+          currentBuild.description = "$description from <a href='https://ci.eclipse.org/cdt/job/$CDT_REPO/job/$CDT_BRANCH'>$CDT_REPO/job/$CDT_BRANCH</a>"
         }
         sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
           sh './releng/scripts/promote-a-build.sh'

--- a/releng/scripts/promote-a-build.sh
+++ b/releng/scripts/promote-a-build.sh
@@ -6,25 +6,20 @@ set -x # echo all commands used for debugging purposes
 
 SSHUSER="genie.cdt@projects-storage.eclipse.org"
 SSH="ssh ${SSHUSER}"
-SCP="scp"
 DOWNLOAD=/home/data/httpd/download.eclipse.org/tools/cdt/$RELEASE_OR_BUILD/$MINOR_VERSION/$MILESTONE
-ARTIFACTS=https://ci.eclipse.org/cdt/job/$CDT_REPO/job/$CDT_BRANCH/$CDT_BUILD_NUMBER/artifact
+ARTIFACTS=/home/data/httpd/download.eclipse.org/tools/cdt/builds/$CDT_REPO/$CDT_BRANCH
+
 if [ "$CDT_REPO" == "cdt" ]; then
-    ARTIFACTS_REPO_TARGET=$ARTIFACTS/releng/org.eclipse.cdt.repo/target
     ZIP_NAME=org.eclipse.cdt.repo.zip
 elif [ "$CDT_REPO" == "cdt-lsp" ]; then
-    ARTIFACTS_REPO_TARGET=$ARTIFACTS/releng/org.eclipse.cdt.lsp.repository/target
     ZIP_NAME=org.eclipse.cdt.lsp.repository.zip
 else
     echo "unexpected value for CDT_REPO: ${CDT_REPO}"
     exit 1
 fi
 
-echo Using download location root of $DOWNLOAD
-echo Using artifacts location root of $ARTIFACTS
-
-echo Testing to make sure artifacts location is sane
-wget -q --output-document=/dev/null  $ARTIFACTS
+echo Using output download location root of $DOWNLOAD
+echo Using input download location root of $ARTIFACTS
 
 ECHO=echo
 if [ "$DRY_RUN" == "false" ]; then
@@ -36,14 +31,7 @@ fi
 echo Testing to make sure we are publishing to a new directory
 $SSH "test ! -e $DOWNLOAD"
 $ECHO $SSH "mkdir -p $DOWNLOAD"
-
-$ECHO $SSH "cd $DOWNLOAD && \
-    wget -q $ARTIFACTS_REPO_TARGET/repository/*zip*/repository.zip && \
-    unzip -q repository.zip && \
-    mv repository/* . && \
-    rm -r repository repository.zip"
-
-$ECHO $SSH "cd $DOWNLOAD && \
-    wget -q $ARTIFACTS_REPO_TARGET/$ZIP_NAME && \
-    mv $ZIP_NAME $MILESTONE.zip"
-
+echo Copying artifacts from latest build output of $CDT_REPO/$CDT_BRANCH to $DOWNLOAD
+$ECHO $SSH "cp -rpvf $ARTIFACTS/* $DOWNLOAD/"
+echo Renaming zip of artifacts to match the expected name for the milestone
+$ECHO $SSH "mv -vf $DOWNLOAD/$ZIP_NAME $DOWNLOAD/$MILESTONE.zip"


### PR DESCRIPTION
In the past we would download from CI, now we simply copy the latest build of the given branch to download location.

This became necessary because there is no longer anonymous access to CI from download.eclipse.org, so the wget commands no longer work.

The downside of this method is that we can only deploy the latest build on a branch.

Worksaround https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/7520