### PR TITLE
Generate disabled menu item icon descriptor

### DIFF
--- a/memory/org.eclipse.cdt.debug.ui.memory.floatingpoint/META-INF/MANIFEST.MF
+++ b/memory/org.eclipse.cdt.debug.ui.memory.floatingpoint/META-INF/MANIFEST.MF
@@ -2,12 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.cdt.debug.ui.memory.floatingpoint;singleton:=true
-Bundle-Version: 1.2.400.qualifier
+Bundle-Version: 1.2.500.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.debug.core;bundle-version="[3.23.0,4)",
  org.eclipse.debug.ui;bundle-version="[3.19.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.34.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.207.200,4)",
+ org.eclipse.jface;bundle-version="[3.40.0,4.0.0)",
  org.eclipse.search;bundle-version="[3.17.200,4)",
  org.eclipse.cdt.debug.core;bundle-version="[9.0.0,10)"
 Bundle-ActivationPolicy: lazy

--- a/memory/org.eclipse.cdt.debug.ui.memory.floatingpoint/src/org/eclipse/cdt/debug/ui/memory/floatingpoint/FPRendering.java
+++ b/memory/org.eclipse.cdt.debug.ui.memory.floatingpoint/src/org/eclipse/cdt/debug/ui/memory/floatingpoint/FPRendering.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 Wind River Systems Inc. and others.
+ * Copyright (c) 2006, 2026 Wind River Systems Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     Ted R Williams (Wind River Systems, Inc.) - initial implementation
  *     Randy Rohrbach (Wind River Systems, Inc.) - Copied and modified to create the floating point plugin
+ *     John Dallaway - Generate disabled menu item icon descriptor (#1485)
  *******************************************************************************/
 
 package org.eclipse.cdt.debug.ui.memory.floatingpoint;
@@ -1195,10 +1196,10 @@ class CopyAction extends Action {
 		fRendering = rendering;
 		setText(DebugUIMessages.CopyViewToClipboardAction_title);
 		setToolTipText(DebugUIMessages.CopyViewToClipboardAction_tooltip);
-		setImageDescriptor(
-				DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_COPY_VIEW_TO_CLIPBOARD));
-		setDisabledImageDescriptor(
-				DebugPluginImages.getImageDescriptor(IInternalDebugUIConstants.IMG_DLCL_COPY_VIEW_TO_CLIPBOARD));
+		ImageDescriptor descriptor = DebugPluginImages
+				.getImageDescriptor(IInternalDebugUIConstants.IMG_ELCL_COPY_VIEW_TO_CLIPBOARD);
+		setImageDescriptor(descriptor);
+		setDisabledImageDescriptor(descriptor.asDisabledDescriptor());
 	}
 
 	@Override


### PR DESCRIPTION
Fixes build failure following removal of `org.eclipse.debug.internal.ui.IInternalDebugUIConstants.IMG_DLCL_COPY_VIEW_TO_CLIPBOARD` at: https://github.com/eclipse-platform/eclipse.platform/commit/5dcc27891cd920c313709f9afabbcd8b69f6f10f