### PR TITLE
[releng] CDT target file update for 2026-09 development

### DIFF
--- a/releng/org.eclipse.cdt.target/cdt.target
+++ b/releng/org.eclipse.cdt.target/cdt.target
@@ -7,7 +7,7 @@
 			<unit id="org.eclipse.license.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds/" />
+			<repository location="https://download.eclipse.org/eclipse/updates/4.41-I-builds/" />
 			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0" />
 			<unit id="org.eclipse.jdt.annotation" version="0.0.0" />
 			<unit id="org.eclipse.sdk.feature.group" version="0.0.0" />
@@ -43,7 +43,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<!-- We explicitly have CDT in target platform so that developers can develop org.eclipse.cdt.core/ui without requiring all the projects from CDT in their workspace. -->
-			<repository location="https://download.eclipse.org/tools/cdt/releases/12.4/cdt-12.4.0/"/>
+			<repository location="https://download.eclipse.org/tools/cdt/releases/12.5/cdt-12.5.0/"/>
 			<unit id="org.eclipse.cdt.feature.group" version="0.0.0" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -54,14 +54,14 @@
 				<dependency>
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-api</artifactId>
-					<version>2.0.17</version>
+					<version>2.0.18</version>
 					<type>jar</type>
 				</dependency>
 				<!-- slf4j-api requires 1 impl, provide the one that is generally used in the final product, such as standalone debugger -->
 				<dependency>
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-simple</artifactId>
-					<version>2.0.17</version>
+					<version>2.0.18</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -73,7 +73,7 @@
 				<dependency>
 					<groupId>com.google.code.gson</groupId>
 					<artifactId>gson</artifactId>
-					<version>2.13.2</version>
+					<version>2.14.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -85,7 +85,7 @@
 				<dependency>
 					<groupId>commons-io</groupId>
 					<artifactId>commons-io</artifactId>
-					<version>2.21.0</version>
+					<version>2.22.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -103,19 +103,19 @@
 				<dependency>
 					<groupId>org.junit.jupiter</groupId>
 					<artifactId>junit-jupiter-api</artifactId>
-					<version>5.14.3</version>
+					<version>5.14.4</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.junit.jupiter</groupId>
 					<artifactId>junit-jupiter-engine</artifactId>
-					<version>5.14.3</version>
+					<version>5.14.4</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.mockito</groupId>
 					<artifactId>mockito-core</artifactId>
-					<version>5.21.0</version>
+					<version>5.23.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -127,19 +127,19 @@
 				<dependency>
 					<groupId>net.java.dev.jna</groupId>
 					<artifactId>jna-platform</artifactId>
-					<version>5.18.1</version>
+					<version>5.19.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>net.java.dev.jna</groupId>
 					<artifactId>jna</artifactId>
-					<version>5.18.1</version>
+					<version>5.19.0</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>com.google.guava</groupId>
 					<artifactId>guava</artifactId>
-					<version>33.5.0-jre</version>
+					<version>33.6.0-jre</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -155,31 +155,31 @@
 				<dependency>
 					<groupId>org.ow2.asm</groupId>
 					<artifactId>asm-commons</artifactId>
-					<version>9.9.1</version>
+					<version>9.10.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.ow2.asm</groupId>
 					<artifactId>asm-util</artifactId>
-					<version>9.9.1</version>
+					<version>9.10.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.ow2.asm</groupId>
 					<artifactId>asm</artifactId>
-					<version>9.9.1</version>
+					<version>9.10.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.ow2.asm</groupId>
 					<artifactId>asm-tree</artifactId>
-					<version>9.9.1</version>
+					<version>9.10.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
 					<groupId>org.ow2.asm</groupId>
 					<artifactId>asm-analysis</artifactId>
-					<version>9.9.1</version>
+					<version>9.10.1</version>
 					<type>jar</type>
 				</dependency>
 				<dependency>
@@ -196,7 +196,7 @@
 			</dependencies>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-12/"/>
+			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06/"/>
 			<unit id="org.junit" version="4.13.2.v20240929-1000" />
 			<unit id="org.eclipse.orbit.xml-apis-ext" version="1.0.0.v20240917-0534"/>
 			<unit id="bcpg" version="0.0.0"/>


### PR DESCRIPTION
I'm going to do the version bumping separately so that the builds work. This is an urgent-ish issue because https://download.eclipse.org/eclipse/updates/4.40-I-builds is now 404.